### PR TITLE
Move CI slow tests to AWS us-west-2 to be able to run T5

### DIFF
--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -14,11 +14,11 @@ jobs:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-20.04
     env:
-      AWS_REGION: us-east-1
-      EC2_AMI_ID: ami-0a54664633b809ed5
+      AWS_REGION: us-west-2
+      EC2_AMI_ID: ami-0a20beab46db1fdb6
       EC2_INSTANCE_TYPE: dl1.24xlarge
-      EC2_SUBNET_ID: subnet-b7533b96
-      EC2_SECURITY_GROUP: sg-02677bbf33275aa0e
+      EC2_SUBNET_ID: subnet-452c913d
+      EC2_SECURITY_GROUP: sg-0472192d4db070348
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -49,7 +49,7 @@ jobs:
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: us-west-2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
       - example-diff  # run the job when the previous test job is done
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: us-west-2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -104,7 +104,7 @@ jobs:
       - multi-card  # run the job when the previous test jobs are done
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: us-west-2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
       - single-card  # run the job when the previous test jobs are done
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: us-west-2
     steps:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
@@ -169,7 +169,7 @@ jobs:
       - albert-xxl-single-card
     runs-on: ubuntu-20.04
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: us-west-2
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -290,7 +290,8 @@ class ExampleTesterBase(TestCase):
         self.assertGreaterEqual(
             number_asserted_metrics,
             2,
-            f"{number_asserted_metrics} asserted metric while at least 2 are expected (training time + accuracy). Metrics to assert: {self.REGRESSION_METRICS.keys()}. Metrics received: {baseline.keys()}",
+            f"{number_asserted_metrics} asserted metric while at least 2 are expected (training time + accuracy)."
+            f" Metrics to assert: {self.REGRESSION_METRICS.keys()}. Metrics received: {baseline.keys()}",
         )
 
 
@@ -326,8 +327,7 @@ class MultiCardLanguageModelingExampleTester(
     TASK_NAME = "wikitext"
 
 
-# TODO: uncomment when CI is moved from AWS
-# class MultiCardSummarizationExampleTester(
-#     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization", multi_card=True
-# ):
-#     TASK_NAME = "cnn_dailymail"
+class MultiCardSummarizationExampleTester(
+    ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization", multi_card=True
+):
+    TASK_NAME = "cnn_dailymail"


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR enables to execute CI slow tests on a us-west-2 AWS instance. Issues with T5 happened in us-east-1 (which may be related to the lack of availability of DL1 instances in us-east-1). Enables T5 slow test again. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
