### PR TITLE
Fix key names in CI regression metrics dictionary

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -201,9 +201,9 @@ class ExampleTesterBase(TestCase):
     TASK_NAME = None
     DATASET_PARAMETER_NAME = "dataset_name"
     REGRESSION_METRICS = {
-        "f1_score": (TestCase.assertGreaterEqual, ACCURACY_PERF_FACTOR),
+        "eval_f1": (TestCase.assertGreaterEqual, ACCURACY_PERF_FACTOR),
         "perplexity": (TestCase.assertLessEqual, 2 - ACCURACY_PERF_FACTOR),
-        "training_time": (TestCase.assertLessEqual, TRAINING_TIME_PERF_FACTOR),
+        "train_runtime": (TestCase.assertLessEqual, TRAINING_TIME_PERF_FACTOR),
     }
 
     def _create_command_line(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes an issue in the CI regression script. Some key names of the regression metrics dictionary were wrong and are corrected.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
