### PR TITLE
Fixing the relative path in config read

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -268,7 +268,9 @@ if is_torch_available():
 
     def get_gaudi_config(gaudi_config_name_or_path: Optional[Union[str, Path]] = None) -> GaudiConfig:
         if gaudi_config_name_or_path is None:
-            gaudi_config_name_or_path = Path(__file__).parent.resolve() / Path("configs/gaudi_config_trainer_test.json")
+            gaudi_config_name_or_path = Path(__file__).parent.resolve() / Path(
+                "configs/gaudi_config_trainer_test.json"
+            )
         return GaudiConfig.from_pretrained(gaudi_config_name_or_path)
 
     def get_regression_trainer(a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, **kwargs):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -268,7 +268,7 @@ if is_torch_available():
 
     def get_gaudi_config(gaudi_config_name_or_path: Optional[Union[str, Path]] = None) -> GaudiConfig:
         if gaudi_config_name_or_path is None:
-            gaudi_config_name_or_path = os.path.join("tests", "configs", "gaudi_config_trainer_test.json")
+            gaudi_config_name_or_path = Path(__file__).parent.resolve() / Path("configs/gaudi_config_trainer_test.json")
         return GaudiConfig.from_pretrained(gaudi_config_name_or_path)
 
     def get_regression_trainer(a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, **kwargs):

--- a/tests/test_trainer_distributed.py
+++ b/tests/test_trainer_distributed.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
     parser = HfArgumentParser((GaudiTrainingArguments,))
     training_args = parser.parse_args_into_dataclasses()[0]
 
-    gaudi_config = GaudiConfig.from_pretrained(Path("tests", "configs", "gaudi_config_trainer_test.json"))
+    gaudi_config_file = Path(__file__).parent.resolve() / Path("configs/gaudi_config_trainer_test.json")
+    gaudi_config = GaudiConfig.from_pretrained(gaudi_config_file)
 
     logger.warning(
         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_hpu: {training_args.world_size},"


### PR DESCRIPTION
# What does this PR do?
This change will fix the relative path in gaudi config. Instead uses the absolute path in the current execution env.

Fixes # (issue)
Errors caused by relative gaudi config path when test is triggered from a different path.