### PR TITLE
Add Albert XXL 8x and concurrency to CI/CD

### DIFF
--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -6,7 +6,7 @@ on:
     - cron: 0 23 * * *  # every day at 1am CET
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
 
 jobs:
   start-runner:

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -68,7 +68,7 @@ jobs:
             --ipc=host \
             vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442 \
             /bin/bash tests/ci/example_diff_tests.sh
-  8x:
+  multi-card:
     name: Test multi-card models
     needs:
       - start-runner
@@ -95,12 +95,12 @@ jobs:
             --ipc=host \
             vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442 \
             /bin/bash tests/ci/slow_tests_8x.sh
-  1x:
+  single-card:
     name: Test single-card models
     needs:
       - start-runner
       - example-diff
-      - 8x  # run the job when the previous test jobs are done
+      - multi-card  # run the job when the previous test jobs are done
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
       AWS_REGION: us-east-1
@@ -128,8 +128,8 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - example-diff
-      - 8x
-      - 1x
+      - multi-card
+      - single-card
     runs-on: ubuntu-20.04
     env:
       AWS_REGION: us-east-1

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -6,7 +6,7 @@ on:
     - cron: 0 23 * * *  # every day at 1am CET
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   start-runner:

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 23 * * *  # every day at 1am CET
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
@@ -40,8 +43,8 @@ jobs:
               {"Key": "Name", "Value": "optimum-habana-ci-slow-tests"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
-  do-the-job:
-    name: Run tests
+  example-diff:
+    name: Test examples differences
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
@@ -64,12 +67,69 @@ jobs:
             --net=host \
             --ipc=host \
             vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442 \
-            /bin/bash tests/ci/slow_tests.sh
+            /bin/bash tests/ci/example_diff_tests.sh
+  8x:
+    name: Test multi-card models
+    needs:
+      - start-runner
+      - example-diff  # run the job when the previous test job is done
+    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    env:
+      AWS_REGION: us-east-1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Pull image
+        run: |
+            docker pull vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442
+      - name: Run tests
+        run: |
+            docker run \
+            -v $PWD:/root/workspace \
+            --workdir=/root/workspace \
+            --runtime=habana \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+            --cap-add=sys_nice \
+            --net=host \
+            --ipc=host \
+            vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442 \
+            /bin/bash tests/ci/slow_tests_8x.sh
+  1x:
+    name: Test single-card models
+    needs:
+      - start-runner
+      - example-diff
+      - 8x  # run the job when the previous test jobs are done
+    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    env:
+      AWS_REGION: us-east-1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Pull image
+        run: |
+            docker pull vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442
+      - name: Run tests
+        run: |
+            docker run \
+            -v $PWD:/root/workspace \
+            --workdir=/root/workspace \
+            --runtime=habana \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+            --cap-add=sys_nice \
+            --net=host \
+            --ipc=host \
+            vault.habana.ai/gaudi-docker/1.4.0/ubuntu20.04/habanalabs/pytorch-installer-1.10.2:1.4.0-442 \
+            /bin/bash tests/ci/slow_tests_1x.sh
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - start-runner # required to get output from the start-runner job
-      - do-the-job # required to wait when the main job is done
+      - example-diff
+      - 8x
+      - 1x
     runs-on: ubuntu-20.04
     env:
       AWS_REGION: us-east-1

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@
 
 .PHONY:	style test
 
-slow_tests: export RUN_SLOW = true
-
 # Run code quality checks
 style_check:
 	black --check .
@@ -30,10 +28,20 @@ fast_tests:
 	pip install .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py
 
-# Run non-regression tests and check if examples are up to date with the Transformers library
-slow_tests:
+# Run single-card non-regression tests
+slow_tests_1x:
 	pip install .[tests]
-	python -m pytest tests/test_examples_match_transformers.py tests/test_examples.py
+	python -m pytest tests/test_examples.py -k "single_card"
+
+# Run multi-card non-regression tests
+slow_tests_8x:
+	pip install .[tests]
+	python -m pytest tests/test_examples.py -k "multi_card"
+
+# Check if examples are up to date with the Transformers library
+example_diff_tests:
+	pip install .[tests]
+	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi
 build_dist_install_tools:

--- a/tests/ci/example_diff_tests.sh
+++ b/tests/ci/example_diff_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pip install --upgrade pip
-make slow_tests
+make example_diff_tests

--- a/tests/ci/slow_tests_1x.sh
+++ b/tests/ci/slow_tests_1x.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install --upgrade pip
+export RUN_SLOW=true
+make slow_tests_1x

--- a/tests/ci/slow_tests_8x.sh
+++ b/tests/ci/slow_tests_8x.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install --upgrade pip
+export RUN_SLOW=true
+make slow_tests_8x

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -99,9 +99,12 @@ class ExampleTestMeta(type):
             if models_to_test is None:
                 raise AttributeError(f"Could not create class because no model was found for example {example_name}")
         for model_name, gaudi_config_name in models_to_test:
-            attrs[
-                f"test_{example_name}_{model_name}_{'multi_card' if multi_card else 'single_card'}"
-            ] = cls._create_test(model_name, gaudi_config_name, multi_card)
+            # Conditional statement to filter out ALBERT XXL 1x
+            # because it takes about 6 hours to complete
+            if model_name != "albert-xxlarge-v1" or multi_card:
+                attrs[
+                    f"test_{example_name}_{model_name}_{'multi_card' if multi_card else 'single_card'}"
+                ] = cls._create_test(model_name, gaudi_config_name, multi_card)
         attrs["EXAMPLE_NAME"] = example_name
         return super().__new__(cls, name, bases, attrs)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 # Mapping between model families and specific model names with their configuration
-# TODO: add configuration names once they have been pushed to the hub
 MODELS_TO_TEST_MAPPING = {
     "bert": [
-        # ("bert-base-uncased", "Habana/bert-base-uncased"),  # removed from CI to save time
+        ("bert-base-uncased", "Habana/bert-base-uncased"),
         ("bert-large-uncased-whole-word-masking", "Habana/bert-large-uncased-whole-word-masking"),
     ],
     "roberta": [
@@ -26,7 +26,7 @@ MODELS_TO_TEST_MAPPING = {
     ],
     "albert": [
         ("albert-large-v2", "Habana/albert-large-v2"),
-        # ("albert-xxlarge-v1", "Habana/albert-xxlarge-v1"),  # make Github action job exceed the limit of 6 hours
+        ("albert-xxlarge-v1", "Habana/albert-xxlarge-v1"),
     ],
     "distilbert": [
         ("distilbert-base-uncased", "Habana/distilbert-base-uncased"),


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR modifies CI/CD:
- ALBERT XXL 8x is now added to non-regression tests. 1x version is still filtered because it takes 6 hours, which is the maximum time a job can run in a Github workflow (so there is a risk that the job is interrupted right before the end).
- There is a better separation between 1x, 8x and example diff tests. Each kind of test now has its own command in the Makefile.
- Add *concurrency* to all workflows to manage computation resources better:
  - if a fast test is run in a PR while there is already one running (from the same PR), the former one will be cancelled
  - if a slow test is run while there is already one running, the most recent one will be queued

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
