### PR TITLE
fix dim issue of next_token_logits in sample, or else logits_processo…

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1483,7 +1483,7 @@ class GaudiGenerationMixin(GenerationMixin):
 
             token_idx = model_kwargs.get("token_idx", None)
             if token_idx is not None and outputs.logits.shape[-2] > 1:
-                next_token_logits = torch.index_select(outputs.logits, -2, token_idx - 1)
+                next_token_logits = torch.index_select(outputs.logits, -2, token_idx - 1).squeeze(-2)
             else:
                 next_token_logits = outputs.logits[:, -1, :]
 


### PR DESCRIPTION
…r has issue if repetition_penalty is used

Fixes # (issue)
it will core dump if set following in text generation example
generation_config.do_sample=True
generation_config.repetition_penalty=0.75

coredump trace like
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/work/chatbot/inference/generate.py", line 529, in generate_output
    return model.generate(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/work/optimum-habana/optimum/habana/transformers/generation/utils.py", line 627, in generate
    return self.sample(
  File "/work/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1531, in sample
    streamer.put(next_tokens.cpu())
RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_BRIDGE syn compile encountered : Graph compile failed. 26 compile time 55892013 ns
