### PR TITLE
Set the env variable USE_DEEPSPEED_HPU to "true" in deepspeed.py

### DIFF
--- a/optimum/habana/transformers/deepspeed.py
+++ b/optimum/habana/transformers/deepspeed.py
@@ -14,7 +14,7 @@
 """
 Integration with Deepspeed
 """
-
+import os
 from copy import deepcopy
 from dataclasses import make_dataclass
 
@@ -136,6 +136,10 @@ def deepspeed_init(trainer, num_training_steps, resume_from_checkpoint=None, inf
 
     HabanaArgs = make_dataclass("HabanaArgs", [("use_hpu", bool), ("no_cuda", bool)])
     habana_args = HabanaArgs(use_hpu=args.use_habana, no_cuda=args.no_cuda)
+    if args.use_habana:
+        # This env variable is initialized here to make sure it is set to "true"
+        # It should be done by the launcher but it does not work for multi-node runs
+        os.environ["DEEPSPEED_USE_HPU"] = "true"
 
     kwargs = dict(
         args=habana_args,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The env variable `USE_DEEPSPEED_HPU` is set to `"true"` Habana's DeepSpeed launcher but it does not work for multi-node runs. This PR fixes this behaviour.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
