### PR TITLE
Fix tests

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1368,8 +1368,8 @@ class GaudiGenerationMixin(GenerationMixin):
         hb_profer = HabanaProfile(warmup=profiling_warmup_steps, active=profiling_steps)
         hb_profer.start()
         this_peer_finished = False  # used by synced_gpus only
-        bucket_size = model_kwargs["bucket_size"]
-        reduce_recompile = model_kwargs["reduce_recompile"]
+        bucket_size = model_kwargs.get("bucket_size", -1)
+        reduce_recompile = model_kwargs.get("reduce_recompile", False)
 
         prompt_len = input_ids.shape[-1]
         if bucket_size >= 0:
@@ -2121,8 +2121,8 @@ class GaudiGenerationMixin(GenerationMixin):
         hb_profer.start()
         this_peer_finished = False  # used by synced_gpus only
 
-        bucket_size = model_kwargs["bucket_size"]
-        reduce_recompile = model_kwargs["reduce_recompile"]
+        bucket_size = model_kwargs.get("bucket_size", -1)
+        reduce_recompile = model_kwargs.get("reduce_recompile", False)
         prompt_len = input_ids.shape[-1]
         if bucket_size >= 0:
             inc = iter(incrementor(bucket_size, prompt_len))


### PR DESCRIPTION
# What does this PR do?

Certain tests like these [here](https://github.com/huggingface/optimum-habana/blob/937a411fc59b3a926f4894876929b3b60f4c634b/tests/transformers/tests/generation/test_utils.py#L880) calls `greedy_search` and `beam_search` directly without [generate](https://github.com/huggingface/optimum-habana/blob/937a411fc59b3a926f4894876929b3b60f4c634b/optimum/habana/transformers/generation/utils.py#L396)

flags like `reduce_recompile` and `bucket_size` are set to default values [here](https://github.com/huggingface/optimum-habana/blob/937a411fc59b3a926f4894876929b3b60f4c634b/optimum/habana/transformers/generation/utils.py#L596), hence they were accessed without defaults in `greedy_search` and `beam_search`. However of the *_search functions are called directly (like in the unit tests), it can fail.

Therefore setting defaults in this PR

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
