### PR TITLE
Use `snapshot_download` whenever possible in the text-generation example

### DIFF
--- a/examples/text-generation/checkpoint_utils.py
+++ b/examples/text-generation/checkpoint_utils.py
@@ -4,38 +4,49 @@ from pathlib import Path
 
 import torch
 from huggingface_hub import snapshot_download
-from transformers.utils import is_offline_mode
+from transformers.utils import is_offline_mode, is_safetensors_available
 
 
-def get_repo_root(model_name_or_path, local_rank):
+def get_repo_root(model_name_or_path, local_rank=-1):
     """
     Downloads the specified model checkpoint and returns the repository where it was downloaded.
     """
-    # Checks if online or not
-    if is_offline_mode():
-        if local_rank == 0:
-            print("Offline mode: forcing local_files_only=True")
+    if Path(model_name_or_path).is_dir():
+        # If it is a local model, no need to download anything
+        return model_name_or_path
+    else:
+        # Checks if online or not
+        if is_offline_mode():
+            if local_rank == 0:
+                print("Offline mode: forcing local_files_only=True")
 
-    # Download only on first process
-    if local_rank == 0:
-        snapshot_download(
+        # Download only on first process
+        if local_rank == -1:
+            return snapshot_download(
+                model_name_or_path,
+                local_files_only=is_offline_mode(),
+                cache_dir=os.getenv("TRANSFORMERS_CACHE", None),
+                allow_patterns=["*.safetensors"] if is_safetensors_available() else ["*.bin"],
+                max_workers=16,
+            )
+        elif local_rank == 0:
+            snapshot_download(
+                model_name_or_path,
+                local_files_only=is_offline_mode(),
+                cache_dir=os.getenv("TRANSFORMERS_CACHE", None),
+                allow_patterns=["*.safetensors"] if is_safetensors_available() else ["*.bin"],
+                max_workers=16,
+            )
+
+        # Make all processes wait so that other processes can get the checkpoint directly from cache
+        torch.distributed.barrier()
+
+        return snapshot_download(
             model_name_or_path,
             local_files_only=is_offline_mode(),
             cache_dir=os.getenv("TRANSFORMERS_CACHE", None),
-            allow_patterns=["*.bin"],
-            ignore_patterns=["*.safetensors"],
+            allow_patterns=["*.safetensors"] if is_safetensors_available() else ["*.bin"],
         )
-
-    # Make all processes wait so that other processes can get the checkpoint directly from cache
-    torch.distributed.barrier()
-
-    return snapshot_download(
-        model_name_or_path,
-        local_files_only=is_offline_mode(),
-        cache_dir=os.getenv("TRANSFORMERS_CACHE", None),
-        allow_patterns=["*.bin"],
-        ignore_patterns=["*.safetensors"],
-    )
 
 
 def get_checkpoint_files(model_name_or_path, local_rank):

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -233,7 +233,6 @@ def main():
         get_repo_root(args.model_name_or_path)
         model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         model = model.eval().to(args.device)
-        is_bloom = model_is_bloom(model.config)
         is_optimized = model_is_optimized(model.config)
 
         if args.use_hpu_graphs:

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -26,7 +26,13 @@ import time
 
 import torch
 import torch.nn.functional as F
-from checkpoint_utils import get_ds_injection_policy, model_is_bloom, model_is_optimized, write_checkpoints_json
+from checkpoint_utils import (
+    get_ds_injection_policy,
+    get_repo_root,
+    model_is_bloom,
+    model_is_optimized,
+    write_checkpoints_json,
+)
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 
@@ -198,6 +204,7 @@ def main():
             with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
                 model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype)
         else:
+            get_repo_root(args.model_name_or_path, args.local_rank)
             with deepspeed.OnDevice(dtype=model_dtype, device=args.device):
                 model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         model = model.eval()
@@ -222,6 +229,7 @@ def main():
         model = deepspeed.init_inference(model, **ds_inference_kwargs)
         model = model.module
     else:
+        get_repo_root(args.model_name_or_path)
         model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         model = model.eval().to(args.device)
         is_bloom = model_is_bloom(model.config)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR enables to download checkpoints with [`snapshot_download`](https://huggingface.co/docs/huggingface_hub/package_reference/file_download#huggingface_hub.snapshot_download) in all cases (it used to be the case for BLOOM only). This allows to have multiple downloads in parallel for sharded checkpoints, leading to shorter waiting times.
It also ensures that `snapshot_download` is not used if the checkpoint folder is local as it would raise an error.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
