### PR TITLE
Support symbolic tracing of GPT2 models.

### DIFF
--- a/optimum/habana/transformers/models/modeling_all_models.py
+++ b/optimum/habana/transformers/models/modeling_all_models.py
@@ -107,10 +107,7 @@ def gaudi_conv1d_forward(self, x):
     size_out = x.size()[:-1] + (self.nf,)
     x = torch.mm(x.view(-1, x.size(-1)), self.weight)
     x = x.view(size_out)
-    bias_shape = [1 for _ in x.shape]
-    bias_shape[-1] = self.nf
-    bias = self.bias.view(bias_shape)
-    x = x + bias
+    x = x + self.bias
     return x
 
 


### PR DESCRIPTION
# What does this PR do?

Addresses test failures from `GAUDI2_CI=1  RUN_SLOW=1 python -m pytest tests/transformers/tests/models/gpt2/test_modeling_gpt2.py -s -v -k test_torch_fx`

Removes an obstacle for symbolic tracing of GPT2 models. Problem line was `[1 for _ in x.shape]`. It is impossible to iterate over `x.shape` during symbolic execution. AFAICT `self.bias` is a single-element tensor, ie. a scalar, so there is no need to change it's shape to perform the addition operation.

There is a new error in the test, but it is raised by transformers not optimum-habana:

```
E           NotImplementedError: Model GaudiGPT2LMHeadModel is not supported yet, supported models: ...
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
