### PR TITLE
Add default model_kwargs to Generation Tester

### DIFF
--- a/tests/transformers/tests/generation/test_utils.py
+++ b/tests/transformers/tests/generation/test_utils.py
@@ -84,6 +84,11 @@ class GenerationTesterMixin:
     all_generative_model_classes = ()
     input_name = "input_ids"
 
+    def _update_default_model_kwargs(self, model_kwargs):
+        model_kwargs["limit_hpu_graphs"] = False
+        model_kwargs["reuse_cache"] = False
+        model_kwargs["bucket_size"] = -1
+
     def _get_input_ids_and_config(self, batch_size=2):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         input_ids = inputs_dict[self.input_name]
@@ -268,6 +273,7 @@ class GenerationTesterMixin:
 
         kwargs = {}
         model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
+
         output_generate = model.generate(
             input_ids,
             do_sample=False,
@@ -294,6 +300,7 @@ class GenerationTesterMixin:
 
         with torch.no_grad():
             model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
+            self._update_default_model_kwargs(model_kwargs)
             output_greedy = model.greedy_search(
                 input_ids,
                 max_length=max_length,
@@ -423,6 +430,7 @@ class GenerationTesterMixin:
 
         with torch.no_grad():
             model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
+            self._update_default_model_kwargs(model_kwargs)
             output_beam_search = model.beam_search(
                 input_ids.repeat_interleave(beam_scorer.num_beams, dim=0),
                 beam_scorer,
@@ -552,6 +560,8 @@ class GenerationTesterMixin:
 
         with torch.no_grad():
             model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
+            self._update_default_model_kwargs(model_kwargs)
+
             output_group_beam_search = model.group_beam_search(
                 input_ids.repeat_interleave(beam_scorer.num_beams, dim=0),
                 beam_scorer,
@@ -615,6 +625,7 @@ class GenerationTesterMixin:
 
         with torch.no_grad():
             model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
+            self._update_default_model_kwargs(model_kwargs)
             output_group_beam_search = model.constrained_beam_search(
                 input_ids.repeat_interleave(constrained_beam_scorer.num_beams, dim=0),
                 constrained_beam_scorer,


### PR DESCRIPTION
These are fixes for issues caught while executing the transformers tests. The issues are captured in https://github.com/huggingface/optimum-habana/issues/445 and
 https://github.com/huggingface/optimum-habana/issues/446

Addressed based on suggestion give here : https://github.com/huggingface/optimum-habana/pull/470#issuecomment-1773121023

@regisss  : please help with the review 

TCs impacted ( listed for t5 but these are common TCs impacting all language models)

==============================================================
FAILED test_modeling_t5.py::T5ModelTest::test_beam_search_generate - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_beam_search_generate_dict_output - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_beam_search_generate_dict_outputs_use_cache - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_constrained_beam_search_generate - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_constrained_beam_search_generate_dict_output - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_greedy_generate - KeyError: 'bucket_size'
FAILED test_modeling_t5.py::T5ModelTest::test_greedy_generate_dict_outputs - KeyError: 'bucket_size'
FAILED test_modeling_t5.py::T5ModelTest::test_greedy_generate_dict_outputs_use_cache - KeyError: 'bucket_size'

FAILED test_modeling_t5.py::T5ModelTest::test_sample_generate - KeyError: 'limit_hpu_graphs'
FAILED test_modeling_t5.py::T5ModelTest::test_sample_generate_dict_output - KeyError: 'limit_hpu_graphs'