### PR TITLE
revert temp workaround for deepspeed@1.11 (pr #411)

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -83,10 +83,8 @@ class GaudiLlamaAttention(LlamaAttention):
         self.past_value = None
 
     def allocate_kv_cache(self, batch_size, seq_len):
-        # TODO: update when auto mp params is enabled in DeepSpeed (cf. https://github.com/HabanaAI/DeepSpeed/blob/94309c7b5dfc1a69858f5c9f25737b2f81a332a5/deepspeed/module_inject/replace_module.py#L440)
-        tp_world_size = int(os.environ.get("WORLD_SIZE", 1))
-        key_shape = (batch_size, self.num_key_value_heads // tp_world_size, seq_len, self.head_dim)
-        value_shape = (batch_size, self.num_key_value_heads // tp_world_size, seq_len, self.head_dim)
+        key_shape = (batch_size, self.num_key_value_heads, seq_len, self.head_dim)
+        value_shape = (batch_size, self.num_key_value_heads, seq_len, self.head_dim)
         if self.past_key is None or self.past_key.shape != key_shape:
             device = self.k_proj.weight.device
             dtype = self.k_proj.weight.dtype


### PR DESCRIPTION
deepspeed@1.12.0 has already supported num_key_value_heads

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
8x Llama2-70b run with  --reuse_cache failed on deepspeed@1.12


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
