### PR TITLE
Fix an issue with dill>=0.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ INSTALL_REQUIRES = [
     "sentencepiece",
     "scipy",
     "pillow",
+    "dill < 0.3.5",  # see https://github.com/huggingface/datasets/issues/4506
+    "multiprocess < 0.70.13", # 0.70.13 depends on dill>=0.3.5, to remove when the dill issue is solved
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes an issue where cached objects used in the `map` method of the dataset lead to wrong results. This is linked to the version of `dill`. This is a temporary fix that should be removed when this [issue](https://github.com/huggingface/datasets/issues/4506) is solved.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
