### PR TITLE
Fix gradient checkpointing for BERT/RoBERTa/ALBERT

### DIFF
--- a/docs/source/tutorials/pretraining.mdx
+++ b/docs/source/tutorials/pretraining.mdx
@@ -28,12 +28,6 @@ model = AutoModelForXXX.from_config(config)
 ```
 with XXX the task to perform, such as `ImageClassification` for example.
 
-<Tip warning={true}>
-
-For some models, you may need to specify `ddp_find_unused_parameters=True` in your training arguments to perform pretraining.
-
-</Tip>
-
 The following is a working example where BERT is pretrained for masked language modeling:
 ```python
 from datasets import load_dataset

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -158,7 +158,6 @@ python ../gaudi_spawn.py \
     --use_habana \
     --use_lazy_mode \
     --gaudi_config_name Habana/roberta-base \
-    --ddp_find_unused_parameters \
     --throughput_warmup_steps 2
 ```
 

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -42,7 +42,6 @@ from transformers import (
     AutoTokenizer,
     DataCollatorForLanguageModeling,
     HfArgumentParser,
-    is_torch_tpu_available,
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint
@@ -552,10 +551,8 @@ def main():
         eval_dataset=eval_dataset if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
-        compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
-        preprocess_logits_for_metrics=preprocess_logits_for_metrics
-        if training_args.do_eval and not is_torch_tpu_available()
-        else None,
+        compute_metrics=compute_metrics if training_args.do_eval else None,
+        preprocess_logits_for_metrics=preprocess_logits_for_metrics if training_args.do_eval else None,
     )
 
     # Training

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -132,7 +132,7 @@ class DataTrainingArguments:
         metadata={
             "help": (
                 "Whether to pad all samples to `max_seq_length`. If False, will pad the samples dynamically when"
-                " batching to the maximum length in the batch (which can be faster on GPU but will be slower on TPU)."
+                " batching to the maximum length in the batch (which can be faster on GPU but will be slower on HPU)."
             )
         },
     )

--- a/examples/question-answering/trainer_qa.py
+++ b/examples/question-answering/trainer_qa.py
@@ -61,10 +61,6 @@ class QuestionAnsweringTrainer(GaudiTrainer):
         else:
             metrics = {}
 
-        if self.args.tpu_metrics_debug or self.args.debug:
-            # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
-            xm.master_print(met.metrics_report())
-
         self.control = self.callback_handler.on_evaluate(self.args, self.state, self.control, metrics)
         return metrics
 

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -279,7 +279,14 @@ class GaudiTrainer(Trainer):
         if self.args.local_rank != -1:
             kwargs = {}
 
-            kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+            if self.args.ddp_find_unused_parameters is not None:
+                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+            elif isinstance(model, PreTrainedModel):
+                # find_unused_parameters breaks checkpointing as per
+                # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
+                kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
+            else:
+                kwargs["find_unused_parameters"] = True
             kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 
             if self.args.use_habana:
@@ -357,6 +364,9 @@ class GaudiTrainer(Trainer):
 
         if resume_from_checkpoint is not None:
             self._load_from_checkpoint(resume_from_checkpoint)
+
+        # Make sure weights are tied in PyTorch
+        self.model.tie_weights()
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -108,16 +108,6 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": "Filter nan and inf losses for logging."},
     )
 
-    ddp_find_unused_parameters: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": (
-                "When using distributed training, the value of the flag `find_unused_parameters` passed to "
-                "`DistributedDataParallel`."
-            )
-        },
-    )
-
     ddp_bucket_cap_mb: Optional[int] = field(
         default=230,
         metadata={

--- a/tests/baselines/roberta_base.json
+++ b/tests/baselines/roberta_base.json
@@ -33,8 +33,7 @@
                 "perplexity": 3.4785,
                 "train_runtime": 61.6658,
                 "extra_arguments": [
-                    "--dataset_config_name wikitext-2-raw-v1",
-                    "--ddp_find_unused_parameters"
+                    "--dataset_config_name wikitext-2-raw-v1"
                 ]
             }
         }

--- a/tests/baselines/roberta_large.json
+++ b/tests/baselines/roberta_large.json
@@ -33,8 +33,7 @@
                 "perplexity": 2.7612,
                 "train_runtime": 128.3589,
                 "extra_arguments": [
-                    "--dataset_config_name wikitext-2-raw-v1",
-                    "--ddp_find_unused_parameters"
+                    "--dataset_config_name wikitext-2-raw-v1"
                 ]
             }
         }


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds `model_tie_weights()` in the `__init__` method of the `GaudiTrainer` class so that there is no unused parameters in BERT/RoBERTa/ALBERT. `ddp_find_unused_parameters` had to be used before and it was not compatible with gradient checkpointing.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
