### PR TITLE
Fix profiling in GaudiTrainer

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -973,9 +973,10 @@ class GaudiTrainer(Trainer):
             self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
             self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, ignore_keys_for_eval)
 
-            hb_profiler.stop()
             if self.control.should_training_stop:
                 break
+
+        hb_profiler.stop()
 
         if args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of training

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -92,6 +92,10 @@ class GaudiTrainingArguments(TrainingArguments):
             host backward building and HPU forward computing.
         non_blocking_data_copy (`bool`, *optional*, defaults to `False`):
             Whether to enable async data copy when preparing inputs.
+        profiling_warmup_steps (`int`, *optional*, defaults to 0):
+            Number of steps to ignore for profling.
+        profiling_steps (`int`, *optional*, defaults to 0):
+            Number of steps to be captured when enabling profiling.
     """
 
     use_habana: Optional[bool] = field(
@@ -147,6 +151,16 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": ("Whether to enable async data copy when preparing inputs.")},
     )
 
+    profiling_warmup_steps: Optional[int] = field(
+        default=0,
+        metadata={"help": ("Number of steps to ignore for profling.")},
+    )
+
+    profiling_steps: Optional[int] = field(
+        default=0,
+        metadata={"help": ("Number of steps to be captured when enabling profiling.")},
+    )
+
     # Overriding the default value of optim because 'adamw_hf' is deprecated
     optim: Optional[Union[OptimizerNames, str]] = field(
         default="adamw_torch",
@@ -174,16 +188,6 @@ class GaudiTrainingArguments(TrainingArguments):
                 "`DistributedDataParallel`."
             )
         },
-    )
-
-    profiling_warmup_steps: Optional[int] = field(
-        default=0,
-        metadata={"help": ("Number of steps to ignore for profling.")},
-    )
-
-    profiling_steps: Optional[int] = field(
-        default=0,
-        metadata={"help": ("Number of steps to be captured when enabling profiling.")},
     )
 
     # Overriding ddp_find_unused_parameters to make False the default value

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1609,6 +1609,11 @@ class GaudiTrainerIntegrationTest(TestCasePlus, GaudiTrainerIntegrationCommon):
         self.assertListEqual(trainer.optimizer.param_groups[0]["params"], wd_params)
         self.assertListEqual(trainer.optimizer.param_groups[1]["params"], no_wd_params)
 
+    def test_profiling(self):
+        # 24 total steps and compilation takes place during the 1st three steps
+        trainer = get_regression_trainer(profiling_warmup_steps=3, profiling_steps=21)
+        trainer.train()
+
 
 @require_torch
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The profiler is currently stopped at the end of the 1st epoch. This should be done after the last training iteration.
I also added a test to be able in the future to catch this kind of error before merging.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
