### PR TITLE
remove two workarounds on esmfold after releasing 1.11.0

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -27,7 +27,6 @@ from .models import (
     GaudiLlamaForCausalLM,
     GaudiOPTForCausalLM,
     GaudiOPTLearnedPositionalEmbedding,
-    _gaudi_esmfold_attention_wrap_up,
     gaudi_albert_forward,
     gaudi_bloom_attention_forward,
     gaudi_bloom_block_forward,
@@ -36,7 +35,6 @@ from .models import (
     gaudi_bloom_model_forward,
     gaudi_conv1d_forward,
     gaudi_esm_for_protein_folding_forward,
-    gaudi_esmfold_self_attention_forward,
     gaudi_esmfolding_trunk_forward,
     gaudi_esmoutput_forward,
     gaudi_esmselfoutput_forward,
@@ -130,8 +128,6 @@ def adapt_transformers_to_gaudi():
     # Optimization for EsmFold on Gaudi
     transformers.models.esm.modeling_esmfold.EsmFoldingTrunk.forward = gaudi_esmfolding_trunk_forward
     transformers.models.esm.modeling_esmfold.EsmForProteinFolding.forward = gaudi_esm_for_protein_folding_forward
-    transformers.models.esm.modeling_esmfold.EsmFoldAttention._wrap_up = _gaudi_esmfold_attention_wrap_up
-    transformers.models.esm.modeling_esmfold.EsmFoldSelfAttention.forward = gaudi_esmfold_self_attention_forward
     transformers.models.esm.openfold_utils.rigid_utils.rot_matmul = gaudi_rot_matmul
     transformers.models.esm.openfold_utils.rigid_utils.rot_vec_mul = gaudi_rot_vec_mul
     transformers.models.esm.modeling_esm.EsmSelfOutput.forward = gaudi_esmselfoutput_forward

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -9,9 +9,7 @@ from .bloom import (
     gaudi_bloom_model_forward,
 )
 from .esm import (
-    _gaudi_esmfold_attention_wrap_up,
     gaudi_esm_for_protein_folding_forward,
-    gaudi_esmfold_self_attention_forward,
     gaudi_esmfolding_trunk_forward,
     gaudi_esmoutput_forward,
     gaudi_esmselfoutput_forward,

--- a/optimum/habana/transformers/models/esm/__init__.py
+++ b/optimum/habana/transformers/models/esm/__init__.py
@@ -1,8 +1,6 @@
 from .modeling_esm import gaudi_esmoutput_forward, gaudi_esmselfoutput_forward
 from .modeling_esmfold import (
-    _gaudi_esmfold_attention_wrap_up,
     gaudi_esm_for_protein_folding_forward,
-    gaudi_esmfold_self_attention_forward,
     gaudi_esmfolding_trunk_forward,
     gaudi_rot_matmul,
     gaudi_rot_vec_mul,

--- a/optimum/habana/transformers/models/esm/modeling_esmfold.py
+++ b/optimum/habana/transformers/models/esm/modeling_esmfold.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 from typing import Optional
 
-import numpy as np
 import torch
-from transformers.models.esm.modeling_esmfold import EsmForProteinFoldingOutput, categorical_lddt, flatten_final_dims
+from transformers.models.esm.modeling_esmfold import EsmForProteinFoldingOutput, categorical_lddt
 from transformers.models.esm.openfold_utils import (
     compute_predicted_aligned_error,
     compute_tm,
@@ -237,90 +236,6 @@ def gaudi_esm_for_protein_folding_forward(
     structure.update(compute_predicted_aligned_error(ptm_logits, max_bin=31, no_bins=self.distogram_bins))
 
     return EsmForProteinFoldingOutput(**structure)
-
-
-def _gaudi_esmfold_attention_wrap_up(self, o: torch.Tensor, q_x: torch.Tensor) -> torch.Tensor:
-    """
-    Copied from EsmFoldAttention._wrap_up:
-    https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt2/modeling_gpt2.py
-    The change is:
-    - Add extra mark_step after sigmoid
-    """
-
-    if self.linear_g is not None:
-        g = self.sigmoid(self.linear_g(q_x))
-        # TODO: WA on HPU accuracy issue. Will be fixed after 1.10.0 releases.
-        if g.device.type == "hpu":
-            import habana_frameworks.torch.core as htcore
-
-            htcore.mark_step()
-
-        # [*, Q, H, C_hidden]
-        g = g.view(g.shape[:-1] + (self.no_heads, -1))
-        o = o * g
-
-    # [*, Q, H * C_hidden]
-    o = flatten_final_dims(o, 2)
-
-    # [*, Q, C_q]
-    o = self.linear_o(o)
-
-    return o
-
-
-def gaudi_esmfold_self_attention_forward(self, x, mask=None, bias=None, indices=None):
-    """
-    Basic self attention with optional mask and external pairwise bias. To handle sequences of different lengths,
-    use mask.
-
-    Inputs:
-        x: batch of input sequneces (.. x L x C) mask: batch of boolean masks where 1=valid, 0=padding position (..
-        x L_k) bias: batch of scalar pairwise attention biases (.. x Lq x Lk x num_heads)
-
-    Outputs:
-        sequence projection (B x L x embed_dim), attention maps (B x L x L x num_heads)
-
-    Copied from EsmFoldSelfAttention.forward:
-    https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt2/modeling_gpt2.py
-    The change is:
-    - Add extra mark_step after sigmoid
-    """
-
-    t = self.proj(x).view(*x.shape[:2], self.num_heads, -1)
-    t = t.permute(0, 2, 1, 3)
-    q, k, v = t.chunk(3, dim=-1)
-
-    q = self.rescale_factor * q
-    a = torch.einsum("...qc,...kc->...qk", q, k)
-
-    # Add external attention bias.
-    if bias is not None:
-        a = a + bias.permute(0, 3, 1, 2)
-
-    # Do not attend to padding tokens.
-    if mask is not None:
-        mask = mask[:, None, None]
-        a = a.masked_fill(mask == False, -np.inf)  # noqa: E712
-
-    a = torch.nn.functional.softmax(a, dim=-1)
-
-    y = torch.einsum("...hqk,...hkc->...qhc", a, v)
-    y = y.reshape(*y.shape[:2], -1)
-
-    if self.gated:
-        # TODO: WA on HPU accuracy issue. Will be fixed after 1.10.0 releases.
-        if y.device.type == "hpu":
-            temp = self.g_proj(x)
-            temp = temp.sigmoid()
-            import habana_frameworks.torch.core as htcore
-
-            htcore.mark_step()
-            y = temp * y
-        else:
-            y = self.g_proj(x).sigmoid() * y
-    y = self.o_proj(y)
-
-    return y, a.permute(0, 3, 1, 2)
 
 
 def gaudi_rot_vec_mul(r: torch.Tensor, t: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
# What does this PR do?

This PR removed 2 workarounds on esmfold scripts. These 2 workarounds were introduced before 1.10 release due to accuracy issue. 

I have verified that there is no accuracy issue on the generated pdb file after removing the 2 WAs. 
