### PR TITLE
Update text generation example to support qwen model

### DIFF
--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,2 +1,5 @@
 datasets
 peft
+transformers_stream_generator
+einops
+tiktoken

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -161,6 +161,11 @@ def setup_parser(parser):
         "generated when running `huggingface-cli login` (stored in `~/.huggingface`).",
     )
     parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Allow custom models, which are defined on the Hub in their own modeling files",
+    )
+    parser.add_argument(
         "--model_revision",
         default="main",
         type=str,

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -296,6 +296,7 @@ def setup_tokenizer(args, model):
     tokenizer_kwargs = {
         "revision": args.model_revision,
         "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
     }
     if args.bad_words is not None or args.force_words is not None:
         tokenizer_kwargs["add_prefix_space"] = True
@@ -314,6 +315,8 @@ def setup_tokenizer(args, model):
         tokenizer.pad_token = tokenizer.decode(tokenizer.pad_token_id)
         tokenizer.eos_token = tokenizer.decode(tokenizer.eos_token_id)
         tokenizer.bos_token = tokenizer.decode(tokenizer.bos_token_id)
+    elif model.config.model_type == "qwen":
+        tokenizer.pad_token = '<|endoftext|>'
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -371,6 +374,7 @@ def initialize_model(args, logger):
     model_kwargs = {
         "revision": args.model_revision,
         "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
     }
     model = (
         setup_model(args, model_dtype, model_kwargs, logger)


### PR DESCRIPTION
# What does this PR do?

Small fixes to support text generation with Qwen.

As stated in [doc](https://github.com/QwenLM/Qwen/blob/main/tokenization_note.md):
```
The concepts of bos, eos, unk, pad, mask, sep and such are not applicable to our pretrained models (Qwen-7B and Qwen-7B-Chat).
```
So special handling for ```pad``` token is required.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
