### PR TITLE
Fix for Falcon error from PR #587

### DIFF
--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -340,7 +340,9 @@ def check_habana_frameworks_version(req_version):
     """
     Checks if the installed version of `habana_frameworks` is equal to `req_version`.
     """
-    return get_habana_frameworks_version() == version.parse(req_version)
+    return (
+        get_habana_frameworks_version().major == version.parse(req_version).major
+    ) and (get_habana_frameworks_version().minor == version.parse(req_version).minor)
 
 
 def get_device_name():

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -340,9 +340,9 @@ def check_habana_frameworks_version(req_version):
     """
     Checks if the installed version of `habana_frameworks` is equal to `req_version`.
     """
-    return (
-        get_habana_frameworks_version().major == version.parse(req_version).major
-    ) and (get_habana_frameworks_version().minor == version.parse(req_version).minor)
+    return (get_habana_frameworks_version().major == version.parse(req_version).major) and (
+        get_habana_frameworks_version().minor == version.parse(req_version).minor
+    )
 
 
 def get_device_name():


### PR DESCRIPTION
After the PR #587, Falcon inference fails with Synapse 1.13.0 because this comparison in here always returns False.
 https://github.com/huggingface/optimum-habana/blob/21238af3e2e4eff84d1db3315d977004c49b45b4/optimum/habana/utils.py#L343 

This is because get_habana_frameworks_version() returns 1.13.0.xxx whereas version.parse(req_version) is 1.13.0.
Thus this PR was created to compare the major and minor versions.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
