### PR TITLE
Add `--bf16` to the text-generation example

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -57,7 +57,7 @@ To run a benchmark and get the throughput of your model, you can run:
 ```
 python (../gaudi_spawn.py --use_deepspeed --world_size number_of_devices) run_generation.py \
 --model_name_or_path path_to_model \
---gaudi_config_name_or_path path_to_gaudi_config \
+--bf16 \
 --max_new_tokens number_of_tokens_to_generate \
 --batch_size batch_size \
 --n_iterations number_of_iterations \
@@ -68,7 +68,7 @@ python (../gaudi_spawn.py --use_deepspeed --world_size number_of_devices) run_ge
 with
 - `number_of_devices` the number of HPUs you want to use
 - `path_to_model` a model name on the Hugging Face Hub or a path to a model saved locally
-- `path_to_gaudi_config` a Gaudi configuration on the Hugging Face Hub or a path to a Gaudi configuration saved locally, this is not used if the run is launched with DeepSpeed-inference
+- `bf16` enables to run generation in bf16 precision, this is not used if the run is launched with DeepSpeed-inference
 - `number_of_tokens_to_generate` the number of tokens to generate for each prompt
 - `batch_size` the size of the batches provided to the model
 - `number_of_iterations` the number of iterations to perform in the benchmark
@@ -85,6 +85,12 @@ python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
 --use_kv_cache \
 --max_new_tokens 100
 ```
+
+> To be able to run gated models like [StarCoder](https://huggingface.co/bigcode/starcoder), you should:
+> - have a HF account
+> - agree to the terms of use of the model in its model card on the HF Hub
+> - set a read token as explained [here](https://huggingface.co/docs/hub/security-tokens)
+> - login to your account using the HF CLI: run `huggingface-cli login` before launching your script
 
 
 ### Use any dataset from the Hugging Face Hub
@@ -103,7 +109,7 @@ python run_generation.py \
 --use_kv_cache \
 --dataset_name JulesBelveze/tldr_news \
 --column_name content \
---gaudi_config_name_or_path Habana/gpt2
+--bf16
 ```
 
 > The prompt length is limited to 16 tokens. Prompts longer than this will be truncated.

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -21,7 +21,6 @@ Conditional text generation on Habana Gaudi/Gaudi2.
 import argparse
 import logging
 import os
-import tempfile
 import time
 
 import torch
@@ -50,10 +49,9 @@ def main():
         help="Path to pre-trained model (on the HF Hub or locally).",
     )
     parser.add_argument(
-        "--gaudi_config_name_or_path",
-        default=None,
-        type=str,
-        help="Path to Gaudi configuration (on the HF Hub or locally).",
+        "--bf16",
+        action="store_true",
+        help="Whether to perform generation in bf16 precision.",
     )
     parser.add_argument("--max_new_tokens", type=int, default=100)
     parser.add_argument("--batch_size", type=int, default=1, help="Input batch size.")
@@ -118,33 +116,6 @@ def main():
         deepspeed.init_distributed(dist_backend="hccl")
         logger.info("DeepSpeed is enabled.")
     else:
-        if args.gaudi_config_name_or_path is None:
-            gaudi_config = None
-            logger.warning(
-                "`--gaudi_config_name_or_path` was not specified so not using Habana Mixed Precision for this run."
-            )
-        else:
-            from optimum.habana import GaudiConfig
-
-            gaudi_config = GaudiConfig.from_pretrained(args.gaudi_config_name_or_path)
-
-            if gaudi_config.use_habana_mixed_precision:
-                from habana_frameworks.torch.hpex import hmp
-
-                # Open temporary files to mixed-precision write ops
-                with tempfile.NamedTemporaryFile() as hmp_bf16_file:
-                    with tempfile.NamedTemporaryFile() as hmp_fp32_file:
-                        # hmp.convert needs ops to be written in text files
-                        gaudi_config.write_bf16_fp32_ops_to_text_files(
-                            hmp_bf16_file.name,
-                            hmp_fp32_file.name,
-                        )
-                        hmp.convert(
-                            opt_level=gaudi_config.hmp_opt_level,
-                            bf16_file_path=hmp_bf16_file.name,
-                            fp32_file_path=hmp_fp32_file.name,
-                            isVerbose=gaudi_config.hmp_is_verbose,
-                        )
         logger.info("Single-device run.")
 
     # Tweak generation so that it runs faster on Gaudi
@@ -154,22 +125,26 @@ def main():
 
     tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
 
+    if use_deepspeed or args.bf16:
+        model_dtype = torch.bfloat16
+    else:
+        model_dtype = torch.float
+
     if use_deepspeed:
         config = AutoConfig.from_pretrained(args.model_name_or_path)
-        args.dtype = torch.bfloat16
         is_bloom = model_is_bloom(config)
 
         if is_bloom:
             # Construct model with fake meta tensors, later will be replaced on devices during ds-inference ckpt load
-            with deepspeed.OnDevice(dtype=args.dtype, device="meta"):
-                model = AutoModelForCausalLM.from_config(config, torch_dtype=args.dtype)
+            with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
+                model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype)
         else:
-            with deepspeed.OnDevice(dtype=args.dtype, device=args.device):
-                model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=args.dtype)
+            with deepspeed.OnDevice(dtype=model_dtype, device=args.device):
+                model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         model = model.eval()
 
         # Initialize the model
-        ds_inference_kwargs = {"dtype": args.dtype}
+        ds_inference_kwargs = {"dtype": model_dtype}
         ds_inference_kwargs["tensor_parallel"] = {"tp_size": world_size}
         ds_inference_kwargs["enable_cuda_graph"] = args.use_hpu_graphs
 
@@ -191,7 +166,7 @@ def main():
             model.module.split_lm_head()
         model = model.module
     else:
-        model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path)
+        model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         model = model.eval().to(args.device)
         is_bloom = model_is_bloom(model.config)
 
@@ -207,11 +182,7 @@ def main():
 
     if rank in [-1, 0]:
         logger.info(f"Args: {args}")
-
-        use_bf16 = False
-        if use_deepspeed or (gaudi_config is not None and gaudi_config.use_habana_mixed_precision):
-            use_bf16 = True
-        logger.info(f"device: {args.device}, n_hpu: {world_size}, bf16: {use_bf16}")
+        logger.info(f"device: {args.device}, n_hpu: {world_size}, bf16: {use_deepspeed or args.bf16}")
 
     # Generation configuration
     generation_config = GenerationConfig(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds the argument `bf16` to the text-generation script to be able to run generation in full bf16 precision. It removes the use of Gaudi config that would apply mixed precision.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
