### PR TITLE
enable hpu rms fused kernel for t5

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -72,6 +72,7 @@ from .models import (
     gaudi_opt_model_forward,
     gaudi_rot_matmul,
     gaudi_rot_vec_mul,
+    gaudi_t5_layernorm_forward,
     gaudi_vit_self_attention_forward,
     gaudi_wav2vec2_forward,
 )
@@ -201,3 +202,6 @@ def adapt_transformers_to_gaudi():
     transformers.models.falcon.modeling_falcon.FalconDecoderLayer.forward = gaudi_falcon_decoder_layer_forward
     transformers.models.falcon.modeling_falcon.FalconAttention.forward = gaudi_falcon_attention_forward
     transformers.models.falcon.modeling_falcon.FalconRotaryEmbedding.forward = gaudi_falcon_rotary_embedding_forward
+
+    # Optimization for t5 on Gaudi
+    transformers.models.t5.modeling_t5.T5LayerNorm.forward = gaudi_t5_layernorm_forward

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -66,6 +66,7 @@ from .opt import (
     gaudi_opt_decoder_layer_forward,
     gaudi_opt_model_forward,
 )
+from .t5 import gaudi_t5_layernorm_forward
 from .vit import gaudi_vit_self_attention_forward
 from .wav2vec2 import (
     _gaudi_wav2vec2_compute_mask_indices,

--- a/optimum/habana/transformers/models/t5/__init__.py
+++ b/optimum/habana/transformers/models/t5/__init__.py
@@ -1,0 +1,1 @@
+from .modeling_t5 import gaudi_t5_layernorm_forward

--- a/optimum/habana/transformers/models/t5/modeling_t5.py
+++ b/optimum/habana/transformers/models/t5/modeling_t5.py
@@ -1,0 +1,29 @@
+import torch
+
+
+try:
+    from habana_frameworks.torch.hpex.normalization import FusedRMSNorm as FusedRMSNorm
+except ImportError:
+    print("Not using HPU fused kernel for RMSNorm")
+    FusedRMSNorm = None
+
+
+def gaudi_t5_layernorm_forward(self, hidden_states):
+    """
+    Copied from T5LayerNorm.forward: https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py
+    The only differences are:
+        - override RMSNorm with Habana fused RMSNorm
+    """
+    if not self.training and hidden_states.device.type == "hpu" and FusedRMSNorm:
+        orig_dtype = hidden_states.dtype
+        hidden_states = FusedRMSNorm.apply(hidden_states.float(), self.weight.float(), self.variance_epsilon)
+        return hidden_states.to(orig_dtype)
+    else:
+        variance = hidden_states.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+
+        # convert into half-precision if necessary
+        if self.weight.dtype in [torch.float16, torch.bfloat16]:
+            hidden_states = hidden_states.to(self.weight.dtype)
+
+        return self.weight * hidden_states


### PR DESCRIPTION
# What does this PR do?
Improve the performance of T5.
T5 layernorm is same with RMSNorm.
Test on run_translation

command:
generate 256 tokens for each sample
```python
python run_translation.py     --model_name_or_path t5-large     --do_eval     --source_lang en     --target_lang ro     --source_prefix "translate English to Romanian: "     --dataset_name wmt16     --dataset_config_name ro-en     --output_dir /tmp/tst-translation     --per_device_eval_batch_size 4    --overwrite_output_dir     --predict_with_generate     --use_habana     --use_lazy_mode     --use_hpu_graphs_for_inference     --gaudi_config_name Habana/t5     --ignore_pad_token_for_loss False     --pad_to_max_length --max_target_length=256 --dataloader_drop_last True
```

||before|after|
|-|-|-|
|eval loss|15.0345|15.0345|
|eval_samples_per_second|2.228|2.734|

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
