### PR TITLE
Refactor how optimized methods for Gaudi replace their counterparts in Transformers

### DIFF
--- a/optimum/habana/__init__.py
+++ b/optimum/habana/__init__.py
@@ -17,8 +17,6 @@
 #  limitations under the License.
 
 from .gaudi_configuration import GaudiConfig
-from .models.gpt2 import GaudiGPT2LMHeadModel
-from .models.t5 import GaudiT5ForConditionalGeneration
 from .trainer import GaudiTrainer
 from .trainer_seq2seq import GaudiSeq2SeqTrainer
 from .training_args import GaudiTrainingArguments

--- a/optimum/habana/generation_utils.py
+++ b/optimum/habana/generation_utils.py
@@ -461,7 +461,7 @@ class GaudiGenerationMixin(GenerationMixin):
             max_length=max_length, max_time=max_time, stopping_criteria=stopping_criteria
         )
 
-        # In lazy mode, imprt Haban torch to be able to add mark_step()
+        # In lazy mode, import Habana torch to be able to add mark_step()
         if lazy_mode:
             import habana_frameworks.torch.core as htcore
 

--- a/optimum/habana/modeling_utils.py
+++ b/optimum/habana/modeling_utils.py
@@ -12,227 +12,46 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import copy
-from typing import Optional, Tuple, Union
-
-import torch
-
-from habana_frameworks.torch.hpex import hmp
-from transformers import PreTrainedModel
-from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.generation_utils import GenerationMixin
 from transformers.modeling_utils import ModuleUtilsMixin
+from transformers.models.albert.modeling_albert import AlbertModel
+from transformers.models.vit.modeling_vit import ViTSelfAttention
+
+from .generation_utils import GaudiGenerationMixin
+from .models import (
+    gaudi_albert_forward,
+    gaudi_get_extended_attention_mask,
+    gaudi_invert_attention_mask,
+    gaudi_vit_self_attention_forward,
+)
 
 
-PRETRAINED_TO_GAUDI_REGISTRY = {}
-
-
-def register(transformers_cls):
+def adapt_transformers_to_gaudi(use_habana_mixed_precision: bool):
     """
-    Class wrapper to register models that require accelerated generation.
-    """
-
-    def wrapper(cls):
-        if transformers_cls is None:
-            raise ValueError(f"None cannot be registered, please provide a valid Transformers model class.")
-        PRETRAINED_TO_GAUDI_REGISTRY[transformers_cls] = cls
-        return cls
-
-    return wrapper
-
-
-def to_gaudi_for_accelerated_generation(model: PreTrainedModel) -> PreTrainedModel:
-    """
-    Convert a model so that its generate method is executed efficiently
-    in lazy mode.
+    Replaces some Transformers' methods for equivalent methods optimized
+    for Gaudi.
 
     Args:
-        model (PreTrainedModel): model to convert.
-
-    Raises:
-        KeyError: when the class of the given model is not registered.
-
-    Returns:
-        PreTrainedModel: converted model.
+        use_habana_mixed_precision (bool): whether HMP is used or not.
     """
 
-    model_cls = model.__class__
-    gaudi_cls = PRETRAINED_TO_GAUDI_REGISTRY.get(model_cls, None)
-    if gaudi_cls is not None:
-        return gaudi_cls.from_transformers(model)
-    else:
-        raise KeyError(f"{model_cls.__name__} Gaudi version not found in registry: {PRETRAINED_TO_GAUDI_REGISTRY}")
+    # Optimization tweak for ViT
+    ViTSelfAttention.forward = gaudi_vit_self_attention_forward
 
+    # Generation is modified to run faster in lazy mode
+    GenerationMixin.generate = GaudiGenerationMixin.generate
+    GenerationMixin.greedy_search = GaudiGenerationMixin.greedy_search
+    GenerationMixin.sample = GaudiGenerationMixin.sample
+    GenerationMixin.beam_search = GaudiGenerationMixin.beam_search
+    GenerationMixin.beam_sample = GaudiGenerationMixin.beam_sample
+    GenerationMixin.group_beam_search = GaudiGenerationMixin.group_beam_search
+    GenerationMixin.constrained_beam_search = GaudiGenerationMixin.constrained_beam_search
 
-class GaudiMixin:
-    @classmethod
-    def from_transformers(cls, model: PreTrainedModel) -> PreTrainedModel:
-        """
-        Convert a model so that its generate method is executed efficiently
-        in lazy mode.
-
-        Args:
-            model (PreTrainedModel): model to convert.
-
-        Returns:
-            PreTrainedModel: converted model.
-        """
-
-        config = copy.deepcopy(model.config)
-        gaudi_model = cls(config)
-        gaudi_model.load_state_dict(model.state_dict())
-
-        return gaudi_model
-
-
-def gaudi_invert_attention_mask(self, encoder_attention_mask: torch.Tensor) -> torch.Tensor:
-    """
-    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L640
-    except that HMP is disabled for computing:
-        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
-    """
-    if encoder_attention_mask.dim() == 3:
-        encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
-    if encoder_attention_mask.dim() == 2:
-        encoder_extended_attention_mask = encoder_attention_mask[:, None, None, :]
-    # T5 has a mask that can compare sequence ids, we can simulate this here with this transposition
-    # Cf. https://github.com/tensorflow/mesh/blob/8d2465e9bc93129b913b5ccc6a59aa97abd96ec6/mesh_tensorflow
-    # /transformer/transformer_layers.py#L270
-    # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
-    # encoder_extended_attention_mask.transpose(-1, -2))
-    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
-    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
-    with hmp.disable_casts():
-        encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
-
-    return encoder_extended_attention_mask
-
-
-def gaudi_get_extended_attention_mask(
-    self, attention_mask: torch.Tensor, input_shape: Tuple[int], device: torch.device = None, dtype: torch.float = None
-) -> torch.Tensor:
-    """
-    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L692
-    except that HMP is disabled for computing:
-        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
-    """
-    if dtype is None:
-        dtype = self.dtype
-
-    if not (attention_mask.dim() == 2 and self.config.is_decoder):
-        # show warning only if it won't be shown in `create_extended_attention_mask_for_decoder`
-        if device is not None:
-            warnings.warn(
-                "The `device` argument is deprecated and will be removed in v5 of Transformers.", FutureWarning
-            )
-    # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
-    # ourselves in which case we just need to make it broadcastable to all heads.
-    if attention_mask.dim() == 3:
-        extended_attention_mask = attention_mask[:, None, :, :]
-    elif attention_mask.dim() == 2:
-        # Provided a padding mask of dimensions [batch_size, seq_length]
-        # - if the model is a decoder, apply a causal mask in addition to the padding mask
-        # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
-        if self.config.is_decoder:
-            extended_attention_mask = ModuleUtilsMixin.create_extended_attention_mask_for_decoder(
-                input_shape, attention_mask, device
-            )
-        else:
-            extended_attention_mask = attention_mask[:, None, None, :]
-    else:
-        raise ValueError(
-            f"Wrong shape for input_ids (shape {input_shape}) or attention_mask (shape {attention_mask.shape})"
-        )
-
-    # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-    # masked positions, this operation will create a tensor which is 0.0 for
-    # positions we want to attend and -10000.0 for masked positions.
-    # Since we are adding it to the raw scores before the softmax, this is
-    # effectively the same as removing these entirely.
-    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
-    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
-    with hmp.disable_casts():
-        extended_attention_mask = extended_attention_mask.to(dtype=dtype)  # fp16 compatibility
-        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
-
-    return extended_attention_mask
-
-
-def gaudi_albert_forward(
-    self,
-    input_ids: Optional[torch.LongTensor] = None,
-    attention_mask: Optional[torch.FloatTensor] = None,
-    token_type_ids: Optional[torch.LongTensor] = None,
-    position_ids: Optional[torch.LongTensor] = None,
-    head_mask: Optional[torch.FloatTensor] = None,
-    inputs_embeds: Optional[torch.FloatTensor] = None,
-    output_attentions: Optional[None] = None,
-    output_hidden_states: Optional[None] = None,
-    return_dict: Optional[None] = None,
-) -> Union[BaseModelOutputWithPooling, Tuple]:
-    """
-    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/models/albert/modeling_albert.py#L689
-    except that HMP is disabled for computing:
-        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
-    """
-    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-    output_hidden_states = (
-        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-    )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-    if input_ids is not None and inputs_embeds is not None:
-        raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
-    elif input_ids is not None:
-        input_shape = input_ids.size()
-    elif inputs_embeds is not None:
-        input_shape = inputs_embeds.size()[:-1]
-    else:
-        raise ValueError("You have to specify either input_ids or inputs_embeds")
-
-    batch_size, seq_length = input_shape
-    device = input_ids.device if input_ids is not None else inputs_embeds.device
-
-    if attention_mask is None:
-        attention_mask = torch.ones(input_shape, device=device)
-    if token_type_ids is None:
-        if hasattr(self.embeddings, "token_type_ids"):
-            buffered_token_type_ids = self.embeddings.token_type_ids[:, :seq_length]
-            buffered_token_type_ids_expanded = buffered_token_type_ids.expand(batch_size, seq_length)
-            token_type_ids = buffered_token_type_ids_expanded
-        else:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
-
-    extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
-    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
-    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
-    with hmp.disable_casts():
-        extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
-    head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
-
-    embedding_output = self.embeddings(
-        input_ids, position_ids=position_ids, token_type_ids=token_type_ids, inputs_embeds=inputs_embeds
-    )
-    encoder_outputs = self.encoder(
-        embedding_output,
-        extended_attention_mask,
-        head_mask=head_mask,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=return_dict,
-    )
-
-    sequence_output = encoder_outputs[0]
-
-    pooled_output = self.pooler_activation(self.pooler(sequence_output[:, 0])) if self.pooler is not None else None
-
-    if not return_dict:
-        return (sequence_output, pooled_output) + encoder_outputs[1:]
-
-    return BaseModelOutputWithPooling(
-        last_hidden_state=sequence_output,
-        pooler_output=pooled_output,
-        hidden_states=encoder_outputs.hidden_states,
-        attentions=encoder_outputs.attentions,
-    )
+    if use_habana_mixed_precision:
+        # When HMP is enabled, replace invert_attention_mask and get_extended_attention_mask
+        # so that HMP is disabled for specific parts of the code
+        ModuleUtilsMixin.invert_attention_mask = gaudi_invert_attention_mask
+        ModuleUtilsMixin.get_extended_attention_mask = gaudi_get_extended_attention_mask
+        # AlbertModel.forward does not rely on get_extended_attention_mask so it also needs
+        # to be replaced when using HMP
+        AlbertModel.forward = gaudi_albert_forward

--- a/optimum/habana/models/__init__.py
+++ b/optimum/habana/models/__init__.py
@@ -1,1 +1,3 @@
-from . import gpt2, t5, vit
+from .albert import gaudi_albert_forward
+from .modeling_all_models import gaudi_get_extended_attention_mask, gaudi_invert_attention_mask
+from .vit import gaudi_vit_self_attention_forward

--- a/optimum/habana/models/albert/__init__.py
+++ b/optimum/habana/models/albert/__init__.py
@@ -1,0 +1,1 @@
+from .modeling_albert import gaudi_albert_forward

--- a/optimum/habana/models/albert/modeling_albert.py
+++ b/optimum/habana/models/albert/modeling_albert.py
@@ -1,0 +1,86 @@
+from typing import Optional, Tuple, Union
+
+import torch
+
+from habana_frameworks.torch.hpex import hmp
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+
+def gaudi_albert_forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.FloatTensor] = None,
+    token_type_ids: Optional[torch.LongTensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    head_mask: Optional[torch.FloatTensor] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    output_attentions: Optional[None] = None,
+    output_hidden_states: Optional[None] = None,
+    return_dict: Optional[None] = None,
+) -> Union[BaseModelOutputWithPooling, Tuple]:
+    """
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/models/albert/modeling_albert.py#L689
+    except that HMP is disabled for computing:
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
+    """
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if input_ids is not None and inputs_embeds is not None:
+        raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+    elif input_ids is not None:
+        input_shape = input_ids.size()
+    elif inputs_embeds is not None:
+        input_shape = inputs_embeds.size()[:-1]
+    else:
+        raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+    batch_size, seq_length = input_shape
+    device = input_ids.device if input_ids is not None else inputs_embeds.device
+
+    if attention_mask is None:
+        attention_mask = torch.ones(input_shape, device=device)
+    if token_type_ids is None:
+        if hasattr(self.embeddings, "token_type_ids"):
+            buffered_token_type_ids = self.embeddings.token_type_ids[:, :seq_length]
+            buffered_token_type_ids_expanded = buffered_token_type_ids.expand(batch_size, seq_length)
+            token_type_ids = buffered_token_type_ids_expanded
+        else:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+    extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
+    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
+    with hmp.disable_casts():
+        extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(self.dtype).min
+    head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
+
+    embedding_output = self.embeddings(
+        input_ids, position_ids=position_ids, token_type_ids=token_type_ids, inputs_embeds=inputs_embeds
+    )
+    encoder_outputs = self.encoder(
+        embedding_output,
+        extended_attention_mask,
+        head_mask=head_mask,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+    )
+
+    sequence_output = encoder_outputs[0]
+
+    pooled_output = self.pooler_activation(self.pooler(sequence_output[:, 0])) if self.pooler is not None else None
+
+    if not return_dict:
+        return (sequence_output, pooled_output) + encoder_outputs[1:]
+
+    return BaseModelOutputWithPooling(
+        last_hidden_state=sequence_output,
+        pooler_output=pooled_output,
+        hidden_states=encoder_outputs.hidden_states,
+        attentions=encoder_outputs.attentions,
+    )

--- a/optimum/habana/models/modeling_all_models.py
+++ b/optimum/habana/models/modeling_all_models.py
@@ -1,0 +1,80 @@
+from typing import Tuple
+
+import torch
+
+from habana_frameworks.torch.hpex import hmp
+from transformers.modeling_utils import ModuleUtilsMixin
+
+
+def gaudi_invert_attention_mask(self, encoder_attention_mask: torch.Tensor) -> torch.Tensor:
+    """
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L640
+    except that HMP is disabled for computing:
+        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
+    """
+    if encoder_attention_mask.dim() == 3:
+        encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
+    if encoder_attention_mask.dim() == 2:
+        encoder_extended_attention_mask = encoder_attention_mask[:, None, None, :]
+    # T5 has a mask that can compare sequence ids, we can simulate this here with this transposition
+    # Cf. https://github.com/tensorflow/mesh/blob/8d2465e9bc93129b913b5ccc6a59aa97abd96ec6/mesh_tensorflow
+    # /transformer/transformer_layers.py#L270
+    # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
+    # encoder_extended_attention_mask.transpose(-1, -2))
+    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
+    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
+    with hmp.disable_casts():
+        encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
+        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
+
+    return encoder_extended_attention_mask
+
+
+def gaudi_get_extended_attention_mask(
+    self, attention_mask: torch.Tensor, input_shape: Tuple[int], device: torch.device = None, dtype: torch.float = None
+) -> torch.Tensor:
+    """
+    Same as https://github.com/huggingface/transformers/blob/a9eee2ffecc874df7dd635b2c6abb246fdb318cc/src/transformers/modeling_utils.py#L692
+    except that HMP is disabled for computing:
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
+    """
+    if dtype is None:
+        dtype = self.dtype
+
+    if not (attention_mask.dim() == 2 and self.config.is_decoder):
+        # show warning only if it won't be shown in `create_extended_attention_mask_for_decoder`
+        if device is not None:
+            warnings.warn(
+                "The `device` argument is deprecated and will be removed in v5 of Transformers.", FutureWarning
+            )
+    # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
+    # ourselves in which case we just need to make it broadcastable to all heads.
+    if attention_mask.dim() == 3:
+        extended_attention_mask = attention_mask[:, None, :, :]
+    elif attention_mask.dim() == 2:
+        # Provided a padding mask of dimensions [batch_size, seq_length]
+        # - if the model is a decoder, apply a causal mask in addition to the padding mask
+        # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
+        if self.config.is_decoder:
+            extended_attention_mask = ModuleUtilsMixin.create_extended_attention_mask_for_decoder(
+                input_shape, attention_mask, device
+            )
+        else:
+            extended_attention_mask = attention_mask[:, None, None, :]
+    else:
+        raise ValueError(
+            f"Wrong shape for input_ids (shape {input_shape}) or attention_mask (shape {attention_mask.shape})"
+        )
+
+    # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
+    # masked positions, this operation will create a tensor which is 0.0 for
+    # positions we want to attend and -10000.0 for masked positions.
+    # Since we are adding it to the raw scores before the softmax, this is
+    # effectively the same as removing these entirely.
+    # HMP is disabled because (1.0 - encoder_extended_attention_mask) may be converted into bf16
+    # while torch.finfo(self.dtype).min is the min value of fp32, which leads to NaNs
+    with hmp.disable_casts():
+        extended_attention_mask = extended_attention_mask.to(dtype=dtype)  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
+
+    return extended_attention_mask

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -36,13 +36,7 @@ from transformers.configuration_utils import PretrainedConfig
 from transformers.data.data_collator import DataCollator
 from transformers.debug_utils import DebugOption, DebugUnderflowOverflow
 from transformers.integrations import hp_params
-from transformers.modeling_utils import ModuleUtilsMixin, PreTrainedModel, unwrap_model
-from transformers.models.albert.modeling_albert import (  # TODO: change how tweaked classes/functions are managed
-    AlbertModel,
-)
-from transformers.models.vit.modeling_vit import (  # TODO: change how tweaked classes/functions are managed
-    ViTSelfAttention,
-)
+from transformers.modeling_utils import PreTrainedModel, unwrap_model
 from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_callback import TrainerCallback, TrainerState
@@ -78,14 +72,7 @@ from transformers.training_args import TrainingArguments
 from transformers.utils import CONFIG_NAME, WEIGHTS_NAME
 
 from .gaudi_configuration import GAUDI_CONFIG_NAME, GaudiConfig
-from .modeling_utils import (
-    PRETRAINED_TO_GAUDI_REGISTRY,
-    gaudi_albert_forward,
-    gaudi_get_extended_attention_mask,
-    gaudi_invert_attention_mask,
-    to_gaudi_for_accelerated_generation,
-)
-from .models.vit import gaudi_vit_self_attention_forward  # TODO: change how tweaked classes/functions are managed
+from .modeling_utils import adapt_transformers_to_gaudi
 from .trainer_utils import convert_into_dtypes, get_dtype, speed_metrics, to_device_dtype
 from .training_args import GaudiTrainingArguments
 
@@ -130,15 +117,6 @@ class GaudiTrainer(Trainer):
             output_dir = "tmp_trainer"
             logger.info(f"No `GaudiTrainingArguments` passed, using `output_dir={output_dir}`.")
             args = GaudiTrainingArguments(output_dir=output_dir)
-
-        # TODO: change how tweaked classes/functions are managed
-        ViTSelfAttention.forward = gaudi_vit_self_attention_forward
-
-        # In lazy_mode, decoder or encoder-decoder architectures are slightly
-        # modified to accelerate the generation process
-        # TODO: change how tweaked classes/functions are managed
-        if args.use_habana and model.__class__ in PRETRAINED_TO_GAUDI_REGISTRY and model is not None:
-            model = to_gaudi_for_accelerated_generation(model)
 
         super().__init__(
             model,
@@ -191,15 +169,6 @@ class GaudiTrainer(Trainer):
                             isVerbose=self.gaudi_config.hmp_is_verbose,
                         )
 
-                # TODO: change how tweaked classes/functions are managed
-                # When HMP is enabled, replace invert_attention_mask and get_extended_attention_mask
-                # so that HMP is disabled for specific parts of the code
-                ModuleUtilsMixin.invert_attention_mask = gaudi_invert_attention_mask
-                ModuleUtilsMixin.get_extended_attention_mask = gaudi_get_extended_attention_mask
-                # AlbertModel.forward does not rely on get_extended_attention_mask so it also needs
-                # to be replaced when using HMP
-                AlbertModel.forward = gaudi_albert_forward
-
             if self.gaudi_config.use_fused_clip_norm:
                 try:
                     from habana_frameworks.torch.hpex.normalization import FusedClipNorm
@@ -220,6 +189,9 @@ class GaudiTrainer(Trainer):
         # transformers.utils.logging
         log_level = args.get_process_log_level()
         logging.set_verbosity(log_level)
+
+        # Some methods needs to be tweaked to optimally run on Gaudi
+        adapt_transformers_to_gaudi(self.gaudi_config.use_habana_mixed_precision)
 
     def create_optimizer(self):
         """


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Some forward methods (e.g. for ViT and ALBERT) and generation methods are tweaked so that they are optimized for running on Gaudi. The replacement logic with their Transformers' counterparts is currently done in the Trainer. This PR moves this logic in `modeling_utils.py` so that only one call is needed in the Trainer.

The way these methods are replaced is not the most elegant one, but it will be much easier to maintain and will profit all models from Transformers (not only the one we validated). For instance, before this PR, only GPT2 and T5 benefit from the optimized generation methods. With this PR, all the models that have a `generate` method will benefit from them.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
