### PR TITLE
Fix deepspeed init issue when using external launcher.

### DIFF
--- a/optimum/habana/accelerate/state.py
+++ b/optimum/habana/accelerate/state.py
@@ -54,15 +54,14 @@ class GaudiPartialState(PartialState):
                             " git+https://github.com/HabanaAI/DeepSpeed.git@1.12.0`."
                         )
                     self.distributed_type = GaudiDistributedType.DEEPSPEED
-                    if not torch.distributed.is_initialized():
-                        import deepspeed
+                    import deepspeed
 
-                        if world_size > 1:
-                            os.environ["HLS_MODULE_ID"] = str(local_rank)
-                            os.environ["ID"] = str(rank)
+                    if world_size > 1:
+                        os.environ["HLS_MODULE_ID"] = str(local_rank)
+                        os.environ["ID"] = str(rank)
 
-                        deepspeed.init_distributed(dist_backend=self.backend, **kwargs)
-                        logger.info("DeepSpeed is enabled.")
+                    deepspeed.init_distributed(dist_backend=self.backend, **kwargs)
+                    logger.info("DeepSpeed is enabled.")
                     self._mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
                 else:
                     self.distributed_type = GaudiDistributedType.MULTI_HPU


### PR DESCRIPTION
If using ray or torchrun to launch the distributed finetune or training with deepspeed, No need to check the torch.distributed.is_initialized, the deepspeed.ini_dist will check it and assign the TorchBackend to cdb

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
