### PR TITLE
sarkar/Add support for max_length in run_generation

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -466,7 +466,8 @@ def main():
                 profiling_steps=args.profiling_steps,
                 profiling_warmup_steps=args.profiling_warmup_steps,
             ).cpu()
-            return tokenizer.batch_decode(outputs, skip_special_tokens=True), input_tokens['input_ids'].shape[-1]
+            return tokenizer.batch_decode(outputs, skip_special_tokens=True), input_tokens["input_ids"].shape[-1]
+
         from optimum.habana.utils import HabanaProfile
 
         # compilation stage disable profiling
@@ -649,7 +650,9 @@ def main():
             t0 = time.perf_counter()
             prompt, outputs, inp_len = generate_dataset(batch)
             duration += time.perf_counter() - t0
-            total_new_tokens_generated += ((args.max_length - inp_len) if args.max_new_tokens is None else args.max_new_tokens)
+            total_new_tokens_generated += (
+                (args.max_length - inp_len) if args.max_new_tokens is None else args.max_new_tokens
+            )
             if rank in [-1, 0]:
                 print(separator)
                 print(f"Batch n°{i+1}")

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -64,8 +64,18 @@ def main():
         action="store_true",
         help="Whether to perform generation in bf16 precision.",
     )
-    parser.add_argument("--max_new_tokens", type=int, default=100, help="Number of tokens to generate. Mutually exclusive with max_length. Set to negative to disable")
-    parser.add_argument("--max_length", type=int, default=-1, help="Max number of tokens (prompt + generation). Mutually exclusive with max_new_tokens. Set to negative to disable")
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=100,
+        help="Number of tokens to generate. Mutually exclusive with max_length. Set to negative to disable",
+    )
+    parser.add_argument(
+        "--max_length",
+        type=int,
+        default=-1,
+        help="Max number of tokens (prompt + generation). Mutually exclusive with max_new_tokens. Set to negative to disable",
+    )
     parser.add_argument(
         "--max_input_tokens",
         type=int,
@@ -509,7 +519,6 @@ def main():
                 with (output_dir / "results.json").open("w", encoding="utf-8") as f:
                     json.dump(results, f, ensure_ascii=False, indent=4)
             from optimum.habana.utils import get_hpu_memory_stats
-            #import pdb; pdb.set_trace()
 
             stats = f"Throughput (including tokenization) = {throughput} tokens/second"
             separator = "-" * len(stats)
@@ -655,6 +664,8 @@ def main():
         t_end = time.time()
 
         throughput = total_new_tokens_generated / duration
+        if args.max_new_tokens < 0:
+            throughput = "Please use max_new_tokens instead of max_length to get throughput"
         # Print Stats
         if rank in [-1, 0]:
             from optimum.habana.utils import get_hpu_memory_stats

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -499,7 +499,7 @@ class GaudiGenerationMixin(GenerationMixin):
         if generation_config.static_shapes:
             # Pad inputs to have static shapes during generation, this gives better performance than dynamic shapes on HPUs
             # In encoder_decoder models, Inputs are already padded
-            if (generation_config.max_new_tokens is None or generation_config.max_new_tokens < 0):
+            if generation_config.max_new_tokens is None or generation_config.max_new_tokens < 0:
                 assert generation_config.max_length > 0
                 generation_config.max_new_tokens = generation_config.max_length - inputs_tensor.shape[-1]
 

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -499,6 +499,9 @@ class GaudiGenerationMixin(GenerationMixin):
         if generation_config.static_shapes:
             # Pad inputs to have static shapes during generation, this gives better performance than dynamic shapes on HPUs
             # In encoder_decoder models, Inputs are already padded
+            if (generation_config.max_new_tokens is None or generation_config.max_new_tokens < 0):
+                assert generation_config.max_length > 0
+                generation_config.max_new_tokens = generation_config.max_length - inputs_tensor.shape[-1]
 
             if not self.config.is_encoder_decoder:
                 # only pad if bucket_size < -1. If we are bucketing (bucket_size > 0), then that is taken care in greedy_search()


### PR DESCRIPTION
# What does this PR do?
semi fix for this [issue](https://github.com/huggingface/optimum-habana/issues/472)

Add support for max_length (as an alternative for max_new_tokens). The change in `utils.py` is needed if someone specifies `max_length` instead of `max_new_tokens`. The change in `run_generation.py` is to activate and test the `max_length` path

The [issue](https://github.com/huggingface/optimum-habana/issues/472) itself is not fixed fully, but it moves past the error mentioned in the issue.



## Tests:


**runs:**
### only max_new_tokens is specified
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --max_new_tokens 100 --batch 8`

### only max_length is specified
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16  --batch 8 --max_length 100`
 
### only max_length is specified, with bucket
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --batch 8 --max_length 100 --bucket_size 30`
  
### only max_new_tokens is specified, with bucket
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --max_new_tokens 100 --batch 8 --bucket_size 30`

### dataset run with max_length
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --batch 8 --max_length 100 --bucket_size 30 --dataset_name squad --column context --dataset_max_samples 32`

### both are not specified (max_new_tokens defaults to 100, old back compat behaviour)
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --batch 8 `

**(expected) fails**
### both are specified
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --max_new_tokens 100 --batch 8 --max_length 108`
 

 
 
### pytest mentioned in the issue:
`cd optimum-habana/tests/transformers/tests/models/gpt2`
`python -m pytest -vs test_modeling_gpt2.py::GPT2ModelTest::test_beam_search_generate`
The original error is gone now. There is new error 

"""
            if sent_lengths[i] < sent_max_len:
                # inserting only the first eos_token_id
>               decoded[i, sent_lengths[i]] = eos_token_id[0]
E               TypeError: 'NoneType' object is not subscriptable

"""

However not sure if beam search is tested/supported/prioritized for GPT2

FWIW, beam search generations with `run_generation.py` with opt/gpt2 using max_length/max_new_tokens pass:
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --max_new_tokens 100 --batch 8 --num_beams 2`
`python run_generation.py --model_name_or_path gpt2  --use_hpu_graphs --use_kv_cache --bf16 --max_new_tokens 100 --batch 8 --num_beams 2`
`python run_generation.py --model_name_or_path facebook/opt-350m  --use_hpu_graphs --use_kv_cache --bf16 --max_length 100 --batch 8 --num_beams 2`
`python run_generation.py --model_name_or_path gpt2  --use_hpu_graphs --use_kv_cache --bf16 --max_length 100 --batch 8 --num_beams 2`


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (472)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
