### PR TITLE
optimize conv1d forward

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -15,6 +15,7 @@
 
 import transformers.models.bloom.modeling_bloom as modeling_bloom
 import transformers.models.gpt2.modeling_gpt2 as modeling_gpt2
+from transformers import pytorch_utils
 from transformers.generation import GenerationMixin
 from transformers.modeling_utils import ModuleUtilsMixin
 from transformers.models.albert.modeling_albert import AlbertModel
@@ -30,6 +31,7 @@ from .models import (
     gaudi_albert_forward,
     gaudi_bloom_attention_forward,
     gaudi_bloom_block_forward,
+    gaudi_conv1d_forward,
     gaudi_get_extended_attention_mask,
     gaudi_invert_attention_mask,
     gaudi_vit_self_attention_forward,
@@ -45,6 +47,8 @@ def adapt_transformers_to_gaudi():
     Args:
         use_habana_mixed_precision (bool): whether HMP is used or not.
     """
+    # optimize Conv1D
+    pytorch_utils.Conv1D.forward = gaudi_conv1d_forward
 
     # Optimization tweak for ViT
     ViTSelfAttention.forward = gaudi_vit_self_attention_forward

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -7,7 +7,7 @@ from .bloom import (
     gaudi_bloom_block_forward,
 )
 from .gpt2 import GaudiGPT2Attention
-from .modeling_all_models import gaudi_get_extended_attention_mask, gaudi_invert_attention_mask
+from .modeling_all_models import gaudi_conv1d_forward, gaudi_get_extended_attention_mask, gaudi_invert_attention_mask
 from .vit import gaudi_vit_self_attention_forward
 from .wav2vec2 import (
     _gaudi_wav2vec2_compute_mask_indices,

--- a/optimum/habana/transformers/models/modeling_all_models.py
+++ b/optimum/habana/transformers/models/modeling_all_models.py
@@ -93,3 +93,15 @@ def gaudi_get_extended_attention_mask(
     extended_attention_mask = extended_attention_mask * torch.finfo(extended_attention_mask.dtype).min
 
     return extended_attention_mask
+
+
+def gaudi_conv1d_forward(self, x):
+    # move reshape before view for tpc auto fusion
+    size_out = x.size()[:-1] + (self.nf,)
+    x = torch.mm(x.view(-1, x.size(-1)), self.weight)
+    x = x.view(size_out)
+    bias_shape = [1 for _ in x.shape]
+    bias_shape[-1] = self.nf
+    bias = self.bias.view(bias_shape)
+    x = x + bias
+    return x


### PR DESCRIPTION
# What does this PR do?

current the implementation of Conv1D is using `torch.addmm`, with which there is a `view` op after bias add, the `view` op is mapped to `reshape` op on Gaudi, a `reshape` will break the tpc auto fusion, so this PR is try to optimize the Conv1D by put the bias add after the `view`.

here is the perf of text-generation with GPT2 on Gaudi2

branch optimize_conv1d: 509
branch main: 422

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
