### PR TITLE
OPT support DS 1x Inference

### DIFF
--- a/examples/text-generation/checkpoint_utils.py
+++ b/examples/text-generation/checkpoint_utils.py
@@ -95,6 +95,6 @@ def get_ds_injection_policy(config):
         if model_type == "opt":
             from transformers.models.opt.modeling_opt import OPTDecoderLayer
 
-            policy = {OPTDecoderLayer: ("self_attn.out_proj", "fc2")}
+            policy = {OPTDecoderLayer: ("self_attn.out_proj", ".fc2")}
 
     return policy

--- a/examples/text-generation/checkpoint_utils.py
+++ b/examples/text-generation/checkpoint_utils.py
@@ -67,9 +67,9 @@ def model_is_bloom(config):
 
 
 def get_optimized_model_name(config):
-    model_names = ["bloom", "gpt2", "opt", "gptj", "gptneox"]
+    model_names = ["bloom", "gpt2", "opt", "gptj", "gpt_neox"]
     for model_name in model_names:
-        if model_name in config.architectures[0].lower():
+        if model_name == config.model_type:
             return model_name
 
     return None


### PR DESCRIPTION
# What does this PR do?

facebook/opt-125m

ds mode

cmd 

```bash
python ../gaudi_spawn.py --use_deepspeed --world_size 1 run_generation.py --model_name_or_path facebook/opt-125m --batch_size 1 --use_hpu_graphs --use_kv_cache --max_new_tokens 100
```

outputs
![image](https://github.com/huggingface/optimum-habana/assets/80079571/b691b735-991d-45e2-9345-de1b57da20c4)

non-ds mode

cmd

```bash
python run_generation.py --model_name_or_path facebook/opt-125m --batch_size 1 --use_hpu_graphs --use_kv_cache --max_new_tokens 100
```

outputs
![image](https://github.com/huggingface/optimum-habana/assets/80079571/5f5a2592-3be6-41b4-a0b0-09d5214c6f03)

<!--
Congratulations! You've made it this far! You're not quite done yet though.
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

know issue

- only support DS 1x, not support DS multi cards
- reasonable but different outputs of opt13B and bloom-560m between non-ds mode and ds mode, no sure if is a issue


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
