### PR TITLE
Use is_habana_available to check if habana_frameworks can be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ with for example the following Gaudi configuration written in a JSON file:
     "add",
     "addmm",
     "bmm",
+    "div",
     "dropout",
     "gelu",
     "iadd",
@@ -127,15 +128,14 @@ with for example the following Gaudi configuration written in a JSON file:
     "layer_norm",
     "matmul",
     "mm",
-    "rsub"
+    "rsub",
+    "softmax",
+    "truediv"
   ],
   "hmp_fp32_ops": [
     "embedding",
     "nll_loss",
-    "log_softmax",
-    "truediv",
-    "div",
-    "softmax"
+    "log_softmax"
   ]
 }
 ```

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -161,19 +161,13 @@ class GaudiTrainer(Trainer):
         self.gaudi_config = copy.deepcopy(gaudi_config)
 
         if self.args.use_lazy_mode:
-            try:
-                import habana_frameworks.torch.core as htcore
-            except ImportError as error:
-                error.msg = f"Could not import habana_frameworks.torch.core. {error.msg}."
-                raise error
+            import habana_frameworks.torch.core as htcore
+
             self.htcore = htcore
 
         if self.gaudi_config.use_habana_mixed_precision:
-            try:
-                from habana_frameworks.torch.hpex import hmp
-            except ImportError as error:
-                error.msg = f"Could not import habana_frameworks.torch.hpex. {error.msg}."
-                raise error
+            from habana_frameworks.torch.hpex import hmp
+
             self.hmp = hmp
 
             # Open temporary files to mixed-precision write ops
@@ -193,13 +187,8 @@ class GaudiTrainer(Trainer):
                     )
 
         if self.gaudi_config.use_fused_clip_norm:
-            try:
-                from habana_frameworks.torch.hpex.normalization import FusedClipNorm
-            except ImportError as error:
-                error.msg = (
-                    f"Could not import 'FusedClipNorm' from 'habana_frameworks.torch.hpex.normalization'. {error.msg}."
-                )
-                raise error
+            from habana_frameworks.torch.hpex.normalization import FusedClipNorm
+
             self.FusedNorm = FusedClipNorm(
                 self.model.parameters(),
                 self.args.max_grad_norm,
@@ -233,13 +222,8 @@ class GaudiTrainer(Trainer):
                     )
 
             if self.gaudi_config.use_fused_adam:
-                try:
-                    from habana_frameworks.torch.hpex.optimizers import FusedAdamW
-                except ImportError as error:
-                    error.msg = (
-                        f"Could not import 'FusedAdamW' from 'habana_frameworks.torch.hpex.optimizers'. {error.msg}."
-                    )
-                    raise error
+                from habana_frameworks.torch.hpex.optimizers import FusedAdamW
+
                 optimizer_cls = FusedAdamW
                 optimizer_kwargs = {
                     "lr": self.args.learning_rate,
@@ -412,11 +396,8 @@ class GaudiTrainer(Trainer):
             # Reinitialize Habana fused clip norm to avoid inconsistencies
             # If not done, test_model_init in test_trainer.py will fail
             if args.use_habana and self.gaudi_config.use_fused_clip_norm:
-                try:
-                    from habana_frameworks.torch.hpex.normalization import FusedClipNorm
-                except ImportError as error:
-                    error.msg = f"Could not import 'FusedClipNorm' from 'habana_frameworks.torch.hpex.normalization'. {error.msg}."
-                    raise error
+                from habana_frameworks.torch.hpex.normalization import FusedClipNorm
+
                 self.FusedNorm = FusedClipNorm(
                     self.model.parameters(),
                     self.args.max_grad_norm,

--- a/tests/test_trainer_distributed.py
+++ b/tests/test_trainer_distributed.py
@@ -68,9 +68,7 @@ class TestGaudiTrainerDistributed(TestCasePlus):
     def test_gaudi_trainer_distributed(self):
 
         output_dir = self.get_auto_remove_tmp_dir()
-        # command_list = [
-        #     f"{self.test_file_dir}/test_trainer_distributed.py --output_dir {output_dir} --use_habana --use_lazy_mode"
-        # ]
+
         command_list = [f"{self.test_file_dir}/test_trainer_distributed.py"]
         command_list += ["--output_dir"]
         command_list += [output_dir]
@@ -94,7 +92,7 @@ class TestGaudiTrainerDistributed(TestCasePlus):
 if __name__ == "__main__":
     # The script below is meant to be run under mpirun, on a machine with multiple HPUs:
     #
-    # PYTHONPATH="src" python optimum-habana/examples/gaudi_spawn.py --world_size 8 --use_mpi --output_dir output_dir ./tests/test_trainer_distributed.py
+    # python ./examples/gaudi_spawn.py --world_size 8 --use_mpi --output_dir output_dir ./tests/test_trainer_distributed.py
 
     parser = HfArgumentParser((GaudiTrainingArguments,))
     training_args = parser.parse_args_into_dataclasses()[0]


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Small cleanup:
- is_habana_available is now used to check if habana features can be used
- list of bf16 and fp32 ops are changed to the default ones (BERT/RoBERTa/ALBERT) in the example of Gaudi configuration in the README


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
