### PR TITLE
fix gptj incorrect output issue in TGI

### DIFF
--- a/text-generation-inference/server/text_generation_server/models/causal_lm.py
+++ b/text-generation-inference/server/text_generation_server/models/causal_lm.py
@@ -492,7 +492,7 @@ class CausalLM(Model):
         return self.tokenizer.decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)
 
     def forward(
-        self, input_ids, attention_mask, token_idx=None, past_key_values: Optional = None
+        self, input_ids, attention_mask, position_ids, token_idx=None, past_key_values: Optional = None
     ) -> Tuple[torch.Tensor, List[Tuple[torch.Tensor, torch.Tensor]]]:
         # Model Forward
         kwargs = {
@@ -504,8 +504,14 @@ class CausalLM(Model):
         }
 
         if self.is_optimized_for_gaudi:
+            if not past_key_values:
+                # add padding to position_id
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
             kwargs["token_idx"] = token_idx
 
+        if self.has_position_ids:
+            kwargs["position_ids"] = position_ids
         outputs = self.model.forward(**kwargs)
         return outputs.logits, outputs.past_key_values
 
@@ -522,6 +528,7 @@ class CausalLM(Model):
         logits, past = self.forward(
             batch.input_ids,
             attention_mask,
+            batch.position_ids,
             token_idx,
             batch.past_key_values,
         )


### PR DESCRIPTION

run model EleutherAI/gpt-j-6b in TGI

 curl 127.0.0.1:8080/generate \
     -X POST \
     -d '{"inputs":"What is DeepSpeed?","parameters":{"max_new_tokens":256, "do_sample": false}}' \
     -H 'Content-Type: application/json'
~

{"generated_text":"QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ:QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ:QQQQQQQQQQQQQQQQQQQQQQQQQQQQQ:QDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
