### PR TITLE
Remove O1/O2 in Gaudi config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ where `gaudi_config_name` is the name of a model from the [Hub](https://huggingf
 ```json
 {
   "use_habana_mixed_precision": true,
-  "hmp_opt_level": "O1",
   "hmp_is_verbose": false,
   "use_fused_adam": true,
   "use_fused_clip_norm": true,

--- a/docs/source/package_reference/gaudi_config.mdx
+++ b/docs/source/package_reference/gaudi_config.mdx
@@ -22,7 +22,6 @@ You can specify which features to use in a Gaudi configuration, which will take 
 ```JSON
 {
   "use_habana_mixed_precision": true/false,
-  "hmp_opt_level": "O1"/"O2",
   "hmp_is_verbose": true/false,
   "use_fused_adam": true/false,
   "use_fused_clip_norm": true/false,
@@ -39,9 +38,6 @@ You can specify which features to use in a Gaudi configuration, which will take 
 
 Here is a description of each configuration parameter:
 - `use_habana_mixed_precision` enables to decide whether or not Habana Mixed Precision (HMP) should be used. HMP allows to mix *fp32* and *bf16* operations. You can find more information [here](https://docs.habana.ai/en/latest/PyTorch/PyTorch_Mixed_Precision/PT_Mixed_Precision.html).
-- `hmp_opt_level` enables to specify the optimization level to use for HMP such as:
-  - `"O1"`, which is the default and recommended mode of operation,
-  - `"O2"`, which can be used for debugging convergence issues as well as for initial iterations of converting a new model to run with mixed precision.
 - `hmp_is_verbose` enables to decide whether to log precision decisions for each operation for debugging purposes. It is disabled by default. You can find an example of such log [here](https://docs.habana.ai/en/latest/PyTorch/PyTorch_Mixed_Precision/PT_Mixed_Precision.html#hmp-logs).
 - `use_fused_adam` enables to decide whether to use the [custom fused implementation of the ADAM optimizer provided by Habana](https://docs.habana.ai/en/latest/PyTorch/Model_Optimization_PyTorch/Custom_Ops_PyTorch.html#custom-optimizers).
 - `use_fused_clip_norm` enables to decide whether to use the [custom fused implementation of gradient norm clipping provided by Habana](https://docs.habana.ai/en/latest/PyTorch/Model_Optimization_PyTorch/Custom_Ops_PyTorch.html#other-custom-ops).
@@ -50,7 +46,7 @@ Here is a description of each configuration parameter:
 
 <Tip warning={true}>
 
-`hmp_opt_level`, `hmp_is_verbose`, `hmp_bf16_ops` and `hmp_fp32_ops` will not be used if `use_habana_mixed_precision` is false.
+`hmp_is_verbose`, `hmp_bf16_ops` and `hmp_fp32_ops` will not be used if `use_habana_mixed_precision` is false.
 
 </Tip>
 
@@ -59,7 +55,6 @@ You can find examples of Gaudi configurations in the [Habana model repository on
 ```JSON
 {
   "use_habana_mixed_precision": true,
-  "hmp_opt_level": "O1",
   "hmp_is_verbose": false,
   "use_fused_adam": true,
   "use_fused_clip_norm": true,

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -53,7 +53,6 @@ where `gaudi_config_name` is the name of a model from the [Hub](https://huggingf
 ```json
 {
   "use_habana_mixed_precision": true,
-  "hmp_opt_level": "O1",
   "hmp_is_verbose": false,
   "use_fused_adam": true,
   "use_fused_clip_norm": true,

--- a/docs/source/usage_guides/accelerate_training.mdx
+++ b/docs/source/usage_guides/accelerate_training.mdx
@@ -57,7 +57,7 @@ Please refer to the [list of supported PyTorch operators](https://docs.habana.ai
 
 </Tip>
 
-To apply HMP, you must set `"use_habana_mixed_precision"` to `true` and `"hmp_opt_level"` to `"O1"` in the Gaudi configuration file.
+To apply HMP, you must set `"use_habana_mixed_precision"` to `true` in the Gaudi configuration file.
 Then, you can specify which operators to compute in *bf16* with `"hmp_bf16_ops"` and which operators to compute in *fp32* with `"hmp_fp32_ops"`.
 If these operators are not specified, their default values are set to be the ones written in the [Gaudi configuration file of BERT](https://huggingface.co/Habana/bert-large-uncased-whole-word-masking/blob/main/gaudi_config.json), which is a good starting point for applying HMP:
 ```

--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -150,7 +150,6 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
                             hmp_fp32_file.name,
                         )
                         self.hmp.convert(
-                            opt_level=self.gaudi_config.hmp_opt_level,
                             bf16_file_path=hmp_bf16_file.name,
                             fp32_file_path=hmp_fp32_file.name,
                             isVerbose=self.gaudi_config.hmp_is_verbose,

--- a/optimum/habana/transformers/gaudi_configuration.py
+++ b/optimum/habana/transformers/gaudi_configuration.py
@@ -52,7 +52,6 @@ class GaudiConfig(BaseConfig):
     def __init__(self, **kwargs):
         # Habana Mixed Precision (MHP) configuration
         self.use_habana_mixed_precision = kwargs.pop("use_habana_mixed_precision", False)
-        self.hmp_opt_level = kwargs.pop("hmp_opt_level", "O1")
         self.hmp_bf16_ops = kwargs.pop("hmp_bf16_ops", DEFAULT_BF16_OPS)
         self.hmp_fp32_ops = kwargs.pop("hmp_fp32_ops", DEFAULT_FP32_OPS)
         self.hmp_is_verbose = kwargs.pop("hmp_is_verbose", False)

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -179,7 +179,6 @@ class GaudiTrainer(Trainer):
                             hmp_fp32_file.name,
                         )
                         self.hmp.convert(
-                            opt_level=self.gaudi_config.hmp_opt_level,
                             bf16_file_path=hmp_bf16_file.name,
                             fp32_file_path=hmp_fp32_file.name,
                             isVerbose=self.gaudi_config.hmp_is_verbose,

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -15,7 +15,7 @@
 
 import random
 import time
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import numpy as np
 import torch
@@ -138,67 +138,3 @@ def set_seed(seed: int):
     if is_torch_available():
         torch.manual_seed(seed)
         hpu_random.manual_seed_all(seed)
-
-
-def input_shape_hash(inputs: Dict[str, Union[torch.Tensor, Any]]) -> int:
-    """
-    Returns a hash based on the shapes of the inputs.
-    For instance, two different tensors of same shape will return the same hash.
-    This is used for HPU graphs to know whether capturing the graph for the current input or not.
-
-    Args:
-        inputs (Dict[str, Union[torch.Tensor, Any]]): the inputs of the model
-
-    Returns:
-        int: hash of the inputs
-    """
-
-    if isinstance(inputs, dict):
-        # Dictionaries are not hashable so turning them into tuples
-        return input_shape_hash(tuple(inputs.items()))
-    elif isinstance(inputs, list) or isinstance(inputs, tuple):
-        # Get the hash of the tuple
-        return hash(tuple(input_shape_hash(el) for el in inputs))
-    elif torch.is_tensor(inputs):
-        # Get the hash of the tensor shape
-        return hash(inputs.shape)
-    else:
-        # Get the hash of the inputs
-        return hash(inputs)
-
-
-def copy_to(dst, src):
-    """
-    Copies the dat from the source object to the target object.
-
-    Args:
-        dst: target
-        src: source
-    """
-    if type(dst) != type(src):
-        raise TypeError(
-            f"dst and src should have the same type, but dst is a {type(dst)} whereas src is a {type(src)}."
-        )
-
-    if isinstance(dst, dict):
-        for (dst_key, dst_value), (src_key, src_value) in zip(dst.items(), src.items()):
-            if dst_key == src_key:
-                copy_to(dst_value, src_value)
-            else:
-                raise ValueError(f"dst_key and src_key should be equal but got {dst_key} and {src_key}.")
-    elif isinstance(dst, list) or isinstance(dst, tuple):
-        for d, s in zip(dst, src):
-            copy_to(d, s)
-    elif torch.is_tensor(dst):
-        dst.copy_(src, non_blocking=True)
-
-
-class CachedParams:
-    """
-    Manages cached inputs, outputs and graph for HPU graphs.
-    """
-
-    def __init__(self, graph_inputs, graph_outputs, graph):
-        self.graph_inputs = graph_inputs
-        self.graph_outputs = graph_outputs
-        self.graph = graph

--- a/tests/configs/gaudi_config_trainer_test.json
+++ b/tests/configs/gaudi_config_trainer_test.json
@@ -1,6 +1,5 @@
 {
     "use_habana_mixed_precision": false,
-    "hmp_opt_level": "O1",
     "hmp_is_verbose": false,
     "use_fused_adam": true,
     "use_fused_clip_norm": true,

--- a/tests/test_gaudi_configuration.py
+++ b/tests/test_gaudi_configuration.py
@@ -22,7 +22,6 @@ from typing import List
 from optimum.habana import GaudiConfig
 
 
-OPT_LEVELS = ["O1", "O2"]
 BF16_OPS_REFERENCE_FILE = Path(__file__).parent.resolve() / Path("configs/bf16_ops.txt")
 FP32_OPS_REFERENCE_FILE = Path(__file__).parent.resolve() / Path("configs/fp32_ops.txt")
 
@@ -58,8 +57,6 @@ class GaudiConfigTester(unittest.TestCase):
 
         self.assertTrue(is_list_of_strings(gaudi_config.hmp_bf16_ops))
         self.assertTrue(is_list_of_strings(gaudi_config.hmp_fp32_ops))
-
-        self.assertIn(gaudi_config.hmp_opt_level, OPT_LEVELS)
 
     def test_write_bf16_fp32_ops_to_text_files(self):
         gaudi_config = GaudiConfig()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Removes `hmp_opt_level` in `GaudiConfig` as it is now recommended to not use it anymore.
Also removes `input_shape_hash`, `copy_to` and `CachedParams` in `utils.py` since those are now defined in `habana_frameworks.torch.hpu.graphs`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
