### PR TITLE
Check if torch.distributed was already initialized in distributed mode

### DIFF
--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -288,21 +288,21 @@ class GaudiTrainer(Trainer):
 
         if self.args.local_rank != -1:
             kwargs = {}
-            if self.args.ddp_find_unused_parameters is not None:
-                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
-            elif isinstance(model, PreTrainedModel):
-                # find_unused_parameters breaks checkpointing as per
-                # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
-                kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
-            else:
-                kwargs["find_unused_parameters"] = True
+            # if self.args.ddp_find_unused_parameters is not None:
+            #     kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+            # elif isinstance(model, PreTrainedModel):
+            #     # find_unused_parameters breaks checkpointing as per
+            #     # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
+            #     kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
+            # else:
+            #     kwargs["find_unused_parameters"] = True
 
             if self.args.ddp_bucket_cap_mb is not None:
                 kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
             if self.args.use_habana:
                 kwargs["bucket_cap_mb"] = 230
                 kwargs["gradient_as_bucket_view"] = True
-                kwargs["find_unused_parameters"] = False
+                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
             model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=[self.args.local_rank] if self.args._n_gpu != 0 and not self.args.use_habana else None,

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -288,21 +288,13 @@ class GaudiTrainer(Trainer):
 
         if self.args.local_rank != -1:
             kwargs = {}
-            # if self.args.ddp_find_unused_parameters is not None:
-            #     kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
-            # elif isinstance(model, PreTrainedModel):
-            #     # find_unused_parameters breaks checkpointing as per
-            #     # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
-            #     kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
-            # else:
-            #     kwargs["find_unused_parameters"] = True
 
-            if self.args.ddp_bucket_cap_mb is not None:
-                kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
+            kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+            kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
+
             if self.args.use_habana:
-                kwargs["bucket_cap_mb"] = 230
                 kwargs["gradient_as_bucket_view"] = True
-                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+
             model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=[self.args.local_rank] if self.args._n_gpu != 0 and not self.args.use_habana else None,

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -209,7 +209,7 @@ class GaudiTrainingArguments(TrainingArguments):
 
             world_size, rank, self.local_rank = initialize_distributed_hpu()
 
-            if self.local_rank != -1:
+            if self.local_rank != -1 and not torch.distributed.is_initialized():
                 if world_size > hthpu.device_count():
                     raise RuntimeError(
                         f"world_size is equal to {world_size} but there are only {hthpu.device_count()} devices."

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -91,11 +91,21 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": "Filter nan and inf losses for logging."},
     )
 
-    ddp_find_unused_parameters: bool = field(
+    ddp_find_unused_parameters: Optional[bool] = field(
         default=False,
         metadata={
             "help": (
                 "When using distributed training, the value of the flag `find_unused_parameters` passed to "
+                "`DistributedDataParallel`."
+            )
+        },
+    )
+
+    ddp_bucket_cap_mb: Optional[int] = field(
+        default=230,
+        metadata={
+            "help": (
+                "When using distributed training, the value of the flag `bucket_cap_mb` passed to "
                 "`DistributedDataParallel`."
             )
         },

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -216,7 +216,7 @@ class GaudiTrainingArguments(TrainingArguments):
                     )
                 if not torch.distributed.is_initialized():
                     torch.distributed.init_process_group(backend="hccl", rank=self.local_rank, world_size=world_size)
-                logger.info("Enabled distributed run.")
+                    logger.info("Enabled distributed run.")
             else:
                 logger.info("Single node run.")
         else:

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -91,6 +91,16 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": "Filter nan and inf losses for logging."},
     )
 
+    ddp_find_unused_parameters: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "When using distributed training, the value of the flag `find_unused_parameters` passed to "
+                "`DistributedDataParallel`."
+            )
+        },
+    )
+
     def __post_init__(self):
         if (self.use_lazy_mode or self.gaudi_config_name) and not self.use_habana:
             raise ValueError("--use_lazy_mode and --gaudi_config_name cannot be used without --use_habana")

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -209,12 +209,13 @@ class GaudiTrainingArguments(TrainingArguments):
 
             world_size, rank, self.local_rank = initialize_distributed_hpu()
 
-            if self.local_rank != -1 and not torch.distributed.is_initialized():
+            if self.local_rank != -1:
                 if world_size > hthpu.device_count():
                     raise RuntimeError(
                         f"world_size is equal to {world_size} but there are only {hthpu.device_count()} devices."
                     )
-                torch.distributed.init_process_group(backend="hccl", rank=self.local_rank, world_size=world_size)
+                if not torch.distributed.is_initialized():
+                    torch.distributed.init_process_group(backend="hccl", rank=self.local_rank, world_size=world_size)
                 logger.info("Enabled distributed run.")
             else:
                 logger.info("Single node run.")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds a check to make sure `torch.distributed` is not initialized twice.

It also adds some flexibility to Torch DDP to specify with training arguments:
- `find_unused_parameters`, which should be `True` for pretraining (default is `False`),
- `ddp_bucket_cap_mb`, default is 230.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
