### PR TITLE
Fix split by whitespaces not a single space

### DIFF
--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -215,7 +215,7 @@ def get_habana_frameworks_version():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    return version.parse(output.stdout.split("\n")[0].split(" ")[-1])
+    return version.parse(output.stdout.split("\n")[0].split()[-1])
 
 
 def get_driver_version():


### PR DESCRIPTION
Example for a run:
====================================
output.stdout:
'habana-torch-plugin     1.14.0.71         \n'
====================================
output.stdout.split("\n")[0].split(" "):
['habana-torch-plugin', '', '', '', '', '1.14.0.71', '', '', '', '', '', '', '', '', '']
so taking the -1 will result in an empty string
====================================
output.stdout.split("\n")[0].split():
['habana-torch-plugin', '1.14.0.71']
so taking -1 will result in the version
