### PR TITLE
Added an option to remove save checkpoint time from throughput calculation

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -77,7 +77,6 @@ from transformers.utils import (
     WEIGHTS_NAME,
     is_datasets_available,
     is_safetensors_available,
-    is_torch_tpu_available,
 )
 
 from optimum.utils import logging
@@ -417,9 +416,6 @@ class GaudiTrainer(Trainer):
 
     def _maybe_log_save_evaluate(self, tr_loss, model, trial, epoch, ignore_keys_for_eval):
         if self.control.should_log:
-            if is_torch_tpu_available():
-                xm.mark_step()
-
             logs: Dict[str, float] = {}
 
             # all_gather + mean() to get average loss over all processes
@@ -456,7 +452,7 @@ class GaudiTrainer(Trainer):
                 save_start = time.time()
             self._save_checkpoint(model, trial, metrics=metrics)
             if self.args.throughput_rm_save_ckpt_time:
-                self.save_ckpt_time += (time.time() - save_start)
+                self.save_ckpt_time += time.time() - save_start
             self.control = self.callback_handler.on_save(self.args, self.state, self.control)
 
     def train(

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -70,7 +70,7 @@ from transformers.trainer_utils import (
     get_last_checkpoint,
     has_length,
 )
-from transformers.training_args import TrainingArguments, ParallelMode
+from transformers.training_args import TrainingArguments
 from transformers.utils import (
     CONFIG_NAME,
     SAFE_WEIGHTS_NAME,

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -85,8 +85,8 @@ class GaudiTrainingArguments(TrainingArguments):
             Number of steps to ignore for throughput calculation. For example, with `throughput_warmup_steps=N`,
             the first N steps will not be considered in the calculation of the throughput. This is especially
             useful in lazy mode where the first two or three iterations typically take longer.
-        throughput_rm_save_ckpt_time ('bool', *optional*, defaults to `False`):
-            Whether to remove save checkpoint time from throughput calculation.
+        adjust_throughput ('bool', *optional*, defaults to `False`):
+            Whether to remove the time taken for logging, evaluating and saving from throughput calculation.
         pipelining_fwd_bwd (`bool`, *optional*, defaults to `False`):
             Whether to add an additional `mark_step` between forward and backward for pipelining
             host backward building and HPU forward computing.

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -85,6 +85,8 @@ class GaudiTrainingArguments(TrainingArguments):
             Number of steps to ignore for throughput calculation. For example, with `throughput_warmup_steps=N`,
             the first N steps will not be considered in the calculation of the throughput. This is especially
             useful in lazy mode where the first two or three iterations typically take longer.
+        throughput_rm_save_ckpt_time ('bool', *optional*, defaults to `False`):
+            Whether to remove save checkpoint time from throughput calculation.
         pipelining_fwd_bwd (`bool`, *optional*, defaults to `False`):
             Whether to add an additional `mark_step` between forward and backward for pipelining
             host backward building and HPU forward computing.
@@ -121,6 +123,11 @@ class GaudiTrainingArguments(TrainingArguments):
                 " useful in lazy mode where the first two or three iterations typically take longer."
             )
         },
+    )
+
+    throughput_rm_save_ckpt_time:  bool = field(
+        default=False,
+        metadata={"help": "Whether to remove save checkpoint time from throughput calculation."},
     )
 
     pipelining_fwd_bwd: Optional[bool] = field(

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -125,9 +125,11 @@ class GaudiTrainingArguments(TrainingArguments):
         },
     )
 
-    adjust_throughput:  bool = field(
+    adjust_throughput: bool = field(
         default=False,
-        metadata={"help": "Whether to remove the time taken for logging, evaluating and saving from throughput calculation."},
+        metadata={
+            "help": "Whether to remove the time taken for logging, evaluating and saving from throughput calculation."
+        },
     )
 
     pipelining_fwd_bwd: Optional[bool] = field(

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -125,9 +125,9 @@ class GaudiTrainingArguments(TrainingArguments):
         },
     )
 
-    throughput_rm_save_ckpt_time:  bool = field(
+    adjust_throughput:  bool = field(
         default=False,
-        metadata={"help": "Whether to remove save checkpoint time from throughput calculation."},
+        metadata={"help": "Whether to remove the time taken for logging, evaluating and saving from throughput calculation."},
     )
 
     pipelining_fwd_bwd: Optional[bool] = field(

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -70,7 +70,7 @@ def speed_metrics(
     num_samples: int = None,
     num_steps: int = None,
     start_time_after_warmup: float = None,
-    save_ckpt_time: float = None,
+    log_evaluate_save_time: float = None,
 ) -> Dict[str, float]:
     """
     Measure and return speed performance metrics.
@@ -83,7 +83,7 @@ def speed_metrics(
         num_samples (int, optional): number of samples processed. Defaults to None.
         num_steps (int, optional): number of steps performed. Defaults to None.
         start_time_after_warmup (float, optional): time after warmup steps have been performed. Defaults to None.
-        save_ckpt_time (float, optional): time save checkpoint have been performed. Defaults to None.
+        log_evaluate_save_time (float, optional): time spent to log, evaluate and save. Defaults to None.
 
     Returns:
         Dict[str, float]: dictionary with performance metrics.
@@ -92,9 +92,9 @@ def speed_metrics(
     runtime = time.time() - start_time
     result = {f"{split}_runtime": round(runtime, 4)}
 
-    # Adjust runtime if save ckpt time is not included
-    if save_ckpt_time is not None:
-        runtime = runtime - save_ckpt_time
+    # Adjust runtime if log_evaluate_save_time should not be included
+    if log_evaluate_save_time is not None:
+        runtime = runtime - log_evaluate_save_time
 
     # Adjust runtime if there were warmup steps
     if start_time_after_warmup is not None:

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -70,6 +70,7 @@ def speed_metrics(
     num_samples: int = None,
     num_steps: int = None,
     start_time_after_warmup: float = None,
+    save_ckpt_time: float = None,
 ) -> Dict[str, float]:
     """
     Measure and return speed performance metrics.
@@ -82,6 +83,7 @@ def speed_metrics(
         num_samples (int, optional): number of samples processed. Defaults to None.
         num_steps (int, optional): number of steps performed. Defaults to None.
         start_time_after_warmup (float, optional): time after warmup steps have been performed. Defaults to None.
+        save_ckpt_time (float, optional): time save checkpoint have been performed. Defaults to None.
 
     Returns:
         Dict[str, float]: dictionary with performance metrics.
@@ -89,6 +91,10 @@ def speed_metrics(
 
     runtime = time.time() - start_time
     result = {f"{split}_runtime": round(runtime, 4)}
+
+    # Adjust runtime if save ckpt time is not included
+    if save_ckpt_time is not None:
+        runtime = runtime - save_ckpt_time
 
     # Adjust runtime if there were warmup steps
     if start_time_after_warmup is not None:


### PR DESCRIPTION
In the case that train time is very short, the distributed training throughput is greatly impacted by saving checkpoint time, and it gives misleading scaling effciency. This patch provides an option to remove the save checkpoint time from throughput calculation.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
