### PR TITLE
Temporary workaround for loading best model at end with DeepSpeed

### DIFF
--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -1496,9 +1496,7 @@ class GaudiTrainer(Trainer):
             load_result = model.load_state_dict(state_dict, strict=False)
             self._issue_warnings_after_load(load_result)
         elif os.path.exists(os.path.join(self.state.best_model_checkpoint, WEIGHTS_INDEX_NAME)):
-            load_result = load_sharded_checkpoint(
-                model, self.state.best_model_checkpoint, strict=False
-            )
+            load_result = load_sharded_checkpoint(model, self.state.best_model_checkpoint, strict=False)
             self._issue_warnings_after_load(load_result)
         else:
             logger.warning(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Loading the best model at the end of training with `--load_best_model_at_end` fails with the current version of Habana DeepSpeed (0.6.1, see https://github.com/huggingface/transformers/issues/17114).
This PR brings a temporary workaround where the best model at the end of training is loaded as a regular PyTorch model and not as a DeepSpeed engine. This should not be an issue since the best model is loaded for inference only and ZeRO-3 has not been validated yet (see [here](https://docs.habana.ai/en/v1.6.0/PyTorch/DeepSpeed/DeepSpeed_User_Guide.html#deepspeed-validated-configurations)) while ZeRO-1/2 are useful for training only.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
