### PR TITLE
add mark_step between fwd and bwd for better performance

### DIFF
--- a/docs/source/usage_guides/accelerate_training.mdx
+++ b/docs/source/usage_guides/accelerate_training.mdx
@@ -92,6 +92,28 @@ If these operators are not specified, their default values are set to be the one
 ]
 ```
 
+## Pipelining forward and backward passes
+
+There are two stages when running models on Habana HPU: python code interpretation on CPU and HPU recipe computation. The HPU computation stage can be triggered manually or when a copy to the CPU is requested, and generally HPU computation is triggered after `loss.backward()` to make the CPU code interpretation and HPU recipe computation overlap as shown in the following illustration:
+
+```
+CPU:...forward + backward   ...optimizer  ...forward + backward   ...optimizer  ...
+HPU:........................forward + backward...optimizer......forward + backward...optimizer
+```
+
+However, when CPU code interpretation takes longer than HPU computation, it becomes the bottleneck and HPU computation can not be triggered until CPU code interpretation is done. So one potential optimization for such cases is to trigger the HPU *forward* computation right after the CPU *forward* interpretation and before the CPU *backward* interpretation. You can see an example below where the CPU *backward* interpretation overlaps with the HPU *forward* computation:
+
+```
+CPU:...forward   ...backward   ...optimizer  ...forward   ...backward   ...optimizer   ...
+HPU:.............forward.......backward......optimizer......forward.....backward.......optimizer
+```
+
+To enable this optimization,you can set the following training argument `--pipelining_fwd_bwd True`.
+
+### Recommendations
+
+- When training models on Habana Gaudi2, we suggest to enable this feature because Gaudi2 is faster than Gaudi1.
+- When training models that require large device memory, we suggest to disable this optimization because it will increase the HPU memory usage.
 
 ## Custom Operators
 

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -142,6 +142,16 @@ class GaudiTrainingArguments(TrainingArguments):
         },
     )
 
+    pipelining_fwd_bwd: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to add an additional mark_step between forward and backward for pipelining "
+                "host BWD building and HPU FWD computing."
+            )
+        },
+    )
+
     def __post_init__(self):
         if (self.use_lazy_mode or self.use_hpu_graphs or self.gaudi_config_name) and not self.use_habana:
             raise ValueError(

--- a/tests/baselines/swin_base_patch4_window7_224_in22k.json
+++ b/tests/baselines/swin_base_patch4_window7_224_in22k.json
@@ -13,7 +13,8 @@
                     "--remove_unused_columns False",
                     "--seed 1337",
                     "--ignore_mismatched_sizes",
-                    "--dataloader_num_workers 1"
+                    "--dataloader_num_workers 1",
+                    "--pipelining_fwd_bwd True"
                 ]
             },
             "multi_card": {
@@ -26,7 +27,8 @@
                     "--remove_unused_columns False",
                     "--seed 1337",
                     "--ignore_mismatched_sizes",
-                    "--dataloader_num_workers 1"
+                    "--dataloader_num_workers 1",
+                    "--pipelining_fwd_bwd True"
                 ]
             }
         }

--- a/tests/baselines/vit_base_patch16_224_in21k.json
+++ b/tests/baselines/vit_base_patch16_224_in21k.json
@@ -12,7 +12,8 @@
                 "extra_arguments": [
                     "--remove_unused_columns False",
                     "--seed 1337",
-                    "--dataloader_num_workers 1"
+                    "--dataloader_num_workers 1",
+                    "--pipelining_fwd_bwd True"
                 ]
             },
             "multi_card": {
@@ -24,7 +25,8 @@
                 "extra_arguments": [
                     "--remove_unused_columns False",
                     "--seed 1337",
-                    "--dataloader_num_workers 1"
+                    "--dataloader_num_workers 1",
+                    "--pipelining_fwd_bwd True"
                 ]
             }
         }


### PR DESCRIPTION
# What does this PR do?

improve Habana HPU performance by adding a new command line args `pipelining_fwd_bwd ` .

when running model on Habana HPU, it is very important to pipelining host graph building and device computing, this PR is to add an additional mark_step between `forward` and `backward` in `training_step` to pipeline the host graph building of backward and device computing of forward. 

profile is bellow:

disable `pipelining_fwd_bwd `
device fwd is after host bwd
![image](https://user-images.githubusercontent.com/80079571/228280823-a857df48-d89f-45bc-aa09-3b62f0dc59e8.png)


enable `pipelining_fwd_bwd `
host bwd and device fwd is pipelined
![image](https://user-images.githubusercontent.com/80079571/228279819-c3b54983-7ccf-4cab-9da5-aa85beb7b660.png)

the final time cost saving is the `cost of host bwd building graph`

here is the performance measured on my local Gaudi2 and Gaudi machine

-gaudi2

| pipelining_fwd_bwd        | 8x        | 1x        |
|                                        -|           -|           -|
|   True                               |     4849                   |             834     |
|   False                              |      3954                 |                  784|

-gaudi

| pipelining_fwd_bwd        | 8x        | 1x        |
|                                        -|           -|           -|
|   False|     2008|        316|
|   True|      2238|                  342|

On Gaudi2 8X performance improved from 3900 to 4800 but on Gaudi there is only 200 improved, the reason is the computing on Gaudi2 is faster than Gaudi(~3X-4X), and the device time cost of Gaudi2 is less than Gaudi, so when pipelining device fwd and host bwd, there is more benefits on Gaudi2.

test command:
```bash
# enable mark_step between fwd and bwd

# 8x
python ../gaudi_spawn.py     --world_size 8 --use_mpi run_image_classification.py     --model_name_ or_path google/vit-base-patch16-224-in21k --dataset_name cifar10     --output_dir /tmp/outputs/  --remove_unused_columns False     --do_train       --num_train_epochs 5     --per_device_train_batch_size 64     - -evaluation_strategy no     - -save_strategy no --load_best_model_at_end False     --save_total_limit 3 --seed 1337     --use_habana     --use_lazy_mode     --use_hpu_graphs     --gaudi_config_name Habana/vit --throughput_warmup_steps 2 --logging_steps 20 --dataloader_num_workers 1 --learning_rate 3.3e-4  --overwrite_output_dir --pipelining_fwd_bwd True

# 1x
python run_image_classification.py --model_name_or_path google/vit-base-patch16-224-in21k --dataset_name cifar10 --output_dir /tmp/outputs/  --remove_unused_columns False --do_train  --learning_rate 3e-5 --num_train_epochs 1 --per_device_train_batch_size 64 --evaluation_strategy no --save_strategy no --load_best_model_at_end no --save_total_limit 3 --seed 1337 --use_habana --use_lazy_mode --use_hpu_graphs --throughput_warmup_steps 2 --overwrite_output_dir --logging_steps 20 --gaudi_config_name Habana/vit --dataloader_num_workers 1 --pipelining_fwd_bwd True

# disable mark_step between fwd and bwd(default)

# 8x
python ../gaudi_spawn.py     --world_size 8 --use_mpi run_image_classification.py     --model_name_ or_path google/vit-base-patch16-224-in21k --dataset_name cifar10     --output_dir /tmp/outputs/  --remove_unused_columns False     --do_train       --num_train_epochs 5     --per_device_train_batch_size 64     - -evaluation_strategy no     - -save_strategy no --load_best_model_at_end False     --save_total_limit 3 --seed 1337     --use_habana     --use_lazy_mode     --use_hpu_graphs     --gaudi_config_name Habana/vit --throughput_warmup_steps 2 --logging_steps 20 --dataloader_num_workers 1 --learning_rate 3.3e-4  --overwrite_output_dir --pipelining_fwd_bwd False

# 1x
python run_image_classification.py --model_name_or_path google/vit-base-patch16-224-in21k --dataset_name cifar10 --output_dir /tmp/outputs/  --remove_unused_columns False --do_train  --learning_rate 3e-5 --num_train_epochs 1 --per_device_train_batch_size 64 --evaluation_strategy no --save_strategy no --load_best_model_at_end no --save_total_limit 3 --seed 1337 --use_habana --use_lazy_mode --use_hpu_graphs --throughput_warmup_steps 2 --overwrite_output_dir --logging_steps 20 --gaudi_config_name Habana/vit --dataloader_num_workers 1 --pipelining_fwd_bwd False
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
