### PR TITLE
add `--trust_remote_code` for text generation examples

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -260,6 +260,11 @@ def setup_parser(parser):
         action="store_true",
         help="Whether to enable device map auto. In case no space left on cpu, weights will be offloaded to disk.",
     )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Whether or not to allow for custom models defined on the Hub in their own modeling files.",
+    )
     args = parser.parse_args()
 
     if args.torch_compile:

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -375,7 +375,7 @@ def initialize_model(args, logger):
         "trust_remote_code": args.trust_remote_code,
     }
     if args.trust_remote_code:
-        print("trust_remote_code is set. Model may not be complaint and may fail")
+        logger.warning("`trust_remote_code` is set, there is no guarantee this model works properly and it may fail")
     if args.disk_offload:
         model_kwargs["device_map"] = "auto"
         model_kwargs["offload_folder"] = "/tmp/offload_folder/"

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -374,6 +374,8 @@ def initialize_model(args, logger):
         "token": args.token,
         "trust_remote_code": args.trust_remote_code,
     }
+    if args.trust_remote_code:
+        print("trust_remote_code is set. Model may not be complaint and may fail")
     if args.disk_offload:
         model_kwargs["device_map"] = "auto"
         model_kwargs["offload_folder"] = "/tmp/offload_folder/"

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -293,6 +293,7 @@ def setup_tokenizer(args, model):
     tokenizer_kwargs = {
         "revision": args.model_revision,
         "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
     }
     if args.bad_words is not None or args.force_words is not None:
         tokenizer_kwargs["add_prefix_space"] = True
@@ -349,6 +350,7 @@ def setup_generation_config(args, model, tokenizer):
     generation_config.use_flash_attention = args.use_flash_attention
     generation_config.flash_attention_recompute = args.flash_attention_recompute
     generation_config.flash_attention_causal_mask = args.flash_attention_causal_mask
+    generation_config.trust_remote_code = args.trust_remote_code
     return generation_config
 
 
@@ -370,6 +372,7 @@ def initialize_model(args, logger):
     model_kwargs = {
         "revision": args.model_revision,
         "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
     }
     if args.disk_offload:
         model_kwargs["device_map"] = "auto"


### PR DESCRIPTION
Add `--trust_remote_code` argument for text generation examples to allow the custom models defined on the Hub in their own modeling files.