### PR TITLE
Fix Llama-70B-FSDP model loading issue

### DIFF
--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -42,7 +42,6 @@ from transformers import (
 from transformers.trainer_utils import is_main_process
 
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
-from optimum.habana.peft.layer import GaudiLoraLayerLinearForward
 from optimum.habana.utils import set_seed
 
 
@@ -675,7 +674,10 @@ def main():
         )
         if training_args.gradient_checkpointing:
             model.enable_input_require_grads()
-        tuners.lora.layer.Linear.forward = GaudiLoraLayerLinearForward
+        if training_args.torch_compile:
+            from optimum.habana.peft.layer import GaudiLoraLayerLinearForward
+
+            tuners.lora.layer.Linear.forward = GaudiLoraLayerLinearForward
         lora_model = get_peft_model(model, peft_config)
         if training_args.bf16:
             lora_model = lora_model.to(torch.bfloat16)

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -568,6 +568,7 @@ class GaudiTrainingArguments(TrainingArguments):
         # accelerate integration for FSDP
         if len(self.fsdp) > 0 and not self.fsdp_config["xla"]:
             os.environ["ACCELERATE_USE_FSDP"] = "true"
+            os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"] = "true"
             from accelerate.utils.constants import (
                 FSDP_AUTO_WRAP_POLICY,
                 FSDP_SHARDING_STRATEGY,


### PR DESCRIPTION
When running large models with FSDP, if we try to load full model params to each card we will run out of CPU RAM (refer to this these PRs https://github.com/huggingface/transformers/pull/25107  https://github.com/huggingface/accelerate/pull/1777. This is avoided by loading model params only to card 0 and broadcasting params to other cards from card 0. Enabled CPU_RAM_EFFICIENT_LOADING configuration in accelerate to support above described functionality.