### PR TITLE
no need to unsqueeze input_id in prepare_inputs_for_generation

### DIFF
--- a/optimum/habana/transformers/models/codegen/modeling_codegen.py
+++ b/optimum/habana/transformers/models/codegen/modeling_codegen.py
@@ -417,9 +417,9 @@ class GaudiCodeGenForCausalLM(CodeGenForCausalLM):
         # only last token for inputs_ids if past is defined in kwargs
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1).unsqueeze(-1)
+                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
                 if token_type_ids is not None:
-                    token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1).unsqueeze(-1)
+                    token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1)
             else:
                 input_ids = input_ids[:, -1].unsqueeze(-1)
                 if token_type_ids is not None:

--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -352,9 +352,9 @@ class GaudiGPTBigCodeForCausalLM(GPTBigCodeForCausalLM):
         # only last token for inputs_ids if past is defined in kwargs
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1).unsqueeze(-1)
+                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
                 if token_type_ids is not None:
-                    token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1).unsqueeze(-1)
+                    token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1)
             else:
                 input_ids = input_ids[:, -1].unsqueeze(-1)
                 if token_type_ids is not None:


### PR DESCRIPTION
when using startcode and codegen for text generation, when --do_sample is enabled in the command line. error like
Traceback (most recent call last):
  File "/intel-extension-for-transformers/optimum-habana/examples/text-generation/run_generation.py", line 484, in <module>
    main()
  File "/intel-extension-for-transformers/optimum-habana/examples/text-generation/run_generation.py", line 288, in main
    generate()
  File "/intel-extension-for-transformers/optimum-habana/examples/text-generation/run_generation.py", line 269, in generate
    outputs = model.generate(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/intel-extension-for-transformers/optimum-habana/optimum/habana/transformers/generation/utils.py", line 849, in generate
    return self.sample(
  File "/intel-extension-for-transformers/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1695, in sample
    outputs = self(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1504, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 631, in forward
    return wrapped_hpugraph_forward(cache, stream, orig_fwd, args, kwargs, disable_tensor_cache, asynchronous, dry_run, max_graphs)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 544, in wrapped_hpugraph_forward
    copy_to(cached.graph_inputs, inputs)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 412, in copy_to
    copy_to(d, s)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 409, in copy_to
    copy_to(dv, sv)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 414, in copy_to
    dst.copy_(src, non_blocking=True)
RuntimeError: Graph compile failed. synStatus=synStatus 26 [Generice failure].
 