### PR TITLE
Update summarization example README

### DIFF
--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -250,6 +250,3 @@ python run_summarization.py \
     --pad_to_max_length \
     --num_beams 1
 ```
-
-
-Only `--num_beams 1` is supported for BART.


### PR DESCRIPTION
document change for Summarization. Removed statement "Only --num_beams 1 is supported for BART." as other options for num_beams are supported part of PR-627


