### PR TITLE
makes the record_shapes of the profiler changeable.

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -772,7 +772,7 @@ class GaudiTrainer(Trainer):
             self.log_evaluate_save_time = 0
         else:
             self.log_evaluate_save_time = None
-            
+
         hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps, record_shapes=self.args.profiling_record_shapes)
         hb_profiler.start()
 

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -772,8 +772,8 @@ class GaudiTrainer(Trainer):
             self.log_evaluate_save_time = 0
         else:
             self.log_evaluate_save_time = None
-            hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps, record_shapes=self.args.profiling_record_shapes)
-
+            
+        hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps, record_shapes=self.args.profiling_record_shapes)
         hb_profiler.start()
 
         total_batched_samples = 0

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -773,7 +773,11 @@ class GaudiTrainer(Trainer):
         else:
             self.log_evaluate_save_time = None
 
-        hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps, record_shapes=self.args.profiling_record_shapes)
+        hb_profiler = HabanaProfile(
+            warmup=self.args.profiling_warmup_steps,
+            active=self.args.profiling_steps,
+            record_shapes=self.args.profiling_record_shapes,
+        )
         hb_profiler.start()
 
         total_batched_samples = 0

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -772,8 +772,8 @@ class GaudiTrainer(Trainer):
             self.log_evaluate_save_time = 0
         else:
             self.log_evaluate_save_time = None
+            hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps, record_shapes=self.args.profiling_record_shapes)
 
-        hb_profiler = HabanaProfile(warmup=self.args.profiling_warmup_steps, active=self.args.profiling_steps)
         hb_profiler.start()
 
         total_batched_samples = 0

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -202,7 +202,7 @@ class GaudiTrainingArguments(TrainingArguments):
     )
 
     profiling_record_shapes: Optional[bool] = field(
-        default=False,
+        default=True,
         metadata={"help": ("Record shapes when enabling profiling.")},
     )
     # Overriding the default value of optim because 'adamw_hf' is deprecated

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -201,6 +201,10 @@ class GaudiTrainingArguments(TrainingArguments):
         metadata={"help": ("Number of steps to be captured when enabling profiling.")},
     )
 
+    profiling_record_shapes: Optional[bool] = field(
+        default=False,
+        metadata={"help": ("Record shapes when enabling profiling.")},
+    )
     # Overriding the default value of optim because 'adamw_hf' is deprecated
     optim: Optional[Union[OptimizerNames, str]] = field(
         default="adamw_torch",

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -235,7 +235,7 @@ class HabanaProfile(object):
 
     HABANA_PROFILE_ENABLED = True
 
-    def __init__(self, warmup: int = 0, active: int = 0, output_dir: str = "./hpu_profile", wait: int = 0):
+    def __init__(self, warmup: int = 0, active: int = 0, record_shapes: bool = True, output_dir: str = "./hpu_profile", wait: int = 0):
         if active <= 0 or warmup <= 0 or not HabanaProfile.HABANA_PROFILE_ENABLED:
 
             def noop():
@@ -253,7 +253,7 @@ class HabanaProfile(object):
                 schedule=schedule,
                 activities=activities,
                 on_trace_ready=torch.profiler.tensorboard_trace_handler(output_dir),
-                record_shapes=True,
+                record_shapes=record_shapes,
                 with_stack=True,
             )
             self.start = profiler.start

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -235,7 +235,14 @@ class HabanaProfile(object):
 
     HABANA_PROFILE_ENABLED = True
 
-    def __init__(self, warmup: int = 0, active: int = 0, record_shapes: bool = True, output_dir: str = "./hpu_profile", wait: int = 0):
+    def __init__(
+        self,
+        warmup: int = 0,
+        active: int = 0,
+        record_shapes: bool = True,
+        output_dir: str = "./hpu_profile",
+        wait: int = 0,
+    ):
         if active <= 0 or warmup <= 0 or not HabanaProfile.HABANA_PROFILE_ENABLED:
 
             def noop():


### PR DESCRIPTION
The default argument of profiler ```record_shapes``` is ```True```. Enabling this may improve memory usage and may lead to some workload crashes with OOM when profiling is enabled. Setting ```record_shapes``` to ```False``` when it is not used could avoid these crashes and enable profiling.  
  
This pr makes the  ```record_shapes``` changeable.


