### PR TITLE
Update pytest version to avoid error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
 ]
 
 TESTS_REQUIRE = [
-    "pytest",
+    "pytest>=7.2.0,<8.0.0",
     "psutil",
     "parameterized",
     "GitPython",


### PR DESCRIPTION
Latest habana docker has pytest 8.1.1 installed by default. 
For transformer, we need the pytest lower than 8.0.0