### PR TITLE
To fix LLAMA-V2-70B-FT-HF (8x) for eager mode

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1482,7 +1482,7 @@ class GaudiTrainer(Trainer):
         if self.args.n_gpu > 1:
             loss = loss.mean()  # mean() to average on multi-gpu parallel training
 
-        if self.args.pipelining_fwd_bwd:
+        if self.args.use_lazy_mode and self.args.pipelining_fwd_bwd:
             self.htcore.mark_step()
 
         self.accelerator.backward(loss)


### PR DESCRIPTION
'mark_step()' should not be called for eager mode so conditionally skipped for eager mode.