### PR TITLE
Update PEFT model example

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -184,14 +184,14 @@ You can also provide the path to a PEFT model to perform generation with the arg
 For example:
 ```bash
 python run_generation.py \
---model_name_or_path huggyllama/llama-7b \
+--model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \
 --use_kv_cache \
 --batch_size 1 \
 --bf16 \
 --max_new_tokens 100 \
 --prompt "Here is my prompt" \
---peft_model AhmedSSoliman/Llama2-CodeGen-PEFT-QLoRA
+--peft_model goliaro/llama-2-7b-lora-full
 ```
 
 ### Using growing bucket optimization

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -178,7 +178,7 @@ python run_generation.py \
 --bf16 \
 --max_new_tokens 100 \
 --prompt "Here is my prompt" \
---peft_model trl-lib/llama-7b-se-rm-peft
+--peft_model AhmedSSoliman/Llama2-CodeGen-PEFT-QLoRA
 ```
 
 ### Using growing bucket optimization

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,2 +1,2 @@
 datasets
-peft
+peft==0.5.0

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,2 +1,2 @@
 datasets
-peft==0.5.0
+peft


### PR DESCRIPTION
# What does this PR do?
model trl-lib/llama-7b-se-rm-peft(one of example in text_generation example) is not compatible with peft v.0.6.0.
Change the example model to other llama-7b-peft model which doesn't use old config parameter. 

https://huggingface.co/trl-lib/llama-7b-se-rm-peft/discussions/3

