### PR TITLE
Fix Llama initialization

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -414,7 +414,7 @@ class GaudiLlamaMLP(LlamaMLP):
 
 class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(self, config: LlamaConfig, layer_idx: int):
-        super().__init__(config, layer_idx)
+        super(LlamaDecoderLayer, self).__init__()
         self.hidden_size = config.hidden_size
 
         self.self_attn = GaudiLlamaAttention(config=config, layer_idx=layer_idx)
@@ -666,7 +666,7 @@ class GaudiLlamaModel(LlamaModel):
                     attn_softmax_bf16,
                     False,
                     use_flash_attention,
-                    True,
+                    flash_attention_recompute,
                 )
             else:
                 layer_outputs = decoder_layer(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

From Harshvardhan:

> I ran the llama2-70B FT command from README after the PR [#651](https://github.com/huggingface/optimum-habana/pull/651) was merged in master. I saw performance drop as shown below.
> 
> with PR:
> ***** train metrics *****
>   epoch                       =        2.0
>   max_memory_allocated (GB)   =      79.79
>   memory_allocated (GB)       =      37.25
>   total_memory_available (GB) =      94.62
>   train_loss                  =     0.8327
>   train_runtime               = 0:45:40.05
>   train_samples_per_second    =      2.376
>   train_steps_per_second      =       0.03
> 
> without PR:
> ***** train metrics *****
>   epoch                       =        2.0
>   max_memory_allocated (GB)   =       71.8
>   memory_allocated (GB)       =      26.61
>   total_memory_available (GB) =      94.62
>   train_loss                  =     0.8327
>   train_runtime               = 0:43:09.01
>   train_samples_per_second    =      2.526
>   train_steps_per_second      =      0.032
> 
> Please see that train_runtime, memory_allocated etc. have increased with the patch.

This PR should fix this. Layers were initialized twice, which seems to make ZeRO-3 confused.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
