### PR TITLE
Adding dataloader_num_workers into example command for better performance

### DIFF
--- a/examples/image-classification/README.md
+++ b/examples/image-classification/README.md
@@ -47,6 +47,7 @@ python run_image_classification.py \
     --use_hpu_graphs \
     --gaudi_config_name Habana/vit \
     --throughput_warmup_steps 2
+    --dataloader_num_workers 1
 ```
 
 For Swin, you need to change/add the following arguments:
@@ -94,6 +95,7 @@ python run_image_classification.py \
     --use_hpu_graphs \
     --gaudi_config_name Habana/vit \
     --throughput_warmup_steps 2
+    --dataloader_num_workers 1
 ```
 
 Internally, the script will use the [`ImageFolder`](https://huggingface.co/docs/datasets/v2.0.0/en/image_process#imagefolder) feature which will automatically turn the folders into 🤗 Dataset objects.
@@ -194,6 +196,7 @@ python ../gaudi_spawn.py \
     --use_hpu_graphs \
     --gaudi_config_name Habana/vit \
     --throughput_warmup_steps 2
+    --dataloader_num_workers 1
 ```
 
 For Swin, you need to change/add the following arguments:
@@ -232,6 +235,7 @@ python ../gaudi_spawn.py \
     --gaudi_config_name Habana/vit \
     --throughput_warmup_steps 2 \
     --deepspeed path_to_my_deepspeed_config
+    --dataloader_num_workers 1
 ```
 
 You can look at the [documentation](https://huggingface.co/docs/optimum/habana/usage_guides/deepspeed) for more information about how to use DeepSpeed in Optimum Habana.

--- a/tests/baselines/swin_base_patch4_window7_224_in22k.json
+++ b/tests/baselines/swin_base_patch4_window7_224_in22k.json
@@ -12,7 +12,8 @@
                 "extra_arguments": [
                     "--remove_unused_columns False",
                     "--seed 1337",
-                    "--ignore_mismatched_sizes"
+                    "--ignore_mismatched_sizes",
+                    "--dataloader_num_workers 1"
                 ]
             },
             "multi_card": {
@@ -24,7 +25,8 @@
                 "extra_arguments": [
                     "--remove_unused_columns False",
                     "--seed 1337",
-                    "--ignore_mismatched_sizes"
+                    "--ignore_mismatched_sizes",
+                    "--dataloader_num_workers 1"
                 ]
             }
         }

--- a/tests/baselines/vit_base_patch16_224_in21k.json
+++ b/tests/baselines/vit_base_patch16_224_in21k.json
@@ -11,7 +11,8 @@
                 "train_samples_per_second": 288.202,
                 "extra_arguments": [
                     "--remove_unused_columns False",
-                    "--seed 1337"
+                    "--seed 1337",
+                    "--dataloader_num_workers 1"
                 ]
             },
             "multi_card": {
@@ -22,7 +23,8 @@
                 "train_samples_per_second": 1680.255,
                 "extra_arguments": [
                     "--remove_unused_columns False",
-                    "--seed 1337"
+                    "--seed 1337",
+                    "--dataloader_num_workers 1"
                 ]
             }
         }


### PR DESCRIPTION
# What does this PR do?

Add dataloader_num_workers  into example command line for ViT and Swin for better performance
here is the perfomrance data of ViT I measured in my local machine .

- Gaudi2

| dataloader_num_workers | 8X  |  1X  |
|--|--|--|
|0 (default)| 2040 | 508 |
|1| 3954| 797|
|2| 3894| 870|
|4| 3896| 985|
|8| 3831| 948|

-Gaudi
| dataloader_num_workers | 8X  |  1X  |
|--|--|--|
|0 (default) | 1605| 315|
|1| 2008| 316|
|2| 2030| 318|
|4| 1979| 332|
|8| 1911| 316|

```bash
python run_image_classification.py --model_name_or_path google/vit-base-patch16-224-in21k --dataset_name cifar10 --output_dir /tmp/outputs/  --remove_unused_columns False --do_train  --learning_rate 3e-5 --num_train_epochs 1 --per_device_train_batch_size 64 --evaluation_strategy no --save_strategy no --load_best_model_at_end no --save_total_limit 3 --seed 1337 --use_habana --use_lazy_mode --use_hpu_graphs --throughput_warmup_steps 2 --overwrite_output_dir --logging_steps 20 --gaudi_config_name Habana/vit --dataloader_num_workers xxx
```

If adding the `--dataloader_num_workers` in the  example command, user could have better performance by default. 
From the performance data I measured, we could see adding `dataloader_num_workers` not hurt performance of Gaudi but improved ~2x on Gaudi2.

profile of time cost of dataloader(Gaudi2)
berfore: 90ms
  
![image](https://user-images.githubusercontent.com/80079571/228136849-1d4533da-c214-4db0-aef2-c582671f33d6.png)

after set the `dataloader_num_workers`: 5.2ms

![image](https://user-images.githubusercontent.com/80079571/228137025-19b7f5e9-3a5e-46a4-a52d-bf4c074e462a.png)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
