### PR TITLE
Enable asynchronous data copy to get better performance

### DIFF
--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -152,6 +152,11 @@ class GaudiTrainingArguments(TrainingArguments):
         },
     )
 
+    non_blocking_data_copy: Optional[bool] = field(
+        default=False,
+        metadata={"help": ("Whether to enable async data copy when preparing inputs.")},
+    )
+
     def __post_init__(self):
         if (self.use_lazy_mode or self.use_hpu_graphs or self.gaudi_config_name) and not self.use_habana:
             raise ValueError(

--- a/tests/baselines/swin_base_patch4_window7_224_in22k.json
+++ b/tests/baselines/swin_base_patch4_window7_224_in22k.json
@@ -14,7 +14,8 @@
                     "--seed 1337",
                     "--ignore_mismatched_sizes",
                     "--dataloader_num_workers 1",
-                    "--pipelining_fwd_bwd True"
+                    "--pipelining_fwd_bwd True",
+                    "--non_blocking_data_copy True"
                 ]
             },
             "multi_card": {
@@ -28,7 +29,8 @@
                     "--seed 1337",
                     "--ignore_mismatched_sizes",
                     "--dataloader_num_workers 1",
-                    "--pipelining_fwd_bwd True"
+                    "--pipelining_fwd_bwd True",
+                    "--non_blocking_data_copy True"
                 ]
             }
         }

--- a/tests/baselines/vit_base_patch16_224_in21k.json
+++ b/tests/baselines/vit_base_patch16_224_in21k.json
@@ -13,7 +13,8 @@
                     "--remove_unused_columns False",
                     "--seed 1337",
                     "--dataloader_num_workers 1",
-                    "--pipelining_fwd_bwd True"
+                    "--pipelining_fwd_bwd True",
+                    "--non_blocking_data_copy True"
                 ]
             },
             "multi_card": {
@@ -26,7 +27,8 @@
                     "--remove_unused_columns False",
                     "--seed 1337",
                     "--dataloader_num_workers 1",
-                    "--pipelining_fwd_bwd True"
+                    "--pipelining_fwd_bwd True",
+                    "--non_blocking_data_copy True"
                 ]
             }
         }


### PR DESCRIPTION
# What does this PR do?
Improve Habana HPU performance, especially the host side performance by enabling 
asynchronous data copy from host to device with arg `non_blocking_data_copy`.

Before setting `non_blocking_data_copy` to True
![image](https://user-images.githubusercontent.com/94743284/233831885-040808e8-6a29-478d-baf9-e9b7acb127cb.png)

After setting `non_blocking_data_copy` to True
![image](https://user-images.githubusercontent.com/94743284/233831934-b2888517-ba15-4334-9a50-eff6fcc1899c.png)

Here is the overall performance before and after enabling `non_blocking_data_copy` (take Swin as an example):

Gaudi2
| non_blocking_data_copy | 1x | 8x |
|----------|:-------------:|------:|
| True | 374 | 1894 |
| False | 354 | 1857 |

Gaudi
| non_blocking_data_copy | 1x | 8x |
|----------|:-------------:|------:|
| True | 183 | 1060 |
| False | 183 | 1061 |

Both 1x and 8x performance get improvement on Gaudi2 but on Gaudi, none of them get any improvement. The reason is that the device computing on Gaudi2 is faster than Gaudi, when asynchronous data copy is enabled, the host can continue to execute other tasks like graph building, then we can get a better pipelining between the host and the device.  But on Gaudi, the device executing time is much longer which already hides the host time, so this optimization is more appropriate for Gaudi2.

Test command
```
# Single-HPU
python ../gaudi_spawn.py \
    --world_size 8 --use_mpi run_image_classification.py \
    --model_name_or_path microsoft/swin-base-patch4-window7-224-in22k \
    --dataset_name cifar10 \
    --output_dir /tmp/outputs/ \
    --remove_unused_columns False \
    --do_train \
    --learning_rate 2e-4 \
    --num_train_epochs 5 \
    --per_device_train_batch_size 64 \
    --evaluation_strategy no \
    --save_strategy no \
    --load_best_model_at_end False \
    --save_total_limit 3 \
    --seed 1337 \
    --use_habana \
    --use_lazy_mode \
    --use_hpu_graphs \
    --gaudi_config_name Habana/swin \
    --throughput_warmup_steps 2 \
    --ignore_mismatched_sizes True \
    --overwrite_output_dir \
    --dataloader_num_workers 1 \
    --non_blocking_data_copy True
```

```
# Multi-HPU
python run_image_classification.py \
    --model_name_or_path microsoft/swin-base-patch4-window7-224-in22k \
    --dataset_name cifar10 \
    --output_dir /tmp/outputs/ \
    --remove_unused_columns False \
    --do_train \
    --learning_rate 3e-5 \
    --num_train_epochs 1 \
    --per_device_train_batch_size 64 \
    --evaluation_strategy no \
    --save_strategy no \
    --load_best_model_at_end False \
    --save_total_limit 3 \
    --seed 1337 \
    --use_habana \
    --use_lazy_mode \
    --use_hpu_graphs \
    --gaudi_config_name Habana/swin \
    --throughput_warmup_steps 2 \
    --ignore_mismatched_sizes True \
    --overwrite_output_dir \
    --dataloader_num_workers 1 \
    --non_blocking_data_copy True
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

<!--Fixes # (issue)-->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
