### PR TITLE
Delay importing deepspeed comm due for perf

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -296,8 +296,6 @@ def gaudi_mixtral_block_sparse_moe_forward(self, hidden_states: torch.Tensor) ->
             output_tensors = [router_logits.clone() for _ in range(dist.get_world_size())]
             dist.all_gather(output_tensors, router_logits)
             router_logits = torch.cat(output_tensors, dim=1)
-    else:
-        print("Not using HPU DeepSpeed.")
 
     routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
     routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -292,9 +292,10 @@ def gaudi_mixtral_block_sparse_moe_forward(self, hidden_states: torch.Tensor) ->
     if is_deepspeed_available():
         from deepspeed import comm as dist
 
-        output_tensors = [router_logits.clone() for _ in range(dist.get_world_size())]
-        dist.all_gather(output_tensors, router_logits)
-        router_logits = torch.cat(output_tensors, dim=1)
+        if dist.is_initialized():
+            output_tensors = [router_logits.clone() for _ in range(dist.get_world_size())]
+            dist.all_gather(output_tensors, router_logits)
+            router_logits = torch.cat(output_tensors, dim=1)
     else:
         print("Not using HPU DeepSpeed.")
 


### PR DESCRIPTION
# What does this PR do?
We are seeing 2-3 secs total run time slowness with most of the mpi multicard tests with deepspeed installed compare to the one without.  We found this part is being called for every single model run which causing the slowdown. 
https://github.com/huggingface/optimum-habana/blob/main/optimum/habana/transformers/models/mixtral/modeling_mixtral.py#L65  
