### PR TITLE
Improve perf and memory usage with reuse cache by slicing inputs till token idx for 1st token generation.

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -202,6 +202,8 @@ def main():
 
     if not args.use_hpu_graphs:
         args.limit_hpu_graphs = False
+        args.reuse_cache = False
+
     # Device is HPU
     args.device = "hpu"
     import habana_frameworks.torch.hpu as torch_hpu

--- a/optimum/habana/transformers/generation/configuration_utils.py
+++ b/optimum/habana/transformers/generation/configuration_utils.py
@@ -27,9 +27,9 @@ class GaudiGenerationConfig(GenerationConfig):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.trim_logits = kwargs.get("trim_logits", False)
-        self.static_shapes = kwargs.get("static_shapes", False)
-        self.ignore_eos = kwargs.get("ignore_eos", False)
-        self.attn_softmax_bf16 = kwargs.get("attn_softmax_bf16", False)
-        self.limit_hpu_graphs = kwargs.get("limit_hpu_graphs", False)
-        self.reuse_cache = kwargs.get("reuse_cache", False)
+        self.trim_logits = kwargs.get("trim_logits", None)
+        self.static_shapes = kwargs.get("static_shapes", None)
+        self.ignore_eos = kwargs.get("ignore_eos", None)
+        self.attn_softmax_bf16 = kwargs.get("attn_softmax_bf16", None)
+        self.limit_hpu_graphs = kwargs.get("limit_hpu_graphs", None)
+        self.reuse_cache = kwargs.get("reuse_cache", None)

--- a/optimum/habana/transformers/generation/configuration_utils.py
+++ b/optimum/habana/transformers/generation/configuration_utils.py
@@ -27,9 +27,9 @@ class GaudiGenerationConfig(GenerationConfig):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.trim_logits = kwargs.get("trim_logits", None)
-        self.static_shapes = kwargs.get("static_shapes", None)
-        self.ignore_eos = kwargs.get("ignore_eos", None)
-        self.attn_softmax_bf16 = kwargs.get("attn_softmax_bf16", None)
-        self.limit_hpu_graphs = kwargs.get("limit_hpu_graphs", None)
-        self.reuse_cache = kwargs.get("reuse_cache", None)
+        self.trim_logits = kwargs.get("trim_logits", False)
+        self.static_shapes = kwargs.get("static_shapes", False)
+        self.ignore_eos = kwargs.get("ignore_eos", False)
+        self.attn_softmax_bf16 = kwargs.get("attn_softmax_bf16", False)
+        self.limit_hpu_graphs = kwargs.get("limit_hpu_graphs", False)
+        self.reuse_cache = kwargs.get("reuse_cache", False)

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -434,9 +434,9 @@ class GaudiGenerationMixin(GenerationMixin):
             generation_config = self.generation_config
 
         generation_config = copy.deepcopy(generation_config)
-        if generation_config.static_shapes is None:
+        if not generation_config.static_shapes:
             generation_config.static_shapes = self.config.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES
-        if generation_config.ignore_eos is None:
+        if not generation_config.ignore_eos:
             generation_config.ignore_eos = lazy_mode
         generation_config.validate()
         model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs
@@ -561,15 +561,19 @@ class GaudiGenerationMixin(GenerationMixin):
                 )
             generation_config.max_length = generation_config.max_new_tokens + input_ids_length
         self._validate_generated_length(generation_config, input_ids_length, has_default_max_length)
+
         # determine whether introduce trim_logits feature
         model_kwargs["trim_logits"] = generation_config.trim_logits
+
         # determine whether attention softmax needs to execute in lower precision
         model_kwargs["attn_softmax_bf16"] = generation_config.attn_softmax_bf16
+
         # determine whether limit_hpu_graphs needs to be used
         model_kwargs["limit_hpu_graphs"] = generation_config.limit_hpu_graphs
 
         # prepare for allocate kv cache
         model_kwargs["reuse_cache"] = generation_config.reuse_cache
+
         if not self.config.is_encoder_decoder:
             calculated_max_length = input_ids.shape[-1]
             if not generation_config.static_shapes and generation_config.max_new_tokens is not None:
@@ -1057,7 +1061,7 @@ class GaudiGenerationMixin(GenerationMixin):
         synced_gpus: bool = False,
         streamer: Optional["BaseStreamer"] = None,
         lazy_mode: Optional[bool] = False,
-        ignore_eos: Optional[bool] = None,
+        ignore_eos: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
         **model_kwargs,
@@ -1108,7 +1112,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
             lazy_mode (`bool`, *optional*, defaults to `False`):
                 Whether the run is executed in lazy mode or not (i.e. eager mode).
-            ignore_eos (`bool`, *optional*):
+            ignore_eos (`bool`, *optional*, defaults to `False`):
                 Whether to ignore finished sequences (faster in lazy mode and with HPU graphs) or not (eager mode).
             profiling_warmup_steps (`int`, *optional*, defaults to 0):
                 Number of steps to ignore for profling.
@@ -1359,7 +1363,7 @@ class GaudiGenerationMixin(GenerationMixin):
         synced_gpus: bool = False,
         streamer: Optional["BaseStreamer"] = None,
         lazy_mode: Optional[bool] = False,
-        ignore_eos: Optional[bool] = None,
+        ignore_eos: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
         **model_kwargs,
@@ -1413,7 +1417,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
             lazy_mode (`bool`, *optional*, defaults to `False`):
                 Whether the run is executed in lazy mode or not (i.e. eager mode).
-            ignore_eos (`bool`, *optional*):
+            ignore_eos (`bool`, *optional*, defaults to `False`):
                 Whether to ignore finished sequences (faster in lazy mode and with HPU graphs) or not (eager mode).
             profiling_warmup_steps (`int`, *optional*, defaults to 0):
                 Number of steps to ignore for profling.

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -434,9 +434,9 @@ class GaudiGenerationMixin(GenerationMixin):
             generation_config = self.generation_config
 
         generation_config = copy.deepcopy(generation_config)
-        if not generation_config.static_shapes:
+        if generation_config.static_shapes is None:
             generation_config.static_shapes = self.config.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES
-        if not generation_config.ignore_eos:
+        if generation_config.ignore_eos is None:
             generation_config.ignore_eos = lazy_mode
         generation_config.validate()
         model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -92,6 +92,9 @@ class GaudiLlamaAttention(LlamaAttention):
             dtype = self.k_proj.weight.dtype
             self.past_key = torch.zeros(key_shape, dtype=dtype, device=device)
             self.past_value = torch.zeros(value_shape, dtype=dtype, device=device)
+        else:
+            self.past_key.fill_(0)
+            self.past_value.fill_(0)
 
     def reorder(self, tensor, beam_idx, dim_a, dim_b):
         updated = tensor.index_select(0, beam_idx)

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -33,7 +33,7 @@ def update(prev, cur, dim, idx):
     orig_cur = cur
     if cur.shape[2] > 1 and cur.shape[2] <= prev.shape[2]:
         # Initialize
-        prev[:,:,:idx,:].copy_(cur)
+        prev[:, :, :idx, :].copy_(cur)
         return orig_cur
     assert cur.shape[2] == 1, f"Cannot update kv-cache. Unsupported shapes. prev:{prev.shape} cur:{cur.shape}"
     if idx is not None:
@@ -555,7 +555,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
             else:
                 input_ids = input_ids[:, -1:]
         elif reuse_cache and token_idx is not None:
-            # With reuse_cache, KV cache is pre allocated hence for the 1st token we can slice the inputs till token idx for the fwd pass 
+            # With reuse_cache, KV cache is pre allocated hence for the 1st token we can slice the inputs till token idx for the fwd pass
             input_ids = input_ids[:, :token_idx]
             attention_mask = attention_mask[:, :token_idx]
 


### PR DESCRIPTION
Reuse cache pre allocates the KV cache. This can be further leveraged to slice the inputs till the token idx for the 1st token inference and improve perf and memory usage by running till the required seq len only rather than running full padded static input (input + max new tokens length). Memory usage and perf will vary according to the actual input seq len but will be better than running full static shapes.

Use torch.zeros to initialize KV cache rather than uninitialized torch.empty.

Also fix bool dtypes default values.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
