### PR TITLE
Added check if reuse_cache supported by selected model_type

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -600,6 +600,7 @@ class GaudiGenerationMixin(GenerationMixin):
         if model_kwargs["reduce_recompile"]:
             assert generation_config.bucket_size
         if generation_config.reuse_cache:
+            assert self.config.model_type in ["llama"], "reuse_cache only supported by llama at the moment"
             assert generation_config.bucket_size <= 0, "reuse_cache and bucketing flags set together"
 
         if generation_config.static_shapes:


### PR DESCRIPTION
# Add a check if reuse_cache flag supported by selected model_type in GaudiGenerationMixin.generate()

Previously, if run_generation.py ran with other than "llama" model and --reuse_check there was an error:

```AttributeError: 'GaudiMistralForCausalLM' object has no attribute 'allocate_kv_cache'```

Now there is a more user-freindly message describing the problem:

```AssertionError: reuse_cache only supported by llama at the moment```
