### PR TITLE
Add `--distribution_strategy fast_ddp` in contrastive-image-text README and BridgeTower test

### DIFF
--- a/examples/contrastive-image-text/README.md
+++ b/examples/contrastive-image-text/README.md
@@ -143,7 +143,8 @@ python ../gaudi_spawn.py --world_size 8 --use_mpi run_clip.py \
     --dataloader_num_workers 16 \
     --mediapipe_dataloader \
     --use_hpu_graphs_for_training \
-    --bf16
+    --bf16 \
+    --distribution_strategy fast_ddp
 ```
 
 > `--mediapipe_dataloader` only works on Gaudi2.
@@ -206,23 +207,24 @@ For instance, to reproduce the results presented in [this blog post](https://hug
 
 ```bash
 python ../gaudi_spawn.py --use_mpi --world_size 8 run_bridgetower.py \
---output_dir /tmp/bridgetower-test \
---model_name_or_path BridgeTower/bridgetower-large-itm-mlm-itc \
---dataset_name jmhessel/newyorker_caption_contest --dataset_config_name matching \
---dataset_revision 3c6c4f6c0ff7e902833d3afa5f8f3875c2b036e6 \
---image_column image --caption_column image_description \
---remove_unused_columns=False \
---do_train --do_eval --do_predict \
---per_device_train_batch_size="40" --per_device_eval_batch_size="16" \
---num_train_epochs 5 \
---learning_rate="1e-5" \
---overwrite_output_dir \
---save_strategy no \
---use_habana --use_lazy_mode --use_hpu_graphs_for_inference --gaudi_config_name Habana/clip \
---throughput_warmup_steps 3 \
---logging_steps 10 \
---dataloader_num_workers 1 \
---mediapipe_dataloader
+  --output_dir /tmp/bridgetower-test \
+  --model_name_or_path BridgeTower/bridgetower-large-itm-mlm-itc \
+  --dataset_name jmhessel/newyorker_caption_contest --dataset_config_name matching \
+  --dataset_revision 3c6c4f6c0ff7e902833d3afa5f8f3875c2b036e6 \
+  --image_column image --caption_column image_description \
+  --remove_unused_columns=False \
+  --do_train --do_eval --do_predict \
+  --per_device_train_batch_size="40" --per_device_eval_batch_size="16" \
+  --num_train_epochs 5 \
+  --learning_rate="1e-5" \
+  --overwrite_output_dir \
+  --save_strategy no \
+  --use_habana --use_lazy_mode --use_hpu_graphs_for_inference --gaudi_config_name Habana/clip \
+  --throughput_warmup_steps 3 \
+  --logging_steps 10 \
+  --dataloader_num_workers 1 \
+  --mediapipe_dataloader \
+  --distribution_strategy fast_ddp
 ```
 
 > `--mediapipe_dataloader` only works on Gaudi2.

--- a/tests/baselines/bridgetower_large_itm_mlm_itc.json
+++ b/tests/baselines/bridgetower_large_itm_mlm_itc.json
@@ -18,7 +18,8 @@
                         "--mediapipe_dataloader",
                         "--dataloader_num_workers 2",
                         "--logging_steps 10",
-                        "--use_hpu_graphs_for_inference"
+                        "--use_hpu_graphs_for_inference",
+                        "--distribution_strategy fast_ddp"
                     ]
                 }
             }


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

As per title. The BridgeTower CI regression test fails without `--distribution_strategy fast_ddp`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
