### PR TITLE
Add a new argument for taking warmup steps into account in throughput calculation

### DIFF
--- a/examples/question-answering/README.md
+++ b/examples/question-answering/README.md
@@ -53,7 +53,8 @@ python run_qa.py \
   --doc_stride 128 \
   --output_dir ./output/debug_squad/ \
   --use_habana \
-  --use_lazy_mode
+  --use_lazy_mode \
+  --throughput_warmup_steps 2
 ```
 
 Training with the previously defined hyper-parameters yields the following results:
@@ -83,7 +84,8 @@ python ../gaudi_spawn.py \
     --doc_stride 128 \
     --output_dir /tmp/squad_output/ \
     --use_habana \
-    --use_lazy_mode
+    --use_lazy_mode \
+    --throughput_warmup_steps 2
 ```
 
 It runs in 11 minutes with BERT-large and yields the following results:

--- a/examples/text-classification/README.md
+++ b/examples/text-classification/README.md
@@ -51,7 +51,8 @@ python run_glue.py \
   --max_seq_length 128 \
   --output_dir ./output/mrpc/ \
   --use_habana \
-  --use_lazy_mode
+  --use_lazy_mode \
+  --throughput_warmup_steps 2
 ```
 
 ### Multi-card Training
@@ -74,5 +75,6 @@ python ../gaudi_spawn.py \
     --max_seq_length 128 \
     --output_dir /tmp/mrpc_output/ \
     --use_habana \
-    --use_lazy_mode
+    --use_lazy_mode \
+    --throughput_warmup_steps 2
 ```

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -548,7 +548,7 @@ class GaudiTrainer(Trainer):
 
             step = -1
             for step, inputs in enumerate(epoch_iterator):
-                if args.throughput_warmup_steps == epoch * steps_in_epoch + step:
+                if args.throughput_warmup_steps > 0 and args.throughput_warmup_steps == epoch * steps_in_epoch + step:
                     start_time_after_warmup = time.time()
 
                 # Skip past any already trained steps if resuming training

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -54,11 +54,13 @@ class GaudiTrainingArguments(TrainingArguments):
     """
 
     use_habana: Optional[bool] = field(
-        default=False, metadata={"help": "Whether to use Habana's HPU for training the model."}
+        default=False,
+        metadata={"help": "Whether to use Habana's HPU for training the model."},
     )
 
     gaudi_config_name: Optional[str] = field(
-        default=None, metadata={"help": "Pretrained Gaudi config name or path if not the same as model_name."}
+        default=None,
+        metadata={"help": "Pretrained Gaudi config name or path if not the same as model_name."},
     )
 
     use_lazy_mode: bool = field(
@@ -66,11 +68,24 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": "Whether to use lazy mode for training the model."},
     )
 
+    throughput_warmup_steps: int = field(
+        default=0,
+        metadata={
+            "help": "Number of steps to ignore for throughput calculation. For example, with throughput_warmup_steps=N, the first N steps will not be considered in the calculation of the throughput. This is especially useful in lazy mode."
+        },
+    )
+
     # Override the default value of epsilon to be consistent with Habana FusedAdamW
-    adam_epsilon: float = field(default=1e-6, metadata={"help": "Epsilon for AdamW optimizer."})
+    adam_epsilon: float = field(
+        default=1e-6,
+        metadata={"help": "Epsilon for AdamW optimizer."},
+    )
 
     # Override logging_nan_inf_filter to make False the default value
-    logging_nan_inf_filter: bool = field(default=False, metadata={"help": "Filter nan and inf losses for logging."})
+    logging_nan_inf_filter: bool = field(
+        default=False,
+        metadata={"help": "Filter nan and inf losses for logging."},
+    )
 
     def __post_init__(self):
         # Raise errors for arguments that are not supported by optimum-habana

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -108,6 +108,9 @@ class GaudiTrainingArguments(TrainingArguments):
         if self.tf32:
             raise ValueError("--tf32 is not supported by optimum-habana.")
 
+        if self.throughput_warmup_steps < 0:
+            raise ValueError("--throughput_warmup_steps must be positive.")
+
         super().__post_init__()
 
     def __str__(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -238,6 +238,7 @@ class ExampleTesterBase(TestCase):
             f"--max_seq_length {max_seq_length}",
             "--use_habana",
             "--use_lazy_mode",
+            "--throughput_warmup_steps 2",
         ]
         if extra_command_line_arguments is not None:
             cmd_line += extra_command_line_arguments


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds a new argument `throughput_warmup_steps` that enables to remove warmup steps from the throughput calculation at the end of the training (in lazy mode for instance).

This requires to override the `speed_metrics` method in `trainer_utils.py`.

Examples and tests have been updated accordingly.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
