### PR TITLE
Fix 'transformers' version to 4.28.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers >= 4.26.0",
+    "transformers >= 4.26.0, <= 4.28.1",
     "optimum",
     "torch",
     "accelerate",


### PR DESCRIPTION
The newest version causes the `GaudiTrainingArguments._setup_devices()` to hang due to infinite loop. It is probably related to this change: https://github.com/huggingface/optimum-habana/pull/198/commits/f8acdc8a31efe7cd0c98f9dd8da404946f9cd1ae

`self.get_process_log_level()` checks `should_log` property, which reads properly `local_process_index`, which reads `parallel_mode`, which reads `n_gpu`, which falls back to `_setup_devices`.

To reproduce the issue: `bash tests/ci/slow_tests_deepspeed.sh`

# What does this PR do?

Fixes the `transformers` version to 4.28.1, which does no cause an infinite loop.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
