### PR TITLE
Enable GaudiConfig instantiation from inside the trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Original script:
 ```python
 from transformers import Trainer, TrainingArguments
 
+training_args = TrainingArguments(
+  # training arguments...
+)
+
 # A lot of code here
 
 # Initialize our Trainer
@@ -85,21 +89,20 @@ Transformed version that can run on Gaudi:
 ```python
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
 
-# A lot of the same code as the original script here
-
-# Loading the GaudiConfig needed by the GaudiTrainer to fine-tune the model on HPUs
-gaudi_config = GaudiConfig.from_pretrained(
-    training_args.gaudi_config_name,
-    cache_dir=model_args.cache_dir,
-    revision=model_args.model_revision,
-    use_auth_token=True if model_args.use_auth_token else None,
+training_args = GaudiTrainingArguments(
+  # same training arguments...
+  use_habana=True,
+  use_lazy_mode=True,  # whether to use lazy or eager mode
+  gaudi_config_name=path_to_gaudi_config,
 )
+
+# A lot of the same code as the original script here
 
 # Initialize our Trainer
 trainer = GaudiTrainer(
     model=model,
-    gaudi_config=gaudi_config,
-    # The training arguments differ a bit from the original ones, that is why we use GaudiTrainingArguments
+    # You can manually specify the Gaudi configuration to use with
+    # gaudi_config=my_gaudi_config
     args=training_args,
     train_dataset=train_dataset if training_args.do_train else None,
     eval_dataset=eval_dataset if training_args.do_eval else None,
@@ -109,7 +112,7 @@ trainer = GaudiTrainer(
 )
 ```
 
-where `training_args.gaudi_config_name` is the name of a model from the [Hub](https://huggingface.co/Habana) (Gaudi configurations are stored in model repositories). You can also give the path to a custom Gaudi configuration written in a JSON file such as this one:
+where `gaudi_config_name` is the name of a model from the [Hub](https://huggingface.co/Habana) (Gaudi configurations are stored in model repositories). You can also give the path to a custom Gaudi configuration written in a JSON file such as this one:
 ```json
 {
   "use_habana_mixed_precision": true,
@@ -139,6 +142,16 @@ where `training_args.gaudi_config_name` is the name of a model from the [Hub](ht
     "log_softmax"
   ]
 }
+```
+
+If you prefer to instantiate a Gaudi configuration to work on it before giving it to the trainer, you can do it as follows:
+```python
+gaudi_config = GaudiConfig.from_pretrained(
+    gaudi_config_name,
+    cache_dir=model_args.cache_dir,
+    revision=model_args.model_revision,
+    use_auth_token=True if model_args.use_auth_token else None,
+)
 ```
 
 

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -130,7 +130,10 @@ class GaudiTrainer(Trainer):
             preprocess_logits_for_metrics,
         )
 
-        self.gaudi_config = copy.deepcopy(gaudi_config)
+        if gaudi_config is None:
+            self.gaudi_config = GaudiConfig.from_pretrained(args.gaudi_config_name)
+        else:
+            self.gaudi_config = copy.deepcopy(gaudi_config)
 
         if self.args.use_habana:
             if self.args.use_lazy_mode:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ INSTALL_REQUIRES = [
     "sentencepiece",
     "scipy",
     "pillow",
-    "huggingface_hub==0.4.0",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The user does not have to instantiate a GaudiConfig object anymore, it will be done automatically based on the value of `gaudi_config_name` in the training arguments if no Gaudi configuration is given to the trainer.

The `huggingface_hub` dependency is also removed since it is now managed by Optimum.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
