### PR TITLE
Replace always() in CI workflows

### DIFF
--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -71,7 +71,7 @@ jobs:
             /bin/bash tests/ci/example_diff_tests.sh
   deepspeed:
     name: Test DeepSpeed models
-    if: ${{ always() }}
+    if: ${{ !cancelled() && (success() || failure()) }}
     needs:
       - start-runner
       - example-diff  # run the job when the previous test job is done
@@ -99,7 +99,7 @@ jobs:
             /bin/bash tests/ci/slow_tests_deepspeed.sh
   multi-card:
     name: Test multi-card models
-    if: ${{ always() }}
+    if: ${{ !cancelled() && (success() || failure()) }}
     needs:
       - start-runner
       - example-diff
@@ -128,7 +128,7 @@ jobs:
             /bin/bash tests/ci/slow_tests_8x.sh
   single-card:
     name: Test single-card models
-    if: ${{ always() }}
+    if: ${{ !cancelled() && (success() || failure()) }}
     needs:
       - start-runner
       - example-diff
@@ -158,7 +158,7 @@ jobs:
             /bin/bash tests/ci/slow_tests_1x.sh
   albert-xxl-single-card:
     name: Test single-card ALBERT XXL
-    if: ${{ always() }}
+    if: ${{ !cancelled() && (success() || failure()) }}
     needs:
       - start-runner
       - example-diff


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

CI workflows' jobs currently use `if: ${{ always() }}` so that all jobs are always executed (even if previous jobs failed). However, with this conditional statement, jobs are not cancellable (see [here](https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run)). This is annoying when the self-hosted runner cannot be found (for example because it could not be created when no DL1 instance is available on AWS) because in that case the job can spend days looking for the runner (see [here](https://stackoverflow.com/questions/70959954/error-waiting-for-a-runner-to-pick-up-this-job-using-github-actions)) while it can not be manually cancelled. This issue has been discussed [here](https://github.com/orgs/community/discussions/26303), [here](https://github.com/actions/runner/issues/1846) and [here](https://github.com/orgs/community/discussions/25789).

The suggested workaround is to use the [status check functions](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions) `success`, `failure` and `cancelled`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
