### PR TITLE
Add LIMIT_HPU_GRAPH option to save memory for prefill OOM issue

### DIFF
--- a/text-generation-inference/README.md
+++ b/text-generation-inference/README.md
@@ -68,6 +68,7 @@ Enviroment Variables Added:
 |  PROF_STEP            | interger       | 5           | Control profile step                                                         |  add -e in docker run command  |
 |  PROF_PATH            | string         | /root/text-generation-inference                                   | Define profile folder  | add -e in docker run command  |
 |  POST_PROCESS_CPU     | 0/1            | 1           | Define post process device          | add -e in docker run command, for smaller model like bloom-560m, 0 has better performance |
+| LIMIT_HPU_GRAPH       | True/False     | False       | Skip HPU graphr usage for prefill to save memory | add -e in docker run command |
 
 </div>
 

--- a/text-generation-inference/server/text_generation_server/models/causal_lm.py
+++ b/text-generation-inference/server/text_generation_server/models/causal_lm.py
@@ -688,14 +688,20 @@ class CausalLM(Model):
         return self.tokenizer.decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)
 
     def forward(
-        self, input_ids, attention_mask, position_ids, token_idx=None, past_key_values: Optional = None, bypass_hpu_graph: Optional = False,
+        self,
+        input_ids,
+        attention_mask,
+        position_ids,
+        token_idx=None,
+        past_key_values: Optional = None,
+        bypass_hpu_graph: Optional = False,
     ) -> Tuple[torch.Tensor, List[Tuple[torch.Tensor, torch.Tensor]]]:
         # Model Forward
         kwargs = {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "past_key_values": past_key_values,
-            "bypass_hpu_graphs": bypass_hpu_graph
+            "bypass_hpu_graphs": bypass_hpu_graph,
         }
 
         if self.is_optimized_for_gaudi:
@@ -739,7 +745,7 @@ class CausalLM(Model):
             batch.position_ids,
             token_idx,
             batch.past_key_values,
-            bypass_hpu_graph = True if prefill and self.limit_hpu_graph is True else False,
+            bypass_hpu_graph=True if prefill and self.limit_hpu_graph is True else False,
         )
         logsoftmax = torch.softmax(logits[:, -1], -1)
 

--- a/text-generation-inference/server/text_generation_server/models/causal_lm.py
+++ b/text-generation-inference/server/text_generation_server/models/causal_lm.py
@@ -636,6 +636,8 @@ class CausalLM(Model):
         else:
             self.is_optimized_for_gaudi = False
 
+        self.limit_hpu_graph = True if os.getenv("LIMIT_HPU_GRAPH", "False") != "False" else False
+
         if tokenizer.pad_token_id is None:
             if model.config.pad_token_id is not None:
                 tokenizer.pad_token_id = model.config.pad_token_id
@@ -686,13 +688,14 @@ class CausalLM(Model):
         return self.tokenizer.decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)
 
     def forward(
-        self, input_ids, attention_mask, position_ids, token_idx=None, past_key_values: Optional = None
+        self, input_ids, attention_mask, position_ids, token_idx=None, past_key_values: Optional = None, bypass_hpu_graph: Optional = False,
     ) -> Tuple[torch.Tensor, List[Tuple[torch.Tensor, torch.Tensor]]]:
         # Model Forward
         kwargs = {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "past_key_values": past_key_values,
+            "bypass_hpu_graphs": bypass_hpu_graph
         }
 
         if self.is_optimized_for_gaudi:
@@ -736,6 +739,7 @@ class CausalLM(Model):
             batch.position_ids,
             token_idx,
             batch.past_key_values,
+            bypass_hpu_graph = True if prefill and self.limit_hpu_graph is True else False,
         )
         logsoftmax = torch.softmax(logits[:, -1], -1)
 


### PR DESCRIPTION
# What does this PR do?

When sequence_length is large, we are getting out of memory on LLama70b for 8x. Adding an option to turn on/off HPU graph for just for the prefill. 

Environment variable "LIMIT_HPU_GRAPH=True" to be added to Docker run command  to enable this feature. 

command fails without this change with OOM error. 
 text-generation-benchmark -t /mnt/weka/data/llama_inference/Llama-2-70b-hf/ --batch-size 32 -s 300 -d 212 -r 2
 
 

