### PR TITLE
Add instructions for Mixtral-8x7B inference

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -159,6 +159,18 @@ python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
 --do_sample
 ```
 
+To run Mixtral-8x7B inference on a single Gaudi2 card, use the following command:
+```bash
+python run_generation.py \
+ --model_name_or_path mistralai/Mixtral-8x7B-v0.1 \
+ --bf16 \
+ --use_hpu_graphs \
+ --use_kv_cache \
+ --batch_size 1 \
+ --max_new_tokens 128 \
+ --do_sample
+```
+
 > To be able to run gated models like [StarCoder](https://huggingface.co/bigcode/starcoder), you should:
 > - have a HF account
 > - agree to the terms of use of the model in its model card on the HF Hub


### PR DESCRIPTION
# What does this PR do?

The Mixtral-8x7B model is too large to be loaded onto a single Gaudi2 device in 32 bits. This PR demonstrates how to run the Mixtral-8x7B model on a single card, by leveraging the `--bf16` command line option to `run_generation.py`.


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
