### PR TITLE
Fix text generation with DeepSpeed

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -29,8 +29,6 @@ from checkpoint_utils import model_is_bloom, model_is_optimized, write_checkpoin
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
 
-from optimum.habana.utils import get_hpu_memory_stats
-
 
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
@@ -310,6 +308,8 @@ def main():
         throughput = total_new_tokens_generated / duration
 
         if rank in [-1, 0]:
+            from optimum.habana.utils import get_hpu_memory_stats
+
             stats = f"Throughput (including tokenization) = {throughput} tokens/second"
             separator = "-" * len(stats)
             print()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes an issue where multi-card text generation with DeepSpeed fails.
Basically, we need to move imports from `optimum.habana.xxx` after [this line](https://github.com/huggingface/optimum-habana/blob/fe3e10aa5a69ed4b53eba0cc5fabf2b554fa63f5/examples/text-generation/run_generation.py#L120) to make sure env variables are correctly set. Otherwise, it will probably import `habana_frameworks` at some point, which initializes env variables with a default value.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
