### PR TITLE
fix perf drop in flan-t5 summarization

### DIFF
--- a/examples/summarization/ds_flan_t5_z3_config_bf16.json
+++ b/examples/summarization/ds_flan_t5_z3_config_bf16.json
@@ -27,6 +27,7 @@
     "contiguous_gradients": true,
     "sub_group_size": 1e9,
     "reduce_bucket_size": 1666777,
+    "reduce_scatter" : false,
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 1e9,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1678,6 +1678,7 @@ class GaudiTrainerIntegrationTest(TestCasePlus, GaudiTrainerIntegrationCommon):
     @require_safetensors
     def test_load_best_model_from_safetensors(self):
         total = int(self.n_epochs * 64 / self.batch_size)
+        import pdb;pdb.set_trace()
         for save_safetensors, pretrained in product([False, True], [False, True]):
             with tempfile.TemporaryDirectory() as tmpdir:
                 trainer = get_regression_trainer(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1678,7 +1678,6 @@ class GaudiTrainerIntegrationTest(TestCasePlus, GaudiTrainerIntegrationCommon):
     @require_safetensors
     def test_load_best_model_from_safetensors(self):
         total = int(self.n_epochs * 64 / self.batch_size)
-        import pdb;pdb.set_trace()
         for save_safetensors, pretrained in product([False, True], [False, True]):
             with tempfile.TemporaryDirectory() as tmpdir:
                 trainer = get_regression_trainer(


### PR DESCRIPTION
Upto 7% performance drop observed in flan-t5 8x summarization task with deepspeed-fork (synapse 1.16 version).
This PR fixes that.