### PR TITLE
fix gpt_bigcode HCCL issue occured in DDP

### DIFF
--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -221,9 +221,9 @@ def gaudi_gpt_bigcode_model_forward(
     query_length = input_shape[-1]
     key_length = past_length + query_length
     if past_length > 0 and token_idx is not None:
-        self_attention_mask = self.bias[None, past_length - 1 : past_length, :past_length]
+        self_attention_mask = self.bias[None, past_length - 1 : past_length, :past_length].bool()
     else:
-        self_attention_mask = self.bias[None, key_length - query_length : key_length, :key_length]
+        self_attention_mask = self.bias[None, key_length - query_length : key_length, :key_length].bool()
 
     if attention_mask is not None:
         self_attention_mask = self_attention_mask * attention_mask.view(batch_size, 1, -1).to(


### PR DESCRIPTION
Following up on comments from @regisss from this issue # [Error: Getting size for given data type is not supported while fine tuning starcoder model on optimum-habana](https://github.com/huggingface/optimum-habana/issues/350)

this line https://github.com/huggingface/transformers/blob/6a314ea7cd01a78a58403bc83e7c637ef83e6b26/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py#L517 causes HCCL to fail with the below errors.

Similar changes were discussed in the issue https://github.com/huggingface/optimum-habana/issues/350

```bash
Training...
Training...
Training...
terminate called after throwing an instance of 'c10::Error'
  what():  Getting size for given data type is not supported: 0
Exception raised from getHCCLDataSize at /npu-stack/pytorch-integration/python_packages/habana_frameworks/torch/distributed/hccl/ProcessGroupHCCL.cpp:128 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x7ff0b09bd53c in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xfa (0x7ff0b098310c in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #2: <unknown function> + 0x544ea (0x7ff0b02f84ea in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/habana_frameworks/torch/distributed/_hccl_C.so)
frame #3: habana_helpers::JobThread::threadFunction() + 0x128 (0x7ff020da6ae8 in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/habana_frameworks/torch/lib/libhabana_pytorch_plugin.so)
frame #4: <unknown function> + 0xd6df4 (0x7ff0b47dedf4 in /lib/x86_64-linux-gnu/libstdc++.so.6)
frame #5: <unknown function> + 0x8609 (0x7ff0b4ab5609 in /lib/x86_64-linux-gnu/libpthread.so.0)
frame #6: clone + 0x43 (0x7ff0b4bef133 in /lib/x86_64-linux-gnu/libc.so.6)

Internal Error: Received signal - Aborted
terminate called after throwing an instance of 'c10::Error'
  what():  Getting size for given data type is not supported: 0
Exception raised from getHCCLDataSize at /npu-stack/pytorch-integration/python_packages/habana_frameworks/torch/distributed/hccl/ProcessGroupHCCL.cpp:128 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x7f881daf453c in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xfa (0x7f881daba10c in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #2: <unknown function> + 0x544ea (0x7f88161634ea in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/habana_frameworks/torch/distributed/_hccl_C.so)
frame #3: habana_helpers::JobThread::threadFunction() + 0x128 (0x7f8816ee3ae8 in /home/devcloud/habanalabs-venv/lib/python3.8/site-packages/habana_frameworks/torch/lib/libhabana_pytorch_plugin.so)
frame #4: <unknown function> + 0xd6df4 (0x7f8822904df4 in /lib/x86_64-linux-gnu/libstdc++.so.6)
frame #5: <unknown function> + 0x8609 (0x7f8822bdb609 in /lib/x86_64-linux-gnu/libpthread.so.0)
frame #6: clone + 0x43 (0x7f8822d15133 in /lib/x86_64-linux-gnu/libc.so.6)

Internal Error: Received signal - Aborted
terminate called after throwing an instance of 'c10::Error'
  what():  Getting size for given data type is not supported: 0
Exception raised from getHCCLDataSize at /npu-stack/pytorch-integration/python_packages/habana_frameworks/torch/distributed/hccl/ProcessGroupHCCL.cpp:128 (most recent call first):
...

Internal Error: Received signal - Aborted
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 2 with PID 0 on node idc382 exited on signal 6 (Aborted).
```

### Expected behavior

We should be able to complete the training loop without issues. We did try to add a fake `_len_` method inside the `class ConstantLengthDataset(IterableDataset)` class, but it still failed.
```ptyhon
def __len__(self):
    return 10
```

But at the same time I see the following observations:
+ We cannot run the starcoder-7B model on 1 HPU due to OOM
+ We can run the 3B model on 1 HPU, no issue with fetching dataset length
+ We cannot run the 3B model on 8 HPUs (infact > 1 HPU) , fails with the same getting size for data type issue.

So, the issue arises whenever we shift to multliple HPU or distributed training on > 1 HPUs.

A Gaudi2 1 HPU = 96 GB of device memory.

