### PR TITLE
Fix variable name in make doc

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Make documentation
         run: |
           cd optimum-habana
-          make doc BUILD_DIR=habana-doc-build VERSION=pr_$PR_NUMBER COMMIT_SHA=$COMMIT_SHA
+          make doc BUILD_DIR=habana-doc-build VERSION=pr_$PR_NUMBER COMMIT_SHA_SUBPACKAGE=$COMMIT_SHA
           cd ..
 
       - name: Push to repositories

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ pypi_upload: build_dist
 	python -m twine upload dist/*
 
 build_doc_docker_image:
-	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA) ./docs
+	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_SUBPACKAGE) ./docs
 
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The environment variable `COMMIT_SHA` collides with the one of Optimum when building the documentation of Optimum. Indeed, in that case, the variable `COMMIT_SHA` for generating the doc of Optimum Habana is supposed to be empty but it will actually be equal to the variable `COMMIT_SHA` defined in the PR documentation workflow, leading to an error because this commit exists in Optimum but not in Optimum Habana.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
