### PR TITLE
Remove falcon model cache unit test 

### DIFF
--- a/tests/transformers/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/transformers/tests/models/falcon/test_modeling_falcon.py
@@ -323,24 +323,6 @@ class FalconModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
         self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
-    def test_cache_conversions(self):
-        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        input_ids = input_dict["input_ids"]
-        model = FalconForCausalLM(config)
-        model.to(torch_device)
-        model.eval()
-        result = model(input_ids, use_cache=True)
-        batch_size = input_ids.shape[0]
-        rw_cache = model._convert_to_rw_cache(result.past_key_values)
-        standard_cache = model._convert_cache_to_standard_format(rw_cache, batch_size)
-        for layer in range(len(rw_cache)):
-            for tensor_idx in range(2):
-                self.assertTrue(rw_cache[layer][tensor_idx].ndim == 3)
-                self.assertTrue(result.past_key_values[layer][tensor_idx].ndim == 4)
-                self.assertTrue(
-                    torch.all(result.past_key_values[layer][tensor_idx] == standard_cache[layer][tensor_idx])
-                )
-
     def test_falcon_sequence_classification_model_for_multi_label(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_labels = 3


### PR DESCRIPTION
Test failed with below error. 
E       AttributeError: 'GaudiFalconForCausalLM' object has no attribute '_convert_to_rw_cache'

_convert_to_rw_cache is no longer supported in transformer v4.37.2. Test case is removed. 