### PR TITLE
Add fallback for PEFT when the base model doesn't exist

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -198,11 +198,8 @@ def peft_model(args, model_dtype, logger, **model_kwargs):
         try:
             list_repo_files(base_model_name)
             base_model_is_remote = True
-        except Exception as e:
-            if "Repository Not Found" in str(e):
-                base_model_is_remote = False
-            else:
-                raise e
+        except Exception:
+            base_model_is_remote = False
 
     if base_model_is_local or base_model_is_remote:
         model = AutoPeftModelForCausalLM.from_pretrained(args.peft_model, torch_dtype=model_dtype, **model_kwargs)

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -201,6 +201,8 @@ def peft_model(args, model_dtype, logger, **model_kwargs):
         except Exception as e:
             if "Repository Not Found" in str(e):
                 base_model_is_remote = False
+            else:
+                raise e
 
     if base_model_is_local or base_model_is_remote:
         model = AutoPeftModelForCausalLM.from_pretrained(args.peft_model, torch_dtype=model_dtype, **model_kwargs)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The PEFT config contains the path to the base model but sometimes this path doesn't exist locally or remotely. This PR enables to fall back to the regular model argument which will be used as the base one.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
