### PR TITLE
Remove deprecated AOT_HPU_TRAINING_BACKEND (#138)

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -151,7 +151,7 @@ def patch_scoped_linear_all_reduce(model):
 
 
 def get_torch_compiled_model(model):
-    model.model = torch.compile(model.model, backend="aot_hpu_inference_backend")
+    model.model = torch.compile(model.model, backend="hpu_backend")
     return model
 
 

--- a/optimum/habana/accelerate/utils/dataclasses.py
+++ b/optimum/habana/accelerate/utils/dataclasses.py
@@ -73,7 +73,6 @@ class GaudiDynamoBackend(str, BaseEnum):
         - **IPEX** -- Uses IPEX for inference on CPU. Inference only. [Read
           more](https://github.com/intel/intel-extension-for-pytorch).
         - **TVM** -- Uses Apach TVM for inference optimizations. [Read more](https://tvm.apache.org/)
-        - **AOT_HPU_TRAINING_BACKEND** -- Uses Habana Gaudi - depracated - will be removed.
         - **HPU_BACKEND** -- Uses Habana Gaudi.
 
     """
@@ -92,7 +91,6 @@ class GaudiDynamoBackend(str, BaseEnum):
     TENSORRT = "TENSORRT"
     IPEX = "IPEX"
     TVM = "TVM"
-    AOT_HPU_TRAINING_BACKEND = "AOT_HPU_TRAINING_BACKEND"
     HPU_BACKEND = "HPU_BACKEND"
 
 

--- a/tests/test_fsdp_examples.py
+++ b/tests/test_fsdp_examples.py
@@ -78,7 +78,7 @@ def _test_fsdp(
         f"--per_device_train_batch_size {batch_size_train}",
         f"--fsdp_config {path_to_example_dir / task / 'fsdp_config.json'}",
         f"--fsdp '{policy}'",
-        "--torch_compile_backend aot_hpu_training_backend",
+        "--torch_compile_backend hpu_backend",
         "--torch_compile",
         "--use_habana",
     ]


### PR DESCRIPTION
The new backend has been introduced to pytorch-integraton - HPU_BACKEND . The deprecated backend ( AOT_HPU_TRAINING_BACKEND ) shall no longer be available in optimum habana as it's going to be removed from pytorch-integration.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
