### PR TITLE
Add default clone URL to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@
 #  limitations under the License.
 SHELL := /bin/bash
 CURRENT_DIR = $(shell pwd)
+DEFAULT_CLONE_URL := https://github.com/huggingface/optimum-habana.git
+# If CLONE_URL is empty, revert to DEFAULT_CLONE_URL
+REAL_CLONE_URL = $(if $(CLONE_URL),$(CLONE_URL),$(DEFAULT_CLONE_URL))
 
 
 .PHONY:	style test
@@ -60,7 +63,7 @@ pypi_upload: build_dist
 	python -m twine upload dist/*
 
 build_doc_docker_image:
-	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_SUBPACKAGE) --build-arg clone_url=$(CLONE_URL) ./docs
+	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_SUBPACKAGE) --build-arg clone_url=$(REAL_CLONE_URL) ./docs
 
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -87,3 +87,5 @@ Please refer to Habana Gaudi's official [installation guide](https://docs.habana
 Tests should be run in a Docker container based on Habana Docker images.
 
 </Tip>
+
+Test

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -87,5 +87,3 @@ Please refer to Habana Gaudi's official [installation guide](https://docs.habana
 Tests should be run in a Docker container based on Habana Docker images.
 
 </Tip>
-
-Test


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

We would like to have a default clone URL to use when building the main documentation of Optimum. This is needed because in that case we cannot retrieve the clone URL from any PR properties.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
