### PR TITLE
Fix CI schedule for ALBERT XXL 1x

### DIFF
--- a/.github/workflows/slow_tests.yml
+++ b/.github/workflows/slow_tests.yml
@@ -170,14 +170,14 @@ jobs:
       AWS_REGION: us-west-2
     steps:
       - name: Checkout
-        if: github.event.schedule == '0 23 * * 6'
+        if: github.event.schedule == '0 21 * * 6'
         uses: actions/checkout@v2
       - name: Pull image
-        if: github.event.schedule == '0 23 * * 6'
+        if: github.event.schedule == '0 21 * * 6'
         run: |
             docker pull vault.habana.ai/gaudi-docker/1.6.1/ubuntu20.04/habanalabs/pytorch-installer-1.12.0:latest
       - name: Run test
-        if: github.event.schedule == '0 23 * * 6'
+        if: github.event.schedule == '0 21 * * 6'
         run: |
             docker run \
             -v $PWD:/root/workspace \
@@ -191,7 +191,7 @@ jobs:
             vault.habana.ai/gaudi-docker/1.6.1/ubuntu20.04/habanalabs/pytorch-installer-1.12.0:latest \
             /bin/bash tests/ci/albert_xxl_1x.sh
       - name: Warning
-        if: github.event.schedule != '0 23 * * 6'
+        if: github.event.schedule != '0 21 * * 6'
         run: echo "ALBERT XXL 1x is only tested on Saturdays."
   stop-runner:
     name: Stop self-hosted EC2 runner


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The starting time of daily regression tests was changed in #120 but the ALBERT XXL 1x test is still triggered when the previous schedule is different. This PR fixes it.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
