### PR TITLE
fixing update method - avoid copy idx to cpu which splitting the graph

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -34,11 +34,11 @@ except ImportError:
     FusedRMSNorm = None
 
 
-def update(prev, cur, dim, idx):
+def update(prev, cur, dim, idx, inp_seq_len):
     orig_cur = cur
     if cur.shape[2] > 1 and cur.shape[2] <= prev.shape[2]:
         # Initialize
-        prev[:, :, :idx, :].copy_(cur)
+        prev[:, :, :inp_seq_len, :].copy_(cur)
         return orig_cur
     assert cur.shape[2] == 1, f"Cannot update kv-cache. Unsupported shapes. prev:{prev.shape} cur:{cur.shape}"
     if idx is not None:
@@ -86,16 +86,21 @@ class GaudiLlamaAttention(LlamaAttention):
 
         self.past_key = None
         self.past_value = None
+        self.inp_seq_len = -1
 
-    def allocate_kv_cache(self, batch_size, seq_len):
-        key_shape = (batch_size, self.num_key_value_heads, seq_len, self.head_dim)
-        value_shape = (batch_size, self.num_key_value_heads, seq_len, self.head_dim)
+    def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):
+        key_shape = (batch_size, self.num_key_value_heads, max_seq_len, self.head_dim)
+        value_shape = (batch_size, self.num_key_value_heads, max_seq_len, self.head_dim)
         if self.past_key is None or self.past_key.shape != key_shape:
+            self.inp_seq_len = inp_seq_len
             device = self.k_proj.weight.device
             dtype = self.k_proj.weight.dtype
             self.past_key = torch.zeros(key_shape, dtype=dtype, device=device)
             self.past_value = torch.zeros(value_shape, dtype=dtype, device=device)
         else:
+            assert (
+                self.inp_seq_len == inp_seq_len
+            ), f"inp_seq_len must be the same. self.inp_seq_len:{self.inp_seq_len} inp_seq_len:{inp_seq_len}"
             self.past_key.fill_(0)
             self.past_value.fill_(0)
 
@@ -182,8 +187,8 @@ class GaudiLlamaAttention(LlamaAttention):
             else:
                 past_key = past_key_value[0]
                 past_value = past_key_value[1]
-            key_states = update(past_key, key_states, 2, token_idx)
-            value_states = update(past_value, value_states, 2, token_idx)
+            key_states = update(past_key, key_states, 2, token_idx, self.inp_seq_len)
+            value_states = update(past_value, value_states, 2, token_idx, self.inp_seq_len)
 
         if use_cache:
             if reuse_cache:
@@ -245,8 +250,8 @@ class GaudiLlamaAttention(LlamaAttention):
 
 
 class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
-    def allocate_kv_cache(self, batch_size, seq_len):
-        self.self_attn.allocate_kv_cache(batch_size, seq_len)
+    def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):
+        self.self_attn.allocate_kv_cache(batch_size, max_seq_len, inp_seq_len)
 
     def reorder_kv_cache(self, beam_idx: torch.LongTensor):
         return self.self_attn.reorder_kv_cache(beam_idx)
@@ -305,9 +310,9 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
 
 
 class GaudiLlamaModel(LlamaModel):
-    def allocate_kv_cache(self, batch_size, seq_len):
+    def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):
         for layer in self.layers:
-            layer.allocate_kv_cache(batch_size, seq_len)
+            layer.allocate_kv_cache(batch_size, max_seq_len, inp_seq_len)
 
     def reorder_kv_cache(self, beam_idx: torch.LongTensor):
         return tuple(layer.reorder_kv_cache(beam_idx) for layer in self.layers)
@@ -464,8 +469,8 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
     - add new args reuse_cache
     """
 
-    def allocate_kv_cache(self, batch_size, seq_len):
-        self.model.allocate_kv_cache(batch_size, seq_len)
+    def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):
+        self.model.allocate_kv_cache(batch_size, max_seq_len, inp_seq_len)
 
     def reorder_kv_cache(self, beam_idx: torch.LongTensor):
         return self.model.reorder_kv_cache(beam_idx)


### PR DESCRIPTION
fixing update method - avoid copy idx to cpu which splitting the graph
issue description:
in the update method when calling to 
prev[:, :, :idx, :].copy_(cur)

the split method is using scalars and not tensors, so pytorch convert the tensor to scalar and only then call to split..
so once we need to convert the tensor to scalar, the bridge is doing mark step and splitting the graph until this point..