### PR TITLE
fix beamsearch crash and incorrect output in decode-only model and en…

### DIFF
--- a/optimum/habana/transformers/generation/__init__.py
+++ b/optimum/habana/transformers/generation/__init__.py
@@ -1,2 +1,7 @@
 from .configuration_utils import GaudiGenerationConfig
+from .stopping_criteria import (
+    gaudi_MaxLengthCriteria_call,
+    gaudi_MaxNewTokensCriteria_call,
+    gaudi_StoppingCriteriaList_call,
+)
 from .utils import MODELS_OPTIMIZED_WITH_STATIC_SHAPES, GaudiGenerationMixin

--- a/optimum/habana/transformers/generation/stopping_criteria.py
+++ b/optimum/habana/transformers/generation/stopping_criteria.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# Copyright 2022 The Google AI Language Team Authors, Facebook AI Research authors and The HuggingFace Inc. team.
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from optimum.utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+def gaudi_MaxLengthCriteria_call(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+    token_idx = kwargs.get("token_idx", None)
+    if token_idx is not None:
+        return token_idx >= self.max_length
+    else:
+        cur_len = input_ids.shape[-1]
+        is_done = cur_len >= self.max_length
+        if self.max_position_embeddings is not None and not is_done and cur_len >= self.max_position_embeddings:
+            logger.warning_once(
+                "This is a friendly reminder - the current text generation call will exceed the model's predefined "
+                f"maximum length ({self.max_position_embeddings}). Depending on the model, you may observe "
+                "exceptions, performance degradation, or nothing at all."
+            )
+        return is_done
+
+
+def gaudi_MaxNewTokensCriteria_call(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+    token_idx = kwargs.get("token_idx", None)
+    if token_idx is not None:
+        return token_idx >= self.max_length
+    else:
+        return input_ids.shape[-1] >= self.max_length
+
+
+def gaudi_StoppingCriteriaList_call(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+    return any(criteria(input_ids, scores, **kwargs) for criteria in self)

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -654,7 +654,7 @@ class GaudiGenerationMixin(GenerationMixin):
 
         self._validate_generated_length(
             generation_config,
-            model_kwargs["token_idx"] if "token_idx" in model_kwargs else input_ids_length,
+            model_kwargs["token_idx"].item() if "token_idx" in model_kwargs else input_ids_length,
             has_default_max_length,
         )
 

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -15,7 +15,13 @@
 
 import transformers
 
-from .generation import GaudiGenerationConfig, GaudiGenerationMixin
+from .generation import (
+    GaudiGenerationConfig,
+    GaudiGenerationMixin,
+    gaudi_MaxLengthCriteria_call,
+    gaudi_MaxNewTokensCriteria_call,
+    gaudi_StoppingCriteriaList_call,
+)
 from .models import (
     GaudiBloomForCausalLM,
     GaudiBloomMLP,
@@ -140,7 +146,6 @@ def adapt_transformers_to_gaudi():
     transformers.generation.GenerationMixin._prepare_decoder_input_ids_for_generation = (
         GaudiGenerationMixin._prepare_decoder_input_ids_for_generation
     )
-    transformers.generation.GenerationMixin._get_stopping_criteria = GaudiGenerationMixin._get_stopping_criteria
     transformers.generation.GenerationMixin._prepare_decoder_attention_mask = (
         GaudiGenerationMixin._prepare_decoder_attention_mask
     )
@@ -153,6 +158,9 @@ def adapt_transformers_to_gaudi():
     transformers.generation.GenerationMixin.constrained_beam_search = GaudiGenerationMixin.constrained_beam_search
     transformers.generation.GenerationConfig = GaudiGenerationConfig
     transformers.modeling_utils.GenerationConfig = GaudiGenerationConfig
+    transformers.generation.MaxLengthCriteria.__call__ = gaudi_MaxLengthCriteria_call
+    transformers.generation.MaxNewTokensCriteria.__call__ = gaudi_MaxNewTokensCriteria_call
+    transformers.generation.StoppingCriteriaList.__call__ = gaudi_StoppingCriteriaList_call
 
     # Optimization for BLOOM generation on Gaudi
     transformers.models.bloom.modeling_bloom.BloomAttention.forward = gaudi_bloom_attention_forward


### PR DESCRIPTION
…code-decode model

found with "do_sample=False, num_beams=4" in generation. test model include
decode only:"gpt2" "tiiuae/falcon-7b-instruct" "distilgpt2"
encode decoder: "facebook/bart-large-cnn" "sshleifer/distilbart-cnn-12-6" "philschmid/bart-large-cnn-samsum"

