### PR TITLE
Improve performance and scalability of BERT FT training (old)

### DIFF
--- a/optimum/habana/transformers/fastddp.py
+++ b/optimum/habana/transformers/fastddp.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+    Fast and lightweight alternative of DistributeDataParallel for Habana Gaudi
+"""
+
+import functools
+
+import torch
+import torch.nn
+
+_all_reduce_group_size = torch.distributed.group.WORLD.size()
+
+_fusion_buffer = None
+_fusion_views = []
+
+_fusion_graph = None
+_unfusion_graph = None
+
+
+def FastDistributedDataParallel(model: torch.nn.Module, fusion_buffer_dtype: torch.dtype):
+    global _fusion_buffer
+    global _fusion_views
+    global _fusion_graph
+    global _unfusion_graph
+
+    gradient_elem_count = 0
+    for param in model.parameters():
+        gradient_elem_count += torch.numel(param)
+
+    _fusion_buffer = torch.zeros(size=(gradient_elem_count,), dtype=fusion_buffer_dtype, device='hpu:0')
+    _fusion_views.clear()
+
+    view_start_index = 0
+    for param in model.parameters():
+        view_next_index = view_start_index + torch.numel(param.data)
+        _fusion_views.append(_fusion_buffer[view_start_index:view_next_index].reshape(param.data.shape))
+        view_start_index = view_next_index
+
+    model.all_reduce_gradients = functools.partial(_all_reduce_gradients, model)
+
+    _fusion_graph = None
+    _unfusion_graph = None
+
+    return model
+
+
+def _all_reduce_gradients(model: torch.nn.Module):
+    global _all_reduce_group_size
+    global _fusion_buffer
+    global _fusion_views
+
+    # Fuse all the gradient into the fusion buffer.
+    global _fusion_graph
+    if _fusion_graph is None:
+        import habana_frameworks.torch as ht
+        _fusion_graph = ht.hpu.HPUGraph()
+        s = ht.hpu.Stream()
+        with ht.hpu.stream(s):
+            _fusion_graph.capture_begin()
+
+            for param_index, param in enumerate(model.parameters()):
+                grad = param.grad
+
+                if param.grad is None:
+                    continue
+
+                grad = grad / _all_reduce_group_size
+
+                if grad.dtype != _fusion_buffer.dtype:
+                    grad = grad.to(_fusion_buffer.dtype)
+
+                view = _fusion_views[param_index]
+
+                view.copy_(grad, non_blocking=True)
+
+            _fusion_graph.capture_end()
+
+    _fusion_graph.replay()
+
+    # All-reduce the gradients.
+    torch.distributed.all_reduce(_fusion_buffer, group=torch.distributed.group.WORLD, async_op=True)
+
+    # Unfuse the gradient from the fusion buffer.
+    global _unfusion_graph
+    if _unfusion_graph is None:
+        import habana_frameworks.torch as ht
+        _unfusion_graph = ht.hpu.HPUGraph()
+        s = ht.hpu.Stream()
+        with ht.hpu.stream(s):
+            _unfusion_graph.capture_begin()
+
+            for param_index, param in enumerate(model.parameters()):
+                if param.grad is None:
+                    continue
+
+                view = _fusion_views[param_index]
+
+                if view.dtype != param.grad.dtype:
+                    view = view.to(param.grad.dtype)
+
+                param.grad.copy_(view, non_blocking=True)
+
+            _unfusion_graph.capture_end()
+
+    _unfusion_graph.replay()

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -214,6 +214,11 @@ class GaudiTrainer(Trainer):
             "ignore", message="User provided device_type of 'cuda', but CUDA is not available. Disabling"
         )
 
+        # HPU graphs training optimization, where FW+BWD passes are scheduled on HPU for execution within milliseconds.
+        self._recorded_fwbwd_graph = None
+        self._recorded_fwbwd_inputs = None
+        self._recorded_fwbwd_output = None
+
     def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
         if self.train_dataset is None or not has_length(self.train_dataset):
             return None
@@ -375,25 +380,8 @@ class GaudiTrainer(Trainer):
             return model
 
         if self.args.local_rank != -1:
-            kwargs = {}
-
-            kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
-            if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
-                logger.warning(
-                    "ddp_find_unused_parameters and gradient_checkpointing are both True, which may lead to an error:"
-                    " https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
-                )
-            kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
-
-            if self.args.use_habana:
-                kwargs["gradient_as_bucket_view"] = True
-
-            model = torch.nn.parallel.DistributedDataParallel(
-                model,
-                device_ids=[self.args.local_rank] if self.args._n_gpu != 0 and not self.args.use_habana else None,
-                output_device=self.args.local_rank if self.args._n_gpu != 0 and not self.args.use_habana else None,
-                **kwargs,
-            )
+            from .fastddp import FastDistributedDataParallel
+            model = FastDistributedDataParallel(model, fusion_buffer_dtype=torch.bfloat16)
 
         return model
 
@@ -641,6 +629,10 @@ class GaudiTrainer(Trainer):
                 if self.is_local_process_zero() and not args.disable_tqdm:
                     steps_trained_progress_bar = tqdm(total=steps_trained_in_current_epoch)
                     steps_trained_progress_bar.set_description("Skipping the first batches")
+        elif self.args.world_size > 1:
+            logger.info("As in multi-worker training, broadcasting the initial model from worker:0 to the rest of the collective group.")
+            for param in model.parameters():
+                torch.distributed.broadcast(param.data, src=0)
 
         # Update the references
         self.callback_handler.model = self.model
@@ -671,7 +663,7 @@ class GaudiTrainer(Trainer):
 
         # set_to_none is not implemented for some optimizers
         try:
-            model.zero_grad(set_to_none=True)
+            model.zero_grad(set_to_none=False)
         except TypeError:
             model.zero_grad()
 
@@ -739,16 +731,15 @@ class GaudiTrainer(Trainer):
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                if (
-                    ((step + 1) % args.gradient_accumulation_steps != 0)
-                    and args.local_rank != -1
-                    and args._no_sync_in_gradient_accumulation
-                ):
-                    # Avoid unnecessary DDP synchronization since there will be no backward pass on this example.
-                    with model.no_sync():
-                        tr_loss_step = self.training_step(model, inputs)
-                else:
-                    tr_loss_step = self.training_step(model, inputs)
+                tr_loss_step = self._take_training_step_fwbwd(model, inputs)
+
+                if self.args.world_size > 1:
+                    if (step + 1) % args.gradient_accumulation_steps == 0 or (
+                        # last step in epoch but step is always smaller than gradient_accumulation_steps
+                        steps_in_epoch <= args.gradient_accumulation_steps
+                        and (step + 1) == steps_in_epoch
+                    ):
+                        model.all_reduce_gradients()
 
                 if args.logging_nan_inf_filter and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step)):
                     # if loss is nan or inf simply add the average of previous logged losses
@@ -811,7 +802,7 @@ class GaudiTrainer(Trainer):
 
                     # set_to_none is not implemented for some optimizers
                     try:
-                        model.zero_grad(set_to_none=True)
+                        model.zero_grad(set_to_none=False)
                     except TypeError:
                         model.zero_grad()
 
@@ -890,6 +881,28 @@ class GaudiTrainer(Trainer):
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
 
         return TrainOutput(self.state.global_step, train_loss, metrics)
+
+    def _take_training_step_fwbwd(self, model, inputs):
+        if self._recorded_fwbwd_graph is None:
+            self._recorded_fwbwd_output = torch.zeros(size=(1,), dtype=torch.bfloat16, device='hpu:0')
+
+            self._recorded_fwbwd_inputs = {}
+            for inp_k, inp_v in inputs.items():
+                self._recorded_fwbwd_inputs[inp_k] = torch.zeros(size=inp_v.shape, dtype=inp_v.dtype, device='hpu:0')
+
+            import habana_frameworks.torch as ht
+            self._recorded_fwbwd_graph = ht.hpu.HPUGraph()
+            s = ht.hpu.Stream()
+            with ht.hpu.stream(s):
+                self._recorded_fwbwd_graph.capture_begin()
+                self._recorded_fwbwd_output.copy_(self.training_step(model, self._recorded_fwbwd_inputs), non_blocking=True)
+                self._recorded_fwbwd_graph.capture_end()
+
+        for inp_k, inp_v in inputs.items():
+            self._recorded_fwbwd_inputs[inp_k].copy_(inp_v, non_blocking=True)
+
+        self._recorded_fwbwd_graph.replay()
+        return self._recorded_fwbwd_output
 
     def _load_rng_state(self, checkpoint):
         # Load RNG states from `checkpoint`


### PR DESCRIPTION
# What does this PR do?

I propose an optimization patch which improves the performance of BERT fine-tuning training and scale up factor to over 90%. In this approach, forward and backward passes are recorded using HPU graph mechanism, which gives a solid general boost (both single-worker and multi-worker), as well as invokes a single all-reduce collective operation on fused bfloat16 gradients. The scaling factor for 8 workers in relation to 1 worker is over 90% measured by unbiased throughput.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?