### PR TITLE
Fix FSDP in transformer4.38

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1173,7 +1173,11 @@ class GaudiTrainer(Trainer):
             if is_accelerate_available() and self.accelerator.distributed_type == GaudiDistributedType.DEEPSPEED:
                 grad_norm = model.get_global_grad_norm()
             else:
-                grad_norm = _grad_norm.item() if _grad_norm is not None else None
+                grad_norm = (
+                    _grad_norm.item()
+                    if (_grad_norm is not None and self.accelerator.distributed_type != GaudiDistributedType.FSDP)
+                    else None
+                )
 
             if grad_norm is not None:
                 logs["grad_norm"] = grad_norm


### PR DESCRIPTION
Fix FSDP ci test issue with "TypeError: Object of type Tensor is not JSON serializable"

Transformer 4.38 logs the grad_norm in log_history. But FSDP doesn't have global grad norm function. When logging non-scalar tensor, the .item fails. The solution now is not to log grad_norm in logging_history for FSDP.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
