### PR TITLE
Run CI on Transformers' latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,14 @@ slow_tests_deepspeed: test_installs
 	python -m pytest tests/test_examples.py -v -s -k "deepspeed"
 
 slow_tests_diffusers: test_installs
+	python -m pip install git+https://github.com/huggingface/transformers.git
 	python -m pip install git+https://github.com/huggingface/diffusers.git
 	python -m pip install ftfy
 	python -m pytest tests/test_diffusers.py -v -s -k "test_no_"
 
 # Check if examples are up to date with the Transformers library
 example_diff_tests: test_installs
+	python -m pip install git+https://github.com/huggingface/transformers.git
 	python -m pytest tests/test_examples_match_transformers.py
 
 # Utilities to release to PyPi
@@ -101,4 +103,3 @@ clean:
 
 test_installs:
 	python -m pip install .[tests]
-	python -m pip install git+https://github.com/huggingface/transformers.git


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The CI is run on the main branch of Transformers to catch changes/issues introduced in Transformers before they are released. Now that Transformers' Trainer relies on Accelerate (see https://github.com/huggingface/transformers/pull/22752), all regression tests relying on it fail (example [here](https://github.com/huggingface/optimum-habana/actions/runs/4725782013)). As a temporary workaround and till proper support for HPUs is integrated into Accelerate, the CI will be run with the latest release of Transformers from now on.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
