### PR TITLE
Disable wav2vec2 symbolic tracing test

### DIFF
--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -726,6 +726,9 @@ class Wav2Vec2ModelTest(ModelTesterMixin, unittest.TestCase):
 
     # Wav2Vec2 cannot be torchscripted because of group norm.
     def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
+        # TODO: fix it
+        self.skipTest("torch 2.1 breaks torch fx tests for wav2vec2/hubert.")
+
         if not is_torch_fx_available() or not self.fx_compatible:
             return
 


### PR DESCRIPTION
Disable wav2vec2 symbolic tracing test

# What does this PR do?

Disables testing of symbolic tracing for the Wav2Vec2 class of models. These tests are currently broken:
```
torch.fx.proxy.TraceError: symbolically traced variables cannot be used as inputs to control flow
```
Presumably this error is caused by the following line in the wav2vec2 implementation, which cannot be evaluated during symbolic tracing:
```
  File "/usr/local/lib/python3.10/dist-packages/transformers/models/wav2vec2/modeling_wav2vec2.py", line 594, in forward
    if attn_weights.size() != (bsz * self.num_heads, tgt_len, src_len):
```
The error can be reproduced with the following code snippet, which demonstrates that a similar issue is present in transformers without optimum-habana:
```python
# start without optimum-habana
from transformers import Wav2Vec2Model, Wav2Vec2Config
from transformers.utils.fx import symbolic_trace
config = {'batch_size': 13, 'seq_length': 1024, 'is_training': False, 'hidden_size': 16, 'feat_extract_norm': 'group', 'feat_extract_dropout': 0.0, 'feat_extract_activation': 'gelu', 'conv_dim': (32, 32, 32), 'conv_stride': (4, 4, 4), 'conv_kernel': (8, 8, 8), 'conv_bias': False, 'num_conv_pos_embeddings': 16, 'num_conv_pos_embedding_groups': 2, 'num_hidden_layers': 2, 'num_attention_heads': 2, 'hidden_dropout_prob': 0.1, 'intermediate_size': 20, 'layer_norm_eps': 1e-05, 'hidden_act': 'gelu', 'initializer_range': 0.02, 'mask_time_prob': 0.5, 'mask_time_length': 2, 'vocab_size': 32, 'do_stable_layer_norm': False, 'num_adapter_layers': 1, 'adapter_stride': 2, 'tdnn_dim': (32, 32), 'tdnn_kernel': (5, 3), 'tdnn_dilation': (1, 2), 'xvector_output_dim': 32}
config = Wav2Vec2Config(**config)
model = Wav2Vec2Model(config=config)
input_names = ['input_values', 'attention_mask']
symbolic_trace(model, input_names)
# TypeError: 'HFProxy' object cannot be interpreted as an integer

# enable optimum-habana with transformers
from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
adapt_transformers_to_gaudi()
model.to("hpu")
model.eval()
symbolic_trace(model, input_names)
# torch.fx.proxy.TraceError: symbolically traced variables cannot be used as inputs to control flow
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
