### PR TITLE
Enable llama attention softmax in bf16

### DIFF
--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -130,6 +130,10 @@ class ModelArguments:
             )
         },
     )
+    attn_softmax_bf16: bool = field(
+        default=False,
+        metadata={"help": ("Whether to run attention softmax layer in bf16 precision",)},
+    )
 
 
 @dataclass
@@ -466,6 +470,8 @@ def main():
         model.generation_config.pad_token_id = 0
         model.generation_config.bos_token_id = 1
         model.generation_config.eos_token_id = 2
+        if model_args.attn_softmax_bf16:
+            model.generation_config.attn_softmax_bf16 = True
 
     if hasattr(model.generation_config, "pad_token_id") and model.generation_config.pad_token_id is not None:
         tokenizer.pad_token_id = model.generation_config.pad_token_id

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -407,7 +407,7 @@ class GaudiLlamaModel(LlamaModel):
                 def create_custom_forward(module):
                     def custom_forward(*inputs):
                         # None for past_key_value
-                        return module(*inputs, past_key_value, output_attentions)
+                        return module(*inputs, past_key_value, output_attentions, attn_softmax_bf16=attn_softmax_bf16)
 
                     return custom_forward
 

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -853,8 +853,8 @@ class GaudiTrainer(Trainer):
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
                 # attn_softmax_bf16 is enabled only for llama
-                if self.model.config.model_type == "llama":
-                    if self.model.generation_config.attn_softmax_bf16:
+                if hasattr(self.model, "generation_config"):
+                    if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
                         inputs["attn_softmax_bf16"] = True
 
                 # TODO: keep syncs for fast DDP?
@@ -1568,8 +1568,8 @@ class GaudiTrainer(Trainer):
                     batch_size = observed_batch_size
 
             # attn_softmax_bf16 is enabled only for llama
-            if self.model.config.model_type == "llama":
-                if self.model.generation_config.attn_softmax_bf16:
+            if hasattr(self.model, "generation_config"):
+                if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
                     inputs["attn_softmax_bf16"] = True
 
             # Prediction step

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -852,6 +852,9 @@ class GaudiTrainer(Trainer):
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
+                if self.model.generation_config.attn_softmax_bf16:
+                    inputs["attn_softmax_bf16"] = True
+
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
                     tr_loss_step = self.training_step(model, inputs)
@@ -1561,6 +1564,9 @@ class GaudiTrainer(Trainer):
                 # For batch samplers, batch_size is not known by the dataloader in advance.
                 if batch_size is None:
                     batch_size = observed_batch_size
+
+            if self.model.generation_config.attn_softmax_bf16:
+                inputs["attn_softmax_bf16"] = True
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -852,7 +852,8 @@ class GaudiTrainer(Trainer):
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                if self.model.generation_config.attn_softmax_bf16:
+                # attn_softmax_bf16 is enabled only for llama
+                if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
                     inputs["attn_softmax_bf16"] = True
 
                 # TODO: keep syncs for fast DDP?
@@ -1565,7 +1566,8 @@ class GaudiTrainer(Trainer):
                 if batch_size is None:
                     batch_size = observed_batch_size
 
-            if self.model.generation_config.attn_softmax_bf16:
+            # attn_softmax_bf16 is enabled only for llama
+            if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
                 inputs["attn_softmax_bf16"] = True
 
             # Prediction step

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -853,8 +853,9 @@ class GaudiTrainer(Trainer):
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
                 # attn_softmax_bf16 is enabled only for llama
-                if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
-                    inputs["attn_softmax_bf16"] = True
+                if self.model.config.model_type == "llama":
+                    if self.model.generation_config.attn_softmax_bf16:
+                        inputs["attn_softmax_bf16"] = True
 
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
@@ -1567,8 +1568,9 @@ class GaudiTrainer(Trainer):
                     batch_size = observed_batch_size
 
             # attn_softmax_bf16 is enabled only for llama
-            if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
-                inputs["attn_softmax_bf16"] = True
+            if self.model.config.model_type == "llama":
+                if self.model.generation_config.attn_softmax_bf16:
+                    inputs["attn_softmax_bf16"] = True
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)

--- a/tests/baselines/llama_7b.json
+++ b/tests/baselines/llama_7b.json
@@ -17,7 +17,8 @@
                         "--use_hpu_graphs_for_inference",
                         "--dataset_concatenation",
                         "--validation_split_percentage 10",
-                        "--max_steps 100"
+                        "--max_steps 100",
+                        "--attn_softmax_bf16"
                     ]
                 }
             }
@@ -53,7 +54,8 @@
                         "--low_cpu_mem_usage True",
                         "--adam_epsilon 1e-08",
                         "--ddp_bucket_cap_mb 50",
-                        "--validation_split_percentage 10"
+                        "--validation_split_percentage 10",
+                        "--attn_softmax_bf16"
                     ]
                 }
             }


### PR DESCRIPTION
This PR adds an input arg to enable BF16 attention softmax layer for Llama finetuning.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
