### PR TITLE
Run CI regression tests on on-prem Gaudi

### DIFF
--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -32,8 +32,8 @@ jobs:
           ls -la ./
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Check for dockerenv file
+        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)
       - name: Run tests
         run: |
           /bin/bash tests/ci/fast_tests.sh
-      - name: Check for dockerenv file
-        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -18,6 +18,7 @@ jobs:
     name: Run tests
     runs-on: self-hosted
     container:
+      runs-on: ubuntu-20.04
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
@@ -25,16 +26,9 @@ jobs:
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Create and start a virtual environment
-        shell: bash
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-      - name: Run tests
-        shell: bash
-        run: |
-          source venv/bin/activate
-          bash tests/ci/fast_tests.sh
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Run tests
+          run: |
+            /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -12,6 +12,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  clean:
+    name: Clean temporary files
+    runs-on: [self-hosted, hpu]
+    steps:
+      - name: Delete cache
+        run: |
+          sudo rm -rf /opt/github-actions-runner/_work/_temp/*
+          echo HERE
+          ls -al /opt/github-actions-runner/_work/_temp
   do-the-job:
     strategy:
       fail-fast: false
@@ -24,11 +33,6 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
     steps:
-      - name: Delete cache
-        run: |
-          rm -rf /github/home/*
-          echo HERE
-          ls -al /github/home
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -29,9 +29,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Create and start a virtual environment
+        shell: bash
         run: |
           python -m venv venv
           source venv/bin/activate
       - name: Run tests
+        shell: bash
         run: |
-          /bin/bash tests/ci/fast_tests.sh
+          source venv/bin/activate
+          bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --net=host --ipc=host --cap-add=sys_nice --runtime --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime --workdir=/root/workspace
       volumes:
         - $PWD:/root/workspace
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -21,8 +21,6 @@ jobs:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -24,11 +24,6 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
     steps:
-      - name: Delete cache
-        run: |
-          rm -rf /github/home/*
-          echo HERE
-          ls -al /github/home
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           rm -rf /github/home/*
           echo HERE
-          ll /github/home
+          ls -al /github/home
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -22,11 +22,12 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana
     steps:
       - name: Delete cache
         run: |
-          rm -rf /github/home/.cache
+          rm -rf /__w/optimum-habana
+          rm -rf /github/home/*
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -23,15 +23,17 @@ jobs:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
-      steps:
-        - name: 'Cleanup build folder'
-          run: |
-            ls -la ./
-            rm -rf ./* || true
-            rm -rf ./.??* || true
-            ls -la ./
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Run tests
-          run: |
-            /bin/bash tests/ci/fast_tests.sh
+    steps:
+      - name: 'Cleanup build folder'
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: |
+          /bin/bash tests/ci/fast_tests.sh
+      - name: Check for dockerenv file
+        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
       volumes:
         - $PWD:/root/workspace
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -12,13 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clean:
-    name: Clean temporary files
-    runs-on: [self-hosted, hpu]
-    steps:
-      - name: Delete cache
-        run: |
-          rm -rf /opt/github-actions-runner/_work/_temp
   do-the-job:
     strategy:
       fail-fast: false
@@ -31,6 +24,11 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
     steps:
+      - name: Delete cache
+        run: |
+          rm -rf /github/home/*
+          echo HERE
+          ll /github/home
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -12,15 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clean:
-    name: Clean temporary files
-    runs-on: [self-hosted, hpu]
-    steps:
-      - name: Delete cache
-        run: |
-          sudo rm -rf /opt/github-actions-runner/_work/_temp/*
-          echo HERE
-          ls -al /opt/github-actions-runner/_work/_temp
   do-the-job:
     strategy:
       fail-fast: false
@@ -33,8 +24,14 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
     steps:
+      - name: Delete cache
+        run: |
+          rm -rf /github/home/*
+          echo HERE
+          ls -al /github/home
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
         run: |
+          export HOME=/root
           /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -17,23 +17,22 @@ jobs:
       fail-fast: false
     name: Run tests
     runs-on: [self-hosted, hpu]
-    container:
-      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      env:
-        HABANA_VISIBLE_DEVICES: all
-        OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
     steps:
-      - name: 'Cleanup build folder'
-        run: |
-          ls -la ./
-          rm -rf ./* || true
-          rm -rf ./.??* || true
-          ls -la ./
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Check for dockerenv file
-        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)
+      - name: Pull image
+        run: |
+          docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
+          docker run \
+          -v $PWD:/root/workspace \
+          --workdir=/root/workspace/optimum-habana \
+          --runtime=habana \
+          -e HABANA_VISIBLE_DEVICES=all \
+          -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+          --cap-add=sys_nice \
+          --net=host \
+          --ipc=host \
+          vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
           /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -2,6 +2,8 @@ name: Unit and integration tests (On-Prem)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -15,31 +17,15 @@ jobs:
       fail-fast: false
     name: Run tests
     runs-on: [self-hosted, hpu]
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
     steps:
-      # - name: 'Cleanup build folder'
-      #   run: |
-      #     ls -la ./
-      #     sudo rm -rf ./* || true
-      #     sudo rm -rf ./.??* || true
-      #     ls -la ./
-      # - name: Checkout
-      #   uses: actions/checkout@v2
-      - name: Pull image
-        run: |
-          docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      # - name: Blabla
-      #   run: |
-      #     docker run
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Run tests
         run: |
-          docker run \
-          -v $PWD:/root/workspace \
-          --workdir=/root/workspace \
-          --runtime=habana \
-          -e HABANA_VISIBLE_DEVICES=all \
-          -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-          --cap-add=sys_nice \
-          --net=host \
-          --ipc=host \
-          vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-          git clone https://github.com/huggingface/optimum-habana.git && cd optimum-habana && git checkout ${{ github.event.pull_request.head.sha }} && /bin/bash tests/ci/fast_tests.sh
+          /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -18,6 +18,12 @@ jobs:
     name: Run tests
     runs-on: [self-hosted, hpu]
     steps:
+      - name: 'Cleanup build folder'
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
       - name: Checkout
         uses: actions/checkout@v2
       - name: Pull image

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -14,8 +14,7 @@ concurrency:
 jobs:
   do-the-job:
     name: Run tests
-    needs: start-runner # required to start the main job when the runner is ready
-    runs-on: paris-dc2-hpu1 # run the job on the newly created runner
+    runs-on: paris-dc2-hpu1
     env:
       AWS_REGION: us-east-1
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -15,8 +15,14 @@ jobs:
   do-the-job:
     name: Run tests
     runs-on: [self-hosted, hpu]
-    env:
-      AWS_REGION: us-east-1
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --net=host --ipc=host --cap-add=sys_nice --runtime --workdir=/root/workspace
+      volumes:
+        - $PWD:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,18 +31,4 @@ jobs:
             docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
-            docker run \
-            --user $UID:$GID \
-            --volume="/etc/group:/etc/group:ro" \
-            --volume="/etc/passwd:/etc/passwd:ro" \
-            --volume="/etc/shadow:/etc/shadow:ro" \
-            -v $PWD:/root/workspace \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-            /bin/bash tests/ci/fast_tests.sh
+              /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -23,15 +23,15 @@ jobs:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
-    steps:
-      - name: 'Cleanup build folder'
-        run: |
-          ls -la ./
-          rm -rf ./* || true
-          rm -rf ./.??* || true
-          ls -la ./
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run tests
-        run: |
-          /bin/bash tests/ci/fast_tests.sh
+      steps:
+        - name: 'Cleanup build folder'
+          run: |
+            ls -la ./
+            rm -rf ./* || true
+            rm -rf ./.??* || true
+            ls -la ./
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Run tests
+          run: |
+            /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -21,8 +21,8 @@ jobs:
       - name: 'Cleanup build folder'
         run: |
           ls -la ./
-          rm -rf ./* || true
-          rm -rf ./.??* || true
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
           ls -la ./
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   do-the-job:
     name: Run tests
-    runs-on: [self-hosted, hpu]
+    runs-on: self-hosted
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -2,8 +2,6 @@ name: Unit and integration tests (On-Prem)
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -18,22 +16,25 @@ jobs:
     name: Run tests
     runs-on: [self-hosted, hpu]
     steps:
-      - name: 'Cleanup build folder'
-        run: |
-          ls -la ./
-          sudo rm -rf ./* || true
-          sudo rm -rf ./.??* || true
-          ls -la ./
-      - name: Checkout
-        uses: actions/checkout@v2
+      # - name: 'Cleanup build folder'
+      #   run: |
+      #     ls -la ./
+      #     sudo rm -rf ./* || true
+      #     sudo rm -rf ./.??* || true
+      #     ls -la ./
+      # - name: Checkout
+      #   uses: actions/checkout@v2
       - name: Pull image
         run: |
           docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      # - name: Blabla
+      #   run: |
+      #     docker run
       - name: Run tests
         run: |
           docker run \
           -v $PWD:/root/workspace \
-          --workdir=/root/workspace/optimum-habana \
+          --workdir=/root/workspace \
           --runtime=habana \
           -e HABANA_VISIBLE_DEVICES=all \
           -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
@@ -41,4 +42,4 @@ jobs:
           --net=host \
           --ipc=host \
           vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-          /bin/bash tests/ci/fast_tests.sh
+          git clone https://github.com/huggingface/optimum-habana.git && cd optimum-habana && git checkout ${{ github.event.pull_request.head.sha }} && /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   do-the-job:
     name: Run tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, hpu]
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm --pull always
+      options: --cap-add=sys_nice --runtime=habana
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm --pull always
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -17,17 +17,22 @@ jobs:
       fail-fast: false
     name: Run tests
     runs-on: [self-hosted, hpu]
-    container:
-      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      env:
-        HABANA_VISIBLE_DEVICES: all
-        OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Pull image
+        run: |
+          docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
+          docker run \
+          -v $PWD:/root/workspace \
+          --workdir=/root/workspace \
+          --runtime=habana \
+          -e HABANA_VISIBLE_DEVICES=all \
+          -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+          --cap-add=sys_nice \
+          --net=host \
+          --ipc=host \
+          vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
           /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -1,9 +1,7 @@
-name: Unit and integration tests (On-Prem)
+name: Unit and integration tests
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -12,21 +10,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  start-runner:
+    name: Start self-hosted EC2 runner
+    runs-on: ubuntu-20.04
+    env:
+      AWS_REGION: us-east-1
+      EC2_AMI_ID: ami-03828378bbb789cf5
+      EC2_INSTANCE_TYPE: dl1.24xlarge
+      EC2_SUBNET_ID: subnet-b7533b96
+      EC2_SECURITY_GROUP: sg-06dd6398b8fa627c9
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: philschmid/philschmid-ec2-github-runner@main
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ env.EC2_AMI_ID }}
+          ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
+          subnet-id: ${{ env.EC2_SUBNET_ID }}
+          security-group-id: ${{ env.EC2_SECURITY_GROUP }}
+          aws-resource-tags: > # optional, requires additional permissions
+            [
+              {"Key": "Name", "Value": "optimum-habana-ci-fast-tests"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
   do-the-job:
-    strategy:
-      fail-fast: false
     name: Run tests
-    runs-on: [self-hosted, hpu]
-    container:
-      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      env:
-        HABANA_VISIBLE_DEVICES: all
-        OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana
+    needs: start-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    env:
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Pull image
+        run: |
+            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
-          export HOME=/root
-          /bin/bash tests/ci/fast_tests.sh
+            docker run \
+            -v $PWD:/root/workspace \
+            --workdir=/root/workspace \
+            --runtime=habana \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+            --cap-add=sys_nice \
+            --net=host \
+            --ipc=host \
+            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
+            /bin/bash tests/ci/fast_tests.sh
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - do-the-job # required to wait when the main job is done
+    runs-on: ubuntu-20.04
+    env:
+      AWS_REGION: us-east-1
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Stop EC2 runner
+        uses: philschmid/philschmid-ec2-github-runner@main
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -24,6 +24,12 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
     steps:
+      - name: 'Cleanup build folder'
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   do-the-job:
     name: Run tests
-    runs-on: paris-dc2-hpu1
+    runs-on: [self-hosted, hpu]
     env:
       AWS_REGION: us-east-1
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -20,7 +20,9 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana
+      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
+      volumes:
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -16,9 +16,8 @@ jobs:
     strategy:
       fail-fast: false
     name: Run tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, hpu]
     container:
-      runs-on: ubuntu-20.04
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
@@ -26,9 +25,9 @@ jobs:
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Run tests
-          run: |
-            /bin/bash tests/ci/fast_tests.sh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: |
+          /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   do-the-job:
+    strategy:
+      fail-fast: false
     name: Run tests
     runs-on: self-hosted
     container:
@@ -26,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Create and start a virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
       - name: Run tests
         run: |
-              /bin/bash tests/ci/fast_tests.sh
+          /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -26,9 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Pull image
-        run: |
-            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
               /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -17,22 +17,15 @@ jobs:
       fail-fast: false
     name: Run tests
     runs-on: [self-hosted, hpu]
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Pull image
-        run: |
-          docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       - name: Run tests
         run: |
-          docker run \
-          -v $PWD:/root/workspace \
-          --workdir=/root/workspace \
-          --runtime=habana \
-          -e HABANA_VISIBLE_DEVICES=all \
-          -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-          --cap-add=sys_nice \
-          --net=host \
-          --ipc=host \
-          vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
           /bin/bash tests/ci/fast_tests.sh

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -1,4 +1,4 @@
-name: Unit and integration tests
+name: Unit and integration tests (On-Prem)
 
 on:
   workflow_dispatch:
@@ -12,44 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  start-runner:
-    name: Start self-hosted EC2 runner
-    runs-on: ubuntu-20.04
-    env:
-      AWS_REGION: us-east-1
-      EC2_AMI_ID: ami-03828378bbb789cf5
-      EC2_INSTANCE_TYPE: dl1.24xlarge
-      EC2_SUBNET_ID: subnet-b7533b96
-      EC2_SECURITY_GROUP: sg-06dd6398b8fa627c9
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: philschmid/philschmid-ec2-github-runner@main
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ${{ env.EC2_AMI_ID }}
-          ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
-          subnet-id: ${{ env.EC2_SUBNET_ID }}
-          security-group-id: ${{ env.EC2_SECURITY_GROUP }}
-          aws-resource-tags: > # optional, requires additional permissions
-            [
-              {"Key": "Name", "Value": "optimum-habana-ci-fast-tests"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
-            ]
   do-the-job:
     name: Run tests
     needs: start-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    runs-on: paris-dc2-hpu1 # run the job on the newly created runner
     env:
       AWS_REGION: us-east-1
     steps:
@@ -71,26 +37,3 @@ jobs:
             --ipc=host \
             vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
             /bin/bash tests/ci/fast_tests.sh
-  stop-runner:
-    name: Stop self-hosted EC2 runner
-    needs:
-      - start-runner # required to get output from the start-runner job
-      - do-the-job # required to wait when the main job is done
-    runs-on: ubuntu-20.04
-    env:
-      AWS_REGION: us-east-1
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Stop EC2 runner
-        uses: philschmid/philschmid-ec2-github-runner@main
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - name: Delete cache
         run: |
-          rm -rf /__w/optimum-habana
           rm -rf /github/home/*
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -12,6 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  clean:
+    name: Clean temporary files
+    runs-on: [self-hosted, hpu]
+    steps:
+      - name: Delete cache
+        run: |
+          rm -rf /opt/github-actions-runner/_work/_temp
   do-the-job:
     strategy:
       fail-fast: false
@@ -24,9 +31,6 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana
     steps:
-      - name: Delete cache
-        run: |
-          rm -rf /github/home/*
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Run tests
         run: |
             docker run \
+            --user $UID:$GID \
+            --volume="/etc/group:/etc/group:ro" \
+            --volume="/etc/passwd:/etc/passwd:ro" \
+            --volume="/etc/shadow:/etc/shadow:ro" \
             -v $PWD:/root/workspace \
             --workdir=/root/workspace \
             --runtime=habana \

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -22,7 +22,7 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
       volumes:
-        - $PWD:/root/workspace
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -24,6 +24,9 @@ jobs:
         OMPI_MCA_btl_vader_single_copy_mechanism: none
       options: --cap-add=sys_nice --runtime=habana  --workdir=/root/workspace
     steps:
+      - name: Delete cache
+        run: |
+          rm -rf /github/home/.cache
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Diff
+      - name: Run Multi-Cards Tests
         run: |
           /bin/bash tests/ci/slow_tests_8x.sh
   single-card:
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Diff
+      - name: Run Single-Card Tests
         run: |
           /bin/bash tests/ci/slow_tests_1x.sh
   albert-xxl-single-card:
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
         uses: actions/checkout@v2
-      - name: Run Diff
+      - name: Run Single-Card ALBERT XXL Tests
         if: github.event.schedule == '0 23 * * 6'
         run: |
           /bin/bash tests/ci/albert_xxl_1x.sh

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -18,7 +18,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:
@@ -37,7 +37,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:
@@ -57,7 +57,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:
@@ -78,7 +78,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
       volumes:
         - /opt/github-actions-runners/_work:/root/workspace
     steps:

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Run tests
         run: |
             docker run \
+            --user $UID:$GID \
+            --volume="/etc/group:/etc/group:ro" \
+            --volume="/etc/passwd:/etc/passwd:ro" \
+            --volume="/etc/shadow:/etc/shadow:ro" \
             -v $PWD:/root/workspace \
             --workdir=/root/workspace \
             --runtime=habana \
@@ -46,6 +50,10 @@ jobs:
       - name: Run tests
         run: |
             docker run \
+            --user $UID:$GID \
+            --volume="/etc/group:/etc/group:ro" \
+            --volume="/etc/passwd:/etc/passwd:ro" \
+            --volume="/etc/shadow:/etc/shadow:ro" \
             -v $PWD:/root/workspace \
             --workdir=/root/workspace \
             --runtime=habana \
@@ -71,6 +79,10 @@ jobs:
       - name: Run tests
         run: |
             docker run \
+            --user $UID:$GID \
+            --volume="/etc/group:/etc/group:ro" \
+            --volume="/etc/passwd:/etc/passwd:ro" \
+            --volume="/etc/shadow:/etc/shadow:ro" \
             -v $PWD:/root/workspace \
             --workdir=/root/workspace \
             --runtime=habana \
@@ -100,6 +112,10 @@ jobs:
         if: github.event.schedule == '0 23 * * 6'
         run: |
             docker run \
+            --user $UID:$GID \
+            --volume="/etc/group:/etc/group:ro" \
+            --volume="/etc/passwd:/etc/passwd:ro" \
+            --volume="/etc/shadow:/etc/shadow:ro" \
             -v $PWD:/root/workspace \
             --workdir=/root/workspace \
             --runtime=habana \

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Diff
         run: |
-        /bin/bash tests/ci/example_diff_tests.sh
+          /bin/bash tests/ci/example_diff_tests.sh
   multi-card:
     name: Test multi-card models
     needs:

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Diff
         run: |
+          export HOME=/root
           /bin/bash tests/ci/example_diff_tests.sh
   multi-card:
     name: Test multi-card models

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -13,8 +13,6 @@ jobs:
   example-diff:
     name: Test examples differences
     runs-on: [self-hosted, hpu]
-    strategy:
-      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
@@ -30,11 +28,9 @@ jobs:
           /bin/bash tests/ci/example_diff_tests.sh
   multi-card:
     name: Test multi-card models
-    needs:
-      - example-diff  # run the job when the previous test job is done
+    if: ${{ always() }}
+    needs: [example-diff]
     runs-on: [self-hosted, hpu]
-    strategy:
-      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
@@ -50,12 +46,9 @@ jobs:
           /bin/bash tests/ci/slow_tests_8x.sh
   single-card:
     name: Test single-card models
-    needs:
-      - example-diff
-      - multi-card  # run the job when the previous test jobs are done
+    if: ${{ always() }}
+    needs: [example-diff, multi-card]
     runs-on: [self-hosted, hpu] # run the job on the newly created runner
-    strategy:
-      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
@@ -71,10 +64,8 @@ jobs:
           /bin/bash tests/ci/slow_tests_1x.sh
   albert-xxl-single-card:
     name: Test single-card ALBERT XXL
-    needs:
-      - example-diff
-      - multi-card
-      - single-card  # run the job when the previous test jobs are done
+    if: ${{ always() }}
+    needs: [example-diff, multi-card, single-card]
     runs-on: [self-hosted, hpu] # run the job on the newly created runner
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -13,14 +13,14 @@ jobs:
   example-diff:
     name: Test examples differences
     runs-on: [self-hosted, hpu]
+    strategy:
+      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
+      options: --cap-add=sys_nice --runtime=habana
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,19 +33,20 @@ jobs:
     needs:
       - example-diff  # run the job when the previous test job is done
     runs-on: [self-hosted, hpu]
+    strategy:
+      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
+      options: --cap-add=sys_nice --runtime=habana
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Multi-Cards Tests
         run: |
+          export HOME=/root
           /bin/bash tests/ci/slow_tests_8x.sh
   single-card:
     name: Test single-card models
@@ -53,19 +54,20 @@ jobs:
       - example-diff
       - multi-card  # run the job when the previous test jobs are done
     runs-on: [self-hosted, hpu] # run the job on the newly created runner
+    strategy:
+      fail-fast: false
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
+      options: --cap-add=sys_nice --runtime=habana
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Single-Card Tests
         run: |
+          export HOME=/root
           /bin/bash tests/ci/slow_tests_1x.sh
   albert-xxl-single-card:
     name: Test single-card ALBERT XXL
@@ -79,9 +81,7 @@ jobs:
       env:
         HABANA_VISIBLE_DEVICES: all
         OMPI_MCA_btl_vader_single_copy_mechanism: none
-      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace --rm
-      volumes:
-        - /opt/github-actions-runners/_work:/root/workspace
+      options: --cap-add=sys_nice --runtime=habana
     steps:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
@@ -89,6 +89,7 @@ jobs:
       - name: Run Single-Card ALBERT XXL Tests
         if: github.event.schedule == '0 23 * * 6'
         run: |
+          export HOME=/root
           /bin/bash tests/ci/albert_xxl_1x.sh
       - name: Warning
         if: github.event.schedule != '0 23 * * 6'

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -1,4 +1,4 @@
-name: Non-regression tests (On-Prem)
+name: Non-regression tests (on-prem)
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   example-diff:
-    name: Test examples differences
+    name: Test example differences
     runs-on: [self-hosted, hpu]
     container:
       image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Diff
+      - name: Check diff between examples of Transformers and Optimum Habana
         run: |
           export HOME=/root
           /bin/bash tests/ci/example_diff_tests.sh
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Multi-Cards Tests
+      - name: Run multi-card tests
         run: |
           export HOME=/root
           /bin/bash tests/ci/slow_tests_8x.sh
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Single-Card Tests
+      - name: Run single-card tests
         run: |
           export HOME=/root
           /bin/bash tests/ci/slow_tests_1x.sh
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
         uses: actions/checkout@v2
-      - name: Run Single-Card ALBERT XXL Tests
+      - name: Run single-card ALBERT XXL test
         if: github.event.schedule == '0 23 * * 6'
         run: |
           export HOME=/root

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -1,4 +1,4 @@
-name: Non-regression tests
+name: Non-regression tests (On-Prem)
 
 on:
   workflow_dispatch:
@@ -10,46 +10,9 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  start-runner:
-    name: Start self-hosted EC2 runner
-    runs-on: ubuntu-20.04
-    env:
-      AWS_REGION: us-west-2
-      EC2_AMI_ID: ami-0f304792286419a88
-      EC2_INSTANCE_TYPE: dl1.24xlarge
-      EC2_SUBNET_ID: subnet-452c913d
-      EC2_SECURITY_GROUP: sg-0f71a90df15bcf053
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: philschmid/philschmid-ec2-github-runner@main
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ${{ env.EC2_AMI_ID }}
-          ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
-          subnet-id: ${{ env.EC2_SUBNET_ID }}
-          security-group-id: ${{ env.EC2_SECURITY_GROUP }}
-          aws-resource-tags: > # optional, requires additional permissions
-            [
-              {"Key": "Name", "Value": "optimum-habana-ci-slow-tests"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
-            ]
   example-diff:
     name: Test examples differences
-    needs: start-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    env:
-      AWS_REGION: us-west-2
+    runs-on: [self-hosted, hpu]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -72,11 +35,8 @@ jobs:
   multi-card:
     name: Test multi-card models
     needs:
-      - start-runner
       - example-diff  # run the job when the previous test job is done
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    env:
-      AWS_REGION: us-west-2
+    runs-on: [self-hosted, hpu]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -99,12 +59,9 @@ jobs:
   single-card:
     name: Test single-card models
     needs:
-      - start-runner
       - example-diff
       - multi-card  # run the job when the previous test jobs are done
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    env:
-      AWS_REGION: us-west-2
+    runs-on: [self-hosted, hpu] # run the job on the newly created runner
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -127,13 +84,10 @@ jobs:
   albert-xxl-single-card:
     name: Test single-card ALBERT XXL
     needs:
-      - start-runner
       - example-diff
       - multi-card
       - single-card  # run the job when the previous test jobs are done
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    env:
-      AWS_REGION: us-west-2
+    runs-on: [self-hosted, hpu] # run the job on the newly created runner
     steps:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
@@ -159,29 +113,3 @@ jobs:
       - name: Warning
         if: github.event.schedule != '0 23 * * 6'
         run: echo "ALBERT XXL 1x is only tested on Saturdays."
-  stop-runner:
-    name: Stop self-hosted EC2 runner
-    needs:
-      - start-runner # required to get output from the start-runner job
-      - example-diff
-      - multi-card
-      - single-card
-      - albert-xxl-single-card
-    runs-on: ubuntu-20.04
-    env:
-      AWS_REGION: us-west-2
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Stop EC2 runner
-        uses: philschmid/philschmid-ec2-github-runner@main
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -13,86 +13,59 @@ jobs:
   example-diff:
     name: Test examples differences
     runs-on: [self-hosted, hpu]
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      volumes:
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Pull image
+      - name: Run Diff
         run: |
-            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      - name: Run tests
-        run: |
-            docker run \
-            --user $UID:$GID \
-            --volume="/etc/group:/etc/group:ro" \
-            --volume="/etc/passwd:/etc/passwd:ro" \
-            --volume="/etc/shadow:/etc/shadow:ro" \
-            -v $PWD:/root/workspace \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-            /bin/bash tests/ci/example_diff_tests.sh
+        /bin/bash tests/ci/example_diff_tests.sh
   multi-card:
     name: Test multi-card models
     needs:
       - example-diff  # run the job when the previous test job is done
     runs-on: [self-hosted, hpu]
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      volumes:
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Pull image
+      - name: Run Diff
         run: |
-            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      - name: Run tests
-        run: |
-            docker run \
-            --user $UID:$GID \
-            --volume="/etc/group:/etc/group:ro" \
-            --volume="/etc/passwd:/etc/passwd:ro" \
-            --volume="/etc/shadow:/etc/shadow:ro" \
-            -v $PWD:/root/workspace \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-            /bin/bash tests/ci/slow_tests_8x.sh
+          /bin/bash tests/ci/slow_tests_8x.sh
   single-card:
     name: Test single-card models
     needs:
       - example-diff
       - multi-card  # run the job when the previous test jobs are done
     runs-on: [self-hosted, hpu] # run the job on the newly created runner
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      volumes:
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Pull image
+      - name: Run Diff
         run: |
-            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      - name: Run tests
-        run: |
-            docker run \
-            --user $UID:$GID \
-            --volume="/etc/group:/etc/group:ro" \
-            --volume="/etc/passwd:/etc/passwd:ro" \
-            --volume="/etc/shadow:/etc/shadow:ro" \
-            -v $PWD:/root/workspace \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-            /bin/bash tests/ci/slow_tests_1x.sh
+          /bin/bash tests/ci/slow_tests_1x.sh
   albert-xxl-single-card:
     name: Test single-card ALBERT XXL
     needs:
@@ -100,32 +73,22 @@ jobs:
       - multi-card
       - single-card  # run the job when the previous test jobs are done
     runs-on: [self-hosted, hpu] # run the job on the newly created runner
+    container:
+      image: vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
+      env:
+        HABANA_VISIBLE_DEVICES: all
+        OMPI_MCA_btl_vader_single_copy_mechanism: none
+      options: --cap-add=sys_nice --runtime=habana --workdir=/root/workspace
+      volumes:
+        - /opt/github-actions-runners/_work:/root/workspace
     steps:
       - name: Checkout
         if: github.event.schedule == '0 23 * * 6'
         uses: actions/checkout@v2
-      - name: Pull image
+      - name: Run Diff
         if: github.event.schedule == '0 23 * * 6'
         run: |
-            docker pull vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610
-      - name: Run test
-        if: github.event.schedule == '0 23 * * 6'
-        run: |
-            docker run \
-            --user $UID:$GID \
-            --volume="/etc/group:/etc/group:ro" \
-            --volume="/etc/passwd:/etc/passwd:ro" \
-            --volume="/etc/shadow:/etc/shadow:ro" \
-            -v $PWD:/root/workspace \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.5.0/ubuntu20.04/habanalabs/pytorch-installer-1.11.0:1.5.0-610 \
-            /bin/bash tests/ci/albert_xxl_1x.sh
+          /bin/bash tests/ci/albert_xxl_1x.sh
       - name: Warning
         if: github.event.schedule != '0 23 * * 6'
         run: echo "ALBERT XXL 1x is only tested on Saturdays."

--- a/Makefile
+++ b/Makefile
@@ -28,28 +28,28 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi
 build_dist_install_tools:
-	pip install build
-	pip install twine
+	pip install --user build
+	pip install --user twine
 
 build_dist:
 	rm -fr build

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --upgrade--user --no-cache-dir .[tests]
+	pip install --upgrade --user --no-cache-dir .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests

--- a/Makefile
+++ b/Makefile
@@ -28,28 +28,28 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	python -m pip install --user .[tests]
+	python -m pip install .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install --user .[tests]
+	pip install .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install --user .[tests]
+	pip install .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install --user .[tests]
+	pip install .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi
 build_dist_install_tools:
-	pip install --user build
-	pip install --user twine
+	pip install build
+	pip install twine
 
 build_dist:
 	rm -fr build

--- a/Makefile
+++ b/Makefile
@@ -28,22 +28,22 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --user --no-cache-dir .[tests]
+	pip install --upgrade--user --no-cache-dir .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install --user --no-cache-dir .[tests]
+	pip install --upgrade --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install --user --no-cache-dir .[tests]
+	pip install --upgrade --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install --user --no-cache-dir .[tests]
+	pip install --upgrade --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi

--- a/Makefile
+++ b/Makefile
@@ -28,22 +28,22 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --user .[tests]
+	pip install --user --no-cache-dir .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install --user .[tests]
+	pip install --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install --user .[tests]
+	pip install --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install --user .[tests]
+	pip install --user --no-cache-dir .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi

--- a/Makefile
+++ b/Makefile
@@ -33,23 +33,23 @@ fast_tests:
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install .[tests]
+	python -m pip install .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install .[tests]
+	python -m pip install .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install .[tests]
+	python -m pip install .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi
 build_dist_install_tools:
-	pip install build
-	pip install twine
+	python -m pip install build
+	python -m pip install twine
 
 build_dist:
 	rm -fr build

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --user .[tests]
+	python -m pip install --user .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests

--- a/Makefile
+++ b/Makefile
@@ -28,22 +28,22 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --upgrade --user --no-cache-dir .[tests]
+	pip install --user --force-reinstall .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install --upgrade --user --no-cache-dir .[tests]
+	pip install --user --force-reinstall .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install --upgrade --user --no-cache-dir .[tests]
+	pip install --user --force-reinstall .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install --upgrade --user --no-cache-dir .[tests]
+	pip install --user --force-reinstall .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ style:
 
 # Run unit and integration tests
 fast_tests:
-	pip install --user --force-reinstall .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_gaudi_configuration.py tests/test_trainer_distributed.py tests/test_trainer.py tests/test_trainer_seq2seq.py
 
 # Run single-card non-regression tests

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,17 @@ fast_tests:
 
 # Run single-card non-regression tests
 slow_tests_1x:
-	pip install --user --force-reinstall .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "single_card"
 
 # Run multi-card non-regression tests
 slow_tests_8x:
-	pip install --user --force-reinstall .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests:
-	pip install --user --force-reinstall .[tests]
+	pip install --user .[tests]
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi

--- a/tests/baselines/bert_base_uncased.json
+++ b/tests/baselines/bert_base_uncased.json
@@ -31,7 +31,7 @@
                 "learning_rate": 3e-5,
                 "train_batch_size": 32,
                 "eval_f1": 0.9005,
-                "train_runtime": 47.7051,
+                "train_runtime": 50.6568,
                 "extra_arguments": [
                     "--max_seq_length 128"
                 ]

--- a/tests/baselines/bert_large_uncased_whole_word_masking.json
+++ b/tests/baselines/bert_large_uncased_whole_word_masking.json
@@ -40,7 +40,7 @@
                 "learning_rate": 3e-5,
                 "train_batch_size": 16,
                 "eval_f1": 0.8414,
-                "train_runtime": 74.8887,
+                "train_runtime": 79.9498,
                 "extra_arguments": [
                     "--max_seq_length 128"
                 ]

--- a/tests/baselines/distilbert_base_uncased.json
+++ b/tests/baselines/distilbert_base_uncased.json
@@ -7,7 +7,7 @@
                 "learning_rate": 5e-5,
                 "train_batch_size": 8,
                 "eval_f1": 85.4623,
-                "train_runtime": 1271.3292,
+                "train_runtime": 1611.9473,
                 "extra_arguments": [
                     "--max_seq_length 384"
                 ]
@@ -16,7 +16,7 @@
                 "learning_rate": 5e-5,
                 "train_batch_size": 8,
                 "eval_f1": 85.447,
-                "train_runtime": 264.8974,
+                "train_runtime": 306.348,
                 "extra_arguments": [
                     "--max_seq_length 384"
                 ]

--- a/tests/baselines/roberta_base.json
+++ b/tests/baselines/roberta_base.json
@@ -16,7 +16,7 @@
                 "learning_rate": 3e-5,
                 "train_batch_size": 12,
                 "eval_f1": 91.8972,
-                "train_runtime": 278.1486,
+                "train_runtime": 297.4567,
                 "extra_arguments": [
                     "--max_seq_length 384"
                 ]

--- a/tests/baselines/vit_base_patch16_224_in21k.json
+++ b/tests/baselines/vit_base_patch16_224_in21k.json
@@ -20,8 +20,8 @@
             "multi_card": {
                 "learning_rate": 2e-5,
                 "train_batch_size": 8,
-                "eval_accuracy": 0.985,
-                "train_runtime": 50.8835,
+                "eval_accuracy": 0.9699,
+                "train_runtime": 55.2972,
                 "extra_arguments": [
                     "--remove_unused_columns False",
                     "--evaluation_strategy epoch",

--- a/tests/ci/albert_xxl_1x.sh
+++ b/tests/ci/albert_xxl_1x.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-python -m pip install --user --upgrade pip
+python -m pip install --upgrade pip
 export RUN_SLOW=true
 export RUN_ALBERT_XXL_1X=true
-python -m pip install --user .[tests]
+python -m pip install .[tests]
 python -m pytest tests/test_examples.py -v -s -k "albert-xxlarge-v1_single_card"

--- a/tests/ci/albert_xxl_1x.sh
+++ b/tests/ci/albert_xxl_1x.sh
@@ -3,5 +3,5 @@
 pip install --user --upgrade pip
 export RUN_SLOW=true
 export RUN_ALBERT_XXL_1X=true
-pip install --user .[tests]
+pip install --user --force-reinstall .[tests]
 python -m pytest tests/test_examples.py -v -s -k "albert-xxlarge-v1_single_card"

--- a/tests/ci/albert_xxl_1x.sh
+++ b/tests/ci/albert_xxl_1x.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pip install --upgrade pip
+pip install --user --upgrade pip
 export RUN_SLOW=true
 export RUN_ALBERT_XXL_1X=true
-pip install .[tests]
+pip install --user .[tests]
 python -m pytest tests/test_examples.py -v -s -k "albert-xxlarge-v1_single_card"

--- a/tests/ci/albert_xxl_1x.sh
+++ b/tests/ci/albert_xxl_1x.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pip install --user --upgrade pip
+python -m pip install --user --upgrade pip
 export RUN_SLOW=true
 export RUN_ALBERT_XXL_1X=true
-pip install --user --force-reinstall .[tests]
+python -m pip install --user .[tests]
 python -m pytest tests/test_examples.py -v -s -k "albert-xxlarge-v1_single_card"

--- a/tests/ci/example_diff_tests.sh
+++ b/tests/ci/example_diff_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install --upgrade pip
+pip install --user --upgrade pip
 make example_diff_tests

--- a/tests/ci/example_diff_tests.sh
+++ b/tests/ci/example_diff_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install --user --upgrade pip
+python -m pip install --upgrade pip
 make example_diff_tests

--- a/tests/ci/fast_tests.sh
+++ b/tests/ci/fast_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-python -m pip install --upgrade --user pip
+python -m pip install --upgrade pip
 make fast_tests

--- a/tests/ci/fast_tests.sh
+++ b/tests/ci/fast_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install --upgrade pip
+pip install --upgrade --user pip
 make fast_tests

--- a/tests/ci/fast_tests.sh
+++ b/tests/ci/fast_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install --upgrade --user pip
+python -m pip install --upgrade --user pip
 make fast_tests

--- a/tests/ci/slow_tests_1x.sh
+++ b/tests/ci/slow_tests_1x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pip install --upgrade pip
+pip install --upgrade --user pip
 export RUN_SLOW=true
 make slow_tests_1x

--- a/tests/ci/slow_tests_1x.sh
+++ b/tests/ci/slow_tests_1x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python -m pip install --upgrade --user pip
+python -m pip install --upgrade pip
 export RUN_SLOW=true
 make slow_tests_1x

--- a/tests/ci/slow_tests_1x.sh
+++ b/tests/ci/slow_tests_1x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pip install --upgrade --user pip
+python -m pip install --upgrade --user pip
 export RUN_SLOW=true
 make slow_tests_1x

--- a/tests/ci/slow_tests_8x.sh
+++ b/tests/ci/slow_tests_8x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python -m pip install --upgrade --user pip
+python -m pip install --upgrade pip
 export RUN_SLOW=true
 make slow_tests_8x

--- a/tests/ci/slow_tests_8x.sh
+++ b/tests/ci/slow_tests_8x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pip install --upgrade pip
+pip install --upgrade --user pip
 export RUN_SLOW=true
 make slow_tests_8x

--- a/tests/ci/slow_tests_8x.sh
+++ b/tests/ci/slow_tests_8x.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pip install --upgrade --user pip
+python -m pip install --upgrade --user pip
 export RUN_SLOW=true
 make slow_tests_8x

--- a/tests/example_diff/run_image_classification.txt
+++ b/tests/example_diff/run_image_classification.txt
@@ -1,0 +1,36 @@
+37a38
+> from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
+44,45c45
+<     Trainer,
+<     TrainingArguments,
+---
+>     set_seed,
+170c170
+<     parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+---
+>     parser = HfArgumentParser((ModelArguments, DataTrainingArguments, GaudiTrainingArguments))
+194a195,201
+>     gaudi_config = GaudiConfig.from_pretrained(
+>         training_args.gaudi_config_name,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+> 
+197,198c204,206
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+---
+>         f"Process rank: {training_args.local_rank}, device: {training_args.device}, "
+>         + f"distributed training: {bool(training_args.local_rank != -1)}, "
+>         + f"mixed-precision training: {gaudi_config.use_habana_mixed_precision}"
+216a225,227
+>     # Set seed before initializing model.
+>     set_seed(training_args.seed)
+> 
+341c352
+<     trainer = Trainer(
+---
+>     trainer = GaudiTrainer(
+342a354
+>         gaudi_config=gaudi_config,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -296,7 +296,7 @@ class ExampleTesterBase(TestCase):
             if metric_name in baseline:
                 number_asserted_metrics += 1
                 assert_function, threshold_factor = assert_function_and_threshold
-                assert_function(self, results[metric_name], threshold_factor * baseline[metric_name])
+                assert_function(self, results[metric_name], threshold_factor * baseline[metric_name], msg=f"for metric {metric_name}.")
         self.assertGreaterEqual(
             number_asserted_metrics,
             2,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -268,7 +268,7 @@ class ExampleTesterBase(TestCase):
         if not Path(requirements_filename).exists():
             return
 
-        cmd_line = f"pip install --user -r {requirements_filename}".split()
+        cmd_line = f"pip install -r {requirements_filename}".split()
         p = subprocess.Popen(cmd_line)
         return_code = p.wait()
         self.assertEqual(return_code, 0)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -268,7 +268,7 @@ class ExampleTesterBase(TestCase):
         if not Path(requirements_filename).exists():
             return
 
-        cmd_line = f"pip install -r {requirements_filename}".split()
+        cmd_line = f"pip install --user -r {requirements_filename}".split()
         p = subprocess.Popen(cmd_line)
         return_code = p.wait()
         self.assertEqual(return_code, 0)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -296,7 +296,12 @@ class ExampleTesterBase(TestCase):
             if metric_name in baseline:
                 number_asserted_metrics += 1
                 assert_function, threshold_factor = assert_function_and_threshold
-                assert_function(self, results[metric_name], threshold_factor * baseline[metric_name], msg=f"for metric {metric_name}.")
+                assert_function(
+                    self,
+                    results[metric_name],
+                    threshold_factor * baseline[metric_name],
+                    msg=f"for metric {metric_name}.",
+                )
         self.assertGreaterEqual(
             number_asserted_metrics,
             2,


### PR DESCRIPTION
Move the CI regression tests to on-prem Gaudi.

Fast (unit and integration) tests run for each commit and PR are still run on AWS instances to avoid collision with other fast tests or runs triggered by users. Since all those cannot be planned beforehand, it is better to run them on different AWS instances.

This PR also modifies the following:
- All the slow tests are now performed, whether one of these tests failed or not. Tests following a failed test used to be skipped.
- Update some CI baselines.
- Add a diff file for the `run_image_classification.py` example. It should have been added in #80.