### PR TITLE
Update CI baseline (TTT) for BERT base MRPC 8x

### DIFF
--- a/tests/baselines/bert_base_uncased.json
+++ b/tests/baselines/bert_base_uncased.json
@@ -40,7 +40,7 @@
                 "learning_rate": 3e-5,
                 "train_batch_size": 16,
                 "eval_f1": 0.8752,
-                "train_runtime": 54.8891,
+                "train_runtime": 60.2122,
                 "extra_arguments": [
                     "--max_seq_length 128"
                 ]


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

There is quite a lot of variance on the training time of `bert-base-uncased` fine-tuned on MRPC in distributed mode. This PR adjusts the corresponding baseline training time.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
