### PR TITLE
Do not use DDP find_unused_parameters unless explicitly required

### DIFF
--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -282,8 +282,8 @@ class GaudiTrainer(Trainer):
             kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
             if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
                 logger.warning(
-                    "ddp_find_unused_parameters and gradient_checkpointing are both True,"
-                    "which may lead to an error: https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
+                    "ddp_find_unused_parameters and gradient_checkpointing are both True,which may lead to an error:"
+                    " https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
                 )
             kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -279,14 +279,12 @@ class GaudiTrainer(Trainer):
         if self.args.local_rank != -1:
             kwargs = {}
 
-            if self.args.ddp_find_unused_parameters is not None:
-                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
-            elif isinstance(model, PreTrainedModel):
-                # find_unused_parameters breaks checkpointing as per
-                # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
-                kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
-            else:
-                kwargs["find_unused_parameters"] = True
+            kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+            if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
+                logger.warning(
+                    "ddp_find_unused_parameters and gradient_checkpointing are both True,"
+                    "wich may lead to an error: https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
+                )
             kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 
             if self.args.use_habana:

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -282,7 +282,7 @@ class GaudiTrainer(Trainer):
             kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
             if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
                 logger.warning(
-                    "ddp_find_unused_parameters and gradient_checkpointing are both True,which may lead to an error:"
+                    "ddp_find_unused_parameters and gradient_checkpointing are both True, which may lead to an error:"
                     " https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
                 )
             kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb

--- a/optimum/habana/trainer.py
+++ b/optimum/habana/trainer.py
@@ -283,7 +283,7 @@ class GaudiTrainer(Trainer):
             if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
                 logger.warning(
                     "ddp_find_unused_parameters and gradient_checkpointing are both True,"
-                    "wich may lead to an error: https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
+                    "which may lead to an error: https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
                 )
             kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 

--- a/optimum/habana/training_args.py
+++ b/optimum/habana/training_args.py
@@ -118,6 +118,16 @@ class GaudiTrainingArguments(TrainingArguments):
         },
     )
 
+    ddp_find_unused_parameters: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "When using distributed training, the value of the flag `find_unused_parameters` passed to "
+                "`DistributedDataParallel`."
+            )
+        },
+    )
+
     def __post_init__(self):
         if (self.use_lazy_mode or self.gaudi_config_name) and not self.use_habana:
             raise ValueError("--use_lazy_mode and --gaudi_config_name cannot be used without --use_habana")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR enables to set `ddp_find_unused_parameters` to `False` by default and set it to `True` in the `GaudiTrainer` only when the argument is explicitly passed with this value.

This was already done that way before https://github.com/huggingface/optimum-habana/pull/118, and we revert back to it because DDP's `find_unused_parameters` makes runs slower and it should not be necessary for models from the Transformers library.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
