### PR TITLE
Enable Flash Attention in recompute and causal modes (#21)

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -556,7 +556,8 @@ python3 ../gaudi_spawn.py --use_deepspeed  --world_size 8  run_lora_clm.py \
   --lora_rank 4 \
   --lora_target_modules "q_proj" "v_proj" "k_proj" "o_proj" \
   --validation_split_percentage 4 \
-  --use_flash_attention True
+  --use_flash_attention True \
+  --flash_attention_causal_mask True
 ```
 
 - Multi-card finetuning of Llama2-70B with FSDP and LoRA:

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -155,6 +155,15 @@ class ModelArguments:
             )
         },
     )
+    flash_attention_causal_mask: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to enable causal mask in Habana flash attention for fine-tuning."
+                " It is applicable only when use_flash_attention is True.",
+            )
+        },
+    )
     use_fused_rope: bool = field(
         default=True,
         metadata={
@@ -547,7 +556,8 @@ def main():
         if model_args.use_flash_attention:
             model.generation_config.use_flash_attention = True
             model.generation_config.flash_attention_recompute = model_args.flash_attention_recompute
-        if model_args.use_fused_rope is False:
+            model.generation_config.flash_attention_causal_mask = model_args.flash_attention_causal_mask
+        if not model_args.use_fused_rope:
             model.generation_config.use_fused_rope = False
 
     if hasattr(model.generation_config, "pad_token_id") and model.generation_config.pad_token_id is not None:

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -354,6 +354,30 @@ QUANT_CONFIG=./quantization_config/maxabs_quant.json python ../gaudi_spawn.py \
 ```
 `--fp8` is required to enable quantization in fp8.
 
+### Using Habana Flash Attention
+
+Habana Flash Attention addresses large sequence lenghts on prompt stage of inference. Using causal attention mask on prompt stage requires input sequences in batch to be of the same length, but can provide a memory saving, thus enabling higher batch sizes.
+
+Below example uses `flash_attention_recompute` mode in order to reduce memory consumption on prompt stage. Additionally since all sequences in a batch are of the same lenght it uses `flash_attention_causal_mask` which will further improve performance by taking advantage of specific lower-diagonal shape of inputs to softmax operation.
+
+```bash
+python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
+--model_name_or_path meta-llama/Llama-2-70b-hf \
+--use_hpu_graphs \
+--use_kv_cache \
+--reuse_cache \
+--trim_logits \
+--attn_softmax_bf16 \
+--max_input_tokens 31744 \
+--max_new_tokens 1024 \
+--batch_size=12 \
+--use_flash_attention \
+--flash_attention_recompute \
+--flash_attention_causal_mask \
+--book_source
+```
+
+For more details see [documentation](https://docs.habana.ai/en/latest/PyTorch/Model_Optimization_PyTorch/Optimization_in_PyTorch_Models.html#using-fused-sdpa).
 
 ## Language Model Evaluation Harness
 

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -228,6 +228,21 @@ def setup_parser(parser):
         help="Whether to enable Habana Flash Attention, provided that the model supports it.",
     )
     parser.add_argument(
+        "--flash_attention_recompute",
+        action="store_true",
+        help="Whether to enable Habana Flash Attention in recompute mode on first token generation. This gives an opportunity of splitting graph internally which helps reduce memory consumption.",
+    )
+    parser.add_argument(
+        "--flash_attention_causal_mask",
+        action="store_true",
+        help="Whether to enable Habana Flash Attention in causal mode on first token generation.",
+    )
+    parser.add_argument(
+        "--book_source",
+        action="store_true",
+        help="Whether to use project Guttenberg books data as input. Usefull for testing large sequence lenghts.",
+    )
+    parser.add_argument(
         "--torch_compile",
         action="store_true",
         help="Whether to use torch compiled model or not.",
@@ -272,6 +287,45 @@ def main():
         # Benchmark over the prompts below
         if args.prompt:
             input_sentences = args.prompt
+        elif args.book_source:
+
+            def download_book(book_id):
+                import os
+
+                import requests
+
+                url = f"https://www.gutenberg.org/cache/epub/{book_id}/pg{book_id}.txt"
+                response = requests.get(url)
+                if response.status_code == 200:
+                    pid = os.getpid()
+                    save_path = f"/tmp/{book_id}_{pid}.txt"
+                    with open(save_path, "wb") as file:
+                        file.write(response.content)
+                    print(f"Book downloaded and saved to: {save_path}")
+                    return save_path
+                else:
+                    print("Failed to download book! Exiting...")
+                    import sys
+
+                    sys.exit()
+
+            def assemble_prompt(prompt_size, book_path):
+                prompt = ""
+                counter = 0
+                book_lines = open(book_path).readlines()
+                for line in book_lines:
+                    for word in line.split():
+                        counter += 1
+                        prompt += word + " "
+                        if counter == prompt_size:
+                            return [prompt] * args.batch_size
+
+            book_ids = [
+                2701,  # Moby Dick; Or, The Whale
+                1513,  # Romeo and Juliet
+                1342,  # Pride and Prejudice
+            ]
+            input_sentences = assemble_prompt(prompt_size=args.max_input_tokens, book_path=download_book(book_ids[0]))
         else:
             input_sentences = [
                 "DeepSpeed is a machine learning framework",

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -347,6 +347,8 @@ def setup_generation_config(args, model, tokenizer):
     if generation_config.reduce_recompile:
         assert generation_config.bucket_size > 0
     generation_config.use_flash_attention = args.use_flash_attention
+    generation_config.flash_attention_recompute = args.flash_attention_recompute
+    generation_config.flash_attention_causal_mask = args.flash_attention_causal_mask
     return generation_config
 
 

--- a/optimum/habana/transformers/generation/configuration_utils.py
+++ b/optimum/habana/transformers/generation/configuration_utils.py
@@ -33,6 +33,8 @@ class GaudiGenerationConfig(GenerationConfig):
         Whether to use flash attention optimization.
     flash_attention_recompute (`bool`, *optional*):
         Whether to enable recompute if use Habana flash attention.
+    flash_attention_causal_mask (`bool`, *optional*):
+        Whether to enable causal_mask if use Habana flash attention.
     """
 
     def __init__(self, **kwargs):
@@ -48,4 +50,5 @@ class GaudiGenerationConfig(GenerationConfig):
         self.reduce_recompile = kwargs.get("reduce_recompile", None)
         self.use_flash_attention = kwargs.get("use_flash_attention", None)
         self.flash_attention_recompute = kwargs.get("flash_attention_recompute", None)
+        self.flash_attention_causal_mask = kwargs.get("flash_attention_causal_mask", None)
         self.use_fused_rope = kwargs.get("use_fused_rope", None)

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -726,6 +726,9 @@ class GaudiGenerationMixin(GenerationMixin):
         # determine whether flash attention needs to be used
         model_kwargs["use_flash_attention"] = generation_config.use_flash_attention
         model_kwargs["flash_attention_recompute"] = True if generation_config.flash_attention_recompute else False
+        model_kwargs["flash_attention_causal_mask"] = True if generation_config.flash_attention_causal_mask else False
+        model_kwargs["use_fused_rope"] = False if not generation_config.use_fused_rope else True
+
         if not self.config.is_encoder_decoder:
             calculated_max_length = input_ids.shape[-1]
             if not generation_config.static_shapes and generation_config.max_new_tokens is not None:

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -925,6 +925,10 @@ class GaudiTrainer(Trainer):
                             inputs["use_flash_attention"] = True
                         if self.model.generation_config.flash_attention_recompute:
                             inputs["flash_attention_recompute"] = True
+                        if self.model.generation_config.flash_attention_causal_mask:
+                            inputs["flash_attention_causal_mask"] = True
+                        if not self.model.generation_config.use_fused_rope:
+                            inputs["use_fused_rope"] = False
 
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
@@ -1806,6 +1810,10 @@ class GaudiTrainer(Trainer):
                         inputs["use_flash_attention"] = True
                     if self.model.generation_config.flash_attention_recompute:
                         inputs["flash_attention_recompute"] = True
+                    if self.model.generation_config.flash_attention_causal_mask:
+                        inputs["flash_attention_causal_mask"] = True
+                    if not self.model.generation_config.use_fused_rope:
+                        inputs["use_fused_rope"] = False
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)


### PR DESCRIPTION
Cherry-pick from: https://github.com/HabanaAI/optimum-habana-fork/pull/21

Original description:
This is a follow-up on: https://github.com/huggingface/optimum-habana/pull/623

where main issue is that when running with Flash Attention in causal mode (required for performance and memory optimizations on 1st token) it will generate a triangular attention mask - same on each batch of the input data.
If we have more than one batch of sequences that have different lengths, tokenizer will include a padding for those sentences that have smaller sequence lengths than 'max input tokens'. In the case of Flash Attention in causal mode, where triangular attention mask is applied to all the inputs, this will effectively mean that padding tokens are also attended to, which will in turn result in junk output being generated

This PR propagates the modes of running to run_generation.py so that optimization can still be used in case of the same length inputs in a batch. This is controlled through: --flash_attention_recompute and --flash_attention_causal_mask.

Additionally this PR provides a way to pass real input data to the model from Project Gutenberg Books for easier testing of large sequence lengths.

Below are the throughput measurements for different ratios of prompt to max seq length:

| Ratio       | Max input tokens | Max new tokens  | Batch size  | Throughput [tokens/s] |
| ---------- | ------------------- | ------------------ | ------------- | ------------- |
| 97%         | 31744                  | 1042                    | 12 | 85.54 |
| 75%         | 24576                  |  8192                   | 16 | 336.29 |
| 50%         | 16384                  | 16384                  | 24 | 521.39 |
| 25%         | 8192                    |  24576                 | 36 | 708.42 |

example of the command tested:
`
python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
    --num_beams 1  --attn_softmax_bf16 --model_name_or_path meta-llama/Llama-2-70b-hf \
    --warmup 2 --n_iterations 3 --use_hpu_graphs --use_kv_cache --max_input_tokens 31744 --max_new_tokens 1042 --bf16 --batch_size 12 --reuse_cache --trim_logits --limit_hpu_graphs --use_flash_attention --flash_attention_recompute --flash_attention_causal_mask --book_source`
    
    
Results on finetuning:

No Flash Attention:
'train_runtime': 2499.5658, 'train_samples_per_second': 2.626

Flash Attention:
'train_runtime': 2487.0323, 'train_samples_per_second': 2.636

Flash Attention Causal:
'train_runtime': 2449.3563, 'train_samples_per_second': 2.686