### PR TITLE
Add commented blocks in CI for speech recognition

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -444,6 +444,10 @@ class MultiCardAudioClassificationExampleTester(
     TASK_NAME = "common_language"
 
 
+# class SpeechRecognitionExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_speech_recognition_ctc"):
+#     TASK_NAME = "librispeech_asr"
+
+
 # class MultiCardSpeechRecognitionExampleTester(
 #     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_speech_recognition_ctc", multi_card=True
 # ):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,6 +43,7 @@ MODELS_TO_TEST_MAPPING = {
     ],
     "wav2vec2": [
         ("facebook/wav2vec2-base", "Habana/wav2vec2"),
+        # ("facebook/wav2vec2-large-lv60", "Habana/wav2vec2"),
     ],
     "swin": [("microsoft/swin-base-patch4-window7-224-in22k", "Habana/swin")],
 }


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds commented blocks of code that can be uncommented to enable regression tests on the `run_speech_recognition_ctc.py` example script. The reason why they are disabled by default is that they take long enough to make the GH workflows reach the 6-hour timeout.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
