### PR TITLE
Trigger workflows for external PRs on label

### DIFF
--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -2,11 +2,11 @@ name: Unit and integration tests
 
 
 # WARNING: As this workflow supports the pull_request_target event, please exercise extra care when editing it.
-# Reference: https://gist.github.com/fxmarty/fba1ea3b2ebbf9a75cca71c08f05a85b
 on:
   workflow_dispatch:
   pull_request_target:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, labeled ]
     paths:
       - "optimum/**.py"
       - "tests/**.py"
@@ -18,10 +18,7 @@ concurrency:
 
 jobs:
   authorize:
-    environment:
-      ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || 'internal' }}
+    if: (github.event.action == 'labeled' && github.event.label.name == 'run-test') || github.event_name != 'pull_request_target' || (! github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     steps:
       - run: true
@@ -79,12 +76,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          fetch-depth: 2
-      - name: Security - check PR SHA
-        if: github.event_name == 'pull_request_target'
-        run: |
-            [[ "$(git rev-parse 'HEAD^2')" == "${{ github.event.pull_request.head.sha }}" ]]
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Pull image
         run: |
             docker pull vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1:latest
@@ -120,12 +112,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          fetch-depth: 2
-      - name: Security - check PR SHA
-        if: github.event_name == 'pull_request_target'
-        run: |
-            [[ "$(git rev-parse 'HEAD^2')" == "${{ github.event.pull_request.head.sha }}" ]]
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Pull image
         run: |
             docker pull vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1:latest


### PR DESCRIPTION
Revert https://github.com/huggingface/optimum-habana/pull/313 as it is not a good solution given that it is not possible to disable notifications for review requests in github: https://github.com/orgs/community/discussions/14564. We do not want to get spammed by review requests at every commit.

The `authorize` job is run only when:
* The PR does not come from a fork ==> runs automatically ==> anybody with write access can still run workflows automatically
* The workflow is triggered not from `pull_request_target` event (e.g. rather `workflow_dispatch` that only people with write access can trigger)
* The PR is labeled `run-tests`, which triggers a `labeled` action type.

Note: this workflow is not susceptible to race condition on commits being added after the PR being labeled, given that we use `if: (github.event.action == 'labeled' && github.event.label.name == 'run-test')` and NOT `if: contains(github.event.pull_request.labels.*.name, 'safe to test')` (which is dangerous). Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

All following jobs require the `authorize` job.

I think it is a decent enough compromise to generalize this to other subpackages.