### PR TITLE
Add additional message when a regression test fails in CI

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -38,12 +38,12 @@ jobs:
       run: |
         source venv/bin/activate
         pip install --upgrade pip
-        pip install black isort ruff
+        pip install black ruff
     - name: Check style with black
       run: |
         source venv/bin/activate
         black --check .
-    - name: Check style with isort
+    - name: Check style with ruff
       run: |
         source venv/bin/activate
         ruff .

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ TESTS_REQUIRE = [
 
 QUALITY_REQUIRES = [
     "black",
-    "isort",
     "ruff",
     "hf_doc_builder @ git+https://github.com/huggingface/doc-builder.git",
 ]


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR enables to display all the measured and reference metrics when one regression test fails in CI. This is useful because if one test fails, then the following regression tests will not be performed and not all regressing metrics will be displayed.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
