### PR TITLE
Fix falcon-40b error when DeepSpeed enabled

### DIFF
--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -30,7 +30,7 @@ jobs:
       EC2_AMI_ID: ami-02086055ccb243ea2
       EC2_INSTANCE_TYPE: dl1.24xlarge
       EC2_SUBNET_ID: subnet-b7533b96
-      EC2_SECURITY_GROUP: sg-059956d687c7ec5c2
+      EC2_SECURITY_GROUP: sg-08af7938042271373
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}

--- a/examples/text-generation/checkpoint_utils.py
+++ b/examples/text-generation/checkpoint_utils.py
@@ -131,4 +131,9 @@ def get_ds_injection_policy(config):
 
             policy = {LlamaDecoderLayer: ("self_attn.o_proj", "mlp.down_proj")}
 
+        if model_type == "falcon":
+            from transformers.models.falcon.modeling_falcon import FalconDecoderLayer
+
+            policy = {FalconDecoderLayer: ("self_attention.dense", "mlp.dense_4h_to_h")}
+
     return policy

--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -75,7 +75,6 @@ def gaudi_falcon_attention_forward(
     - replace F.scaled_dot_product_attention with Habana torch's version
     """
     fused_qkv = self.query_key_value(hidden_states)  # [batch_size, seq_length, 3 x hidden_size]
-    num_kv_heads = self.num_heads if self.new_decoder_architecture else self.num_kv_heads
     # 3 x [batch_size, seq_length, num_heads, head_dim]
     (query_layer, key_layer, value_layer) = self._split_heads(fused_qkv)
 


### PR DESCRIPTION
This patch fixes the error in falcon-40b with DeepSpeed, where the number of heads was updated by DeepSpeed and became too small. So the number of heads has been removed from the reshape and view ops. Instead, the correct number of heads is now inferred from other dim sizes

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
