### PR TITLE
make sure a match between logits and logits_dtype in evaluation_loop

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1556,6 +1556,7 @@ class GaudiTrainer(Trainer):
                 logits = self.accelerator.pad_across_processes(logits, dim=1, pad_index=-100)
                 if self.preprocess_logits_for_metrics is not None:
                     logits = self.preprocess_logits_for_metrics(logits, labels)
+                    logits_dtype = get_dtype(logits)
                 logits = self.accelerator.gather_for_metrics((logits))
                 preds_host = logits if preds_host is None else nested_concat(preds_host, logits, padding_index=-100)
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In the trainer.py/evaluation_loop function, `logits = self.preprocess_logits_for_metrics(logits, labels)` will change the type of logits from tuple to tensor.  But the logits_dtype obtained from `get_dtype(logits)` is still a list type and does not match the shape of the new logits. this will cause the following error in `all_preds = convert_into_dtypes(all_preds, logits_dtype)`.  So I re-get dtype of logits after `logits = self.preprocess_logits_for_metrics(logits, labels)` to ensure a match between logits and logits_dtype.

![image](https://github.com/huggingface/optimum-habana/assets/82423870/fc1eefc8-c43f-442e-addc-c3c717fdfa58)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
