### PR TITLE
Reorder regression tests

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -388,12 +388,6 @@ class DeepspeedCausalLanguageModelingExampleTester(
     TASK_NAME = "wikitext"
 
 
-class MultiCardSummarizationExampleTester(
-    ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization", multi_card=True
-):
-    TASK_NAME = "cnn_dailymail"
-
-
 class ImageClassificationExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_image_classification"
 ):
@@ -410,3 +404,9 @@ class MultiCardMaskedLanguageModelingExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_mlm", multi_card=True
 ):
     TASK_NAME = "wikitext"
+
+
+class MultiCardSummarizationExampleTester(
+    ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization", multi_card=True
+):
+    TASK_NAME = "cnn_dailymail"


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR reorder regression tests so that the multi-card summarization test with T5 is placed at the end. This may help when running CI on AWS instances because this test sometimes silently fails (only on AWS instances) and the reason is still unclear.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
