### PR TITLE
Fix bug with HMP for ALBERT

### DIFF
--- a/optimum/habana/modeling_utils.py
+++ b/optimum/habana/modeling_utils.py
@@ -13,12 +13,13 @@
 #  limitations under the License.
 
 import copy
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
 from habana_frameworks.torch.hpex import hmp
 from transformers import PreTrainedModel
+from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.modeling_utils import ModuleUtilsMixin
 
 
@@ -85,11 +86,9 @@ class GaudiMixin:
 
 def gaudi_invert_attention_mask(self, encoder_attention_mask: torch.Tensor) -> torch.Tensor:
     """
-    Invert an attention mask (e.g., switches 0. and 1.).
-    Args:
-        encoder_attention_mask (`torch.Tensor`): An attention mask.
-    Returns:
-        `torch.Tensor`: The inverted attention mask.
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L640
+    except that HMP is disabled for computing:
+        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
     """
     if encoder_attention_mask.dim() == 3:
         encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
@@ -113,14 +112,9 @@ def gaudi_get_extended_attention_mask(
     self, attention_mask: torch.Tensor, input_shape: Tuple[int], device: torch.device = None, dtype: torch.float = None
 ) -> torch.Tensor:
     """
-    Makes broadcastable attention and causal masks so that future and masked tokens are ignored.
-    Arguments:
-        attention_mask (`torch.Tensor`):
-            Mask with ones indicating tokens to attend to, zeros for tokens to ignore.
-        input_shape (`Tuple[int]`):
-            The shape of the input to the model.
-    Returns:
-        `torch.Tensor` The extended attention mask, with a the same dtype as `attention_mask.dtype`.
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L692
+    except that HMP is disabled for computing:
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
     """
     if dtype is None:
         dtype = self.dtype
@@ -162,3 +156,83 @@ def gaudi_get_extended_attention_mask(
         extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
 
     return extended_attention_mask
+
+
+def gaudi_albert_forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.FloatTensor] = None,
+    token_type_ids: Optional[torch.LongTensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    head_mask: Optional[torch.FloatTensor] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    output_attentions: Optional[None] = None,
+    output_hidden_states: Optional[None] = None,
+    return_dict: Optional[None] = None,
+) -> Union[BaseModelOutputWithPooling, Tuple]:
+    """
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/models/albert/modeling_albert.py#L689
+    except that HMP is disabled for computing:
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
+    """
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if input_ids is not None and inputs_embeds is not None:
+        raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+    elif input_ids is not None:
+        input_shape = input_ids.size()
+    elif inputs_embeds is not None:
+        input_shape = inputs_embeds.size()[:-1]
+    else:
+        raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+    batch_size, seq_length = input_shape
+    device = input_ids.device if input_ids is not None else inputs_embeds.device
+
+    if attention_mask is None:
+        attention_mask = torch.ones(input_shape, device=device)
+    if token_type_ids is None:
+        if hasattr(self.embeddings, "token_type_ids"):
+            buffered_token_type_ids = self.embeddings.token_type_ids[:, :seq_length]
+            buffered_token_type_ids_expanded = buffered_token_type_ids.expand(batch_size, seq_length)
+            token_type_ids = buffered_token_type_ids_expanded
+        else:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+    extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
+    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
+    with hmp.disable_casts():
+        extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
+    head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
+
+    embedding_output = self.embeddings(
+        input_ids, position_ids=position_ids, token_type_ids=token_type_ids, inputs_embeds=inputs_embeds
+    )
+    encoder_outputs = self.encoder(
+        embedding_output,
+        extended_attention_mask,
+        head_mask=head_mask,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+    )
+
+    sequence_output = encoder_outputs[0]
+
+    pooled_output = self.pooler_activation(self.pooler(sequence_output[:, 0])) if self.pooler is not None else None
+
+    if not return_dict:
+        return (sequence_output, pooled_output) + encoder_outputs[1:]
+
+    return BaseModelOutputWithPooling(
+        last_hidden_state=sequence_output,
+        pooler_output=pooled_output,
+        hidden_states=encoder_outputs.hidden_states,
+        attentions=encoder_outputs.attentions,
+    )

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -37,6 +37,7 @@ from transformers.data.data_collator import DataCollator
 from transformers.debug_utils import DebugOption, DebugUnderflowOverflow
 from transformers.integrations import hp_params
 from transformers.modeling_utils import ModuleUtilsMixin, PreTrainedModel, unwrap_model
+from transformers.models.albert.modeling_albert import AlbertModel
 from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_callback import TrainerCallback, TrainerState
@@ -74,6 +75,7 @@ from transformers.utils import CONFIG_NAME, WEIGHTS_NAME
 from .gaudi_configuration import GAUDI_CONFIG_NAME, GaudiConfig
 from .modeling_utils import (
     PRETRAINED_TO_GAUDI_REGISTRY,
+    gaudi_albert_forward,
     gaudi_get_extended_attention_mask,
     gaudi_invert_attention_mask,
     to_gaudi_for_accelerated_generation,
@@ -183,6 +185,9 @@ class GaudiTrainer(Trainer):
                 # so that HMP is disabled for specific parts of the code
                 ModuleUtilsMixin.invert_attention_mask = gaudi_invert_attention_mask
                 ModuleUtilsMixin.get_extended_attention_mask = gaudi_get_extended_attention_mask
+                # AlbertModel.forward does not rely on get_extended_attention_mask so it also needs
+                # to be replaced when using HMP
+                AlbertModel.forward = gaudi_albert_forward
 
             if self.gaudi_config.use_fused_clip_norm:
                 try:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

ALBERT does not rely on the `get_extended_attention_mask` method so it needs its own fix for disabling HMP when computing `extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
