### PR TITLE
Enable clip mediapipe and update G2 baseline

### DIFF
--- a/tests/baselines/clip_roberta.json
+++ b/tests/baselines/clip_roberta.json
@@ -34,8 +34,8 @@
                 "multi_card": {
                     "learning_rate": 5e-5,
                     "train_batch_size": 512,
-                    "train_runtime": 107.7326,
-                    "train_samples_per_second": 9125.619,
+                    "train_runtime": 63.36,
+                    "train_samples_per_second": 18434.069,
                     "extra_arguments": [
                         "--data_dir $PWD/",
                         "--dataset_config_name 2017",
@@ -48,7 +48,8 @@
                         "--use_hpu_graphs_for_training",
                         "--use_hpu_graphs_for_inference",
                         "--dataloader_num_workers 16",
-                        "--distribution_strategy fast_ddp"
+                        "--distribution_strategy fast_ddp",
+                        "--mediapipe_dataloader"
                     ]
                 }
             }


### PR DESCRIPTION
Enables data loading via mediapipe.
Updates Gaudi2 baseline numbers.

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
