### PR TITLE
Support for FlashAttention in Llama2

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -212,6 +212,11 @@ def setup_parser(parser):
         help="Store kv-cache in float8 when kv-cache is used",
     )
     parser.add_argument("--fp8", action="store_true", help="Enable Quantization to fp8")
+    parser.add_argument(
+        "--use_flash_attention",
+        action="store_true",
+        help="Whether to enable Habana Flash Attention.",
+    )
 
     args = parser.parse_args()
 

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -215,7 +215,7 @@ def setup_parser(parser):
     parser.add_argument(
         "--use_flash_attention",
         action="store_true",
-        help="Whether to enable Habana Flash Attention.",
+        help="Whether to enable Habana Flash Attention, provided that the model supports it.",
     )
 
     args = parser.parse_args()

--- a/optimum/habana/transformers/generation/configuration_utils.py
+++ b/optimum/habana/transformers/generation/configuration_utils.py
@@ -29,6 +29,8 @@ class GaudiGenerationConfig(GenerationConfig):
         Only active if `static_shapes` is used. Can't be used with `reuse_cache`.
     kv_cache_fp8 (`bool`, *optional*):
         Store kv-cache in float8 when kv-cache is used
+    use_flash_attention (`bool`, *optional*):
+        Whether to use flash attention optimization.
     """
 
     def __init__(self, **kwargs):
@@ -41,3 +43,4 @@ class GaudiGenerationConfig(GenerationConfig):
         self.reuse_cache = kwargs.get("reuse_cache", None)
         self.bucket_size = kwargs.get("bucket_size", -1)
         self.kv_cache_fp8 = kwargs.get("kv_cache_fp8", None)
+        self.use_flash_attention = kwargs.get("use_flash_attention", None)

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -670,6 +670,9 @@ class GaudiGenerationMixin(GenerationMixin):
         # prepare for allocate kv cache
         model_kwargs["reuse_cache"] = generation_config.reuse_cache
 
+        # determine whether flash attention needs to be used
+        model_kwargs["use_flash_attention"] = generation_config.use_flash_attention
+
         if not self.config.is_encoder_decoder:
             calculated_max_length = input_ids.shape[-1]
             if not generation_config.static_shapes and generation_config.max_new_tokens is not None:

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -539,7 +539,8 @@ class GaudiLlamaModel(LlamaModel):
                 def create_custom_forward(module):
                     def custom_forward(*inputs):
                         # None for past_key_value
-                        return module(*inputs, past_key_value, output_attentions, attn_softmax_bf16=attn_softmax_bf16)
+                        return module(*inputs, past_key_value, output_attentions, attn_softmax_bf16=attn_softmax_bf16,
+                                      use_flash_attention=use_flash_attention)
 
                     return custom_forward
 
@@ -727,6 +728,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
                 "trim_logits": kwargs.get("trim_logits"),
                 "attn_softmax_bf16": kwargs.get("attn_softmax_bf16"),
                 "reuse_cache": reuse_cache,
+                "use_flash_attention": kwargs.get("use_flash_attention")
             }
         )
         return model_inputs

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -838,7 +838,7 @@ class GaudiTrainer(Trainer):
                         if self.model.generation_config.attn_softmax_bf16:
                             inputs["attn_softmax_bf16"] = True
                         if self.model.generation_config.use_flash_attention:
-                            inputs["use_flash_attention"] = False
+                            inputs["use_flash_attention"] = True
 
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
@@ -1539,7 +1539,7 @@ class GaudiTrainer(Trainer):
                     if self.model.generation_config.attn_softmax_bf16:
                         inputs["attn_softmax_bf16"] = True
                     if self.model.generation_config.use_flash_attention:
-                        inputs["use_flash_attention"] = False
+                        inputs["use_flash_attention"] = True
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -832,10 +832,13 @@ class GaudiTrainer(Trainer):
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                # attn_softmax_bf16 is enabled only for llama
+                # attn_softmax_bf16 and use_flash_attention is enabled only for llama
                 if hasattr(self.model, "generation_config") and self.model.generation_config is not None:
-                    if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
-                        inputs["attn_softmax_bf16"] = True
+                    if self.model.config.model_type == "llama":
+                        if self.model.generation_config.attn_softmax_bf16:
+                            inputs["attn_softmax_bf16"] = True
+                        if self.model.generation_config.use_flash_attention:
+                            inputs["use_flash_attention"] = False
 
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
@@ -1530,10 +1533,13 @@ class GaudiTrainer(Trainer):
                 if batch_size is None:
                     batch_size = observed_batch_size
 
-            # attn_softmax_bf16 is enabled only for llama
+            # attn_softmax_bf16 and use_flash_attention are enabled only for llama
             if hasattr(self.model, "generation_config") and self.model.generation_config is not None:
-                if self.model.config.model_type == "llama" and self.model.generation_config.attn_softmax_bf16:
-                    inputs["attn_softmax_bf16"] = True
+                if self.model.config.model_type == "llama":
+                    if self.model.generation_config.attn_softmax_bf16:
+                        inputs["attn_softmax_bf16"] = True
+                    if self.model.generation_config.use_flash_attention:
+                        inputs["use_flash_attention"] = False
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)


### PR DESCRIPTION
# What does this PR do?

This PR introduces support for FusedSDPA operator (Flash Attention) in Llama2.

Below are preliminary results from this change:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wszczure/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wszczure/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{text-align:center;
	vertical-align:middle;}
.xl66
	{mso-number-format:Fixed;
	text-align:center;
	vertical-align:middle;}
.xl67
	{mso-number-format:"0\.000";
	text-align:center;
	vertical-align:middle;}
.xl68
	{text-align:center;
	vertical-align:middle;
	white-space:normal;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


Model | BS | Max input tokens | Max new tokens | Default performance   [tokens/second] | Performance with FusedSDPA   [tokens/second] | Throughput improvement over   default | Default memory allocated [GB] | Memory allocated with   FusedSDPA [GB] | Memory reduction over default [GB]
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
7B 1x | 1 | 16 | 4096 | 124.12 | 124.130 | 1.000 | 14.71 | 14.69 | 0.02
  | 4 | 16 | 4096 | 354.27 | 354.500 | 1.001 | 20.81 | 20.71 | 0.10
13B 1x | 1 | 16 | 4096 | 68.81 | 68.840 | 1.000 | 27.57 | 27.54 | 0.03
  | 4 | 16 | 4096 | 203.63 | 203.790 | 1.001 | 37.05 | 36.95 | 0.10
70B 8x | 1 | 16 | 100 | 55.55 | 56.440 | 1.016 | 16.68 | 16.66 | 0.02
  | 40 | 16 | 100 | 1875.95 | 1893.266 | 1.009 | 18.55 | 17.21 | 1.34
  | 1 | 16 | 2048 | 60.23 | 59.617 | 0.990 | 16.76 | 16.74 | 0.02
  | 40 | 16 | 2048 | 1685.81 | 1686.918 | 1.001 | 21.25 | 20.27 | 0.98
  | 60 | 16 | 2048 | 2206.59 | 2208.290 | 1.001 | 24.67 | 22.09 | 2.58
  | 1 | 16 | 4096 | 59.77 | 59.044 | 0.988 | 16.86 | 16.82 | 0.04
  | 40 | 16 | 4096 | 1366.84 | 1368.552 | 1.001 | 24.99 | 23.50 | 1.49
  | 60 | 16 | 4096 | 1689.34 | 1689.680 | 1.0 | 30.09 | 26.92 | 3.17



</body>

</html>

By default this is turned off.