### PR TITLE
Add make clean to delete log files/folders generated by runs on Gaudi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,8 @@ doc: build_doc_docker_image
 		--version $(VERSION) \
 		--html \
 		--clean
+
+clean:
+	find . -name "habana_log.livealloc.log_*" -type f -delete
+	find . -name .lock -type f -delete
+	find . -name .graph_dumps -type d -delete


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds a `make clean` to delete log files and folders generated by Gaudi during each run, such as `.graph_dumps/` or `habana_log.livealloc.log_*`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
