### PR TITLE
Fix GaudiSeq2SeqTrainer

### DIFF
--- a/optimum/habana/transformers/trainer_seq2seq.py
+++ b/optimum/habana/transformers/trainer_seq2seq.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from transformers.trainer_callback import TrainerCallback
     from transformers.trainer_utils import EvalPrediction, PredictionOutput
 
+    from .gaudi_configuration import GaudiConfig
     from .training_args import GaudiTrainingArguments
 
 
@@ -44,6 +45,7 @@ class GaudiSeq2SeqTrainer(GaudiTrainer):
     def __init__(
         self,
         model: Union["PreTrainedModel", torch.nn.Module] = None,
+        gaudi_config: "GaudiConfig" = None,
         args: "GaudiTrainingArguments" = None,
         data_collator: Optional["DataCollator"] = None,
         train_dataset: Optional[Dataset] = None,
@@ -57,6 +59,7 @@ class GaudiSeq2SeqTrainer(GaudiTrainer):
     ):
         super().__init__(
             model=model,
+            gaudi_config=gaudi_config,
             args=args,
             data_collator=data_collator,
             train_dataset=train_dataset,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes an issue introduced in #202  with the `GaudiSeq2SeqTrainer` class. The `gaudi_config` argument in the `__init__` method was missing, which triggered an error if `gaudi_config_name` is `None` in the training arguments.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
