### PR TITLE
No need to wrap DDP when using Fast DDP

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1994,6 +1994,7 @@ class GaudiTrainer(Trainer):
             deepspeed_plugin=self.args.deepspeed_plugin,
             gradient_accumulation_plugin=gradient_accumulation_plugin,
             even_batches=self.args.use_lazy_mode and not self.args.dataloader_drop_last,
+            distribution_strategy=self.args.distribution_strategy,
         )
 
         # deepspeed and accelerate flags covering both trainer args and accelerate launcher


### PR DESCRIPTION
# What does this PR do?

When I enable fast ddp with `--distribution_strategy fast_ddp`, the model is wrapped with `torch.nn.parallel.DistributedDataParallel` from `accelerator.prepare_model()`, this could be incorrect since fast ddp handles gradients all-reduce by itself. In this patch, it checks if it's not fast ddp before wrap with `torch.nn.parallel.DistributedDataParallel` in `accelerator`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - no
- [x] Did you make sure to update the documentation with your changes?
  - no need update doc 
- [x] Did you write any new necessary tests?
  - no need new tests