### PR TITLE
sasarkar/Map list to tensors

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -592,8 +592,10 @@ def main():
             )
 
     if training_args.do_train:
+
         def tensor_mapper(x):
-            return {i:torch.tensor(x[i], dtype=torch.int32) for i in x}
+            return {i: torch.tensor(x[i], dtype=torch.int32) for i in x}
+
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
         train_dataset = lm_datasets["train"]

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -592,9 +592,12 @@ def main():
             )
 
     if training_args.do_train:
+        def tensor_mapper(x):
+            return {i:torch.tensor(x[i], dtype=torch.int32) for i in x}
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
         train_dataset = lm_datasets["train"]
+        train_dataset = train_dataset.map(tensor_mapper)
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -599,7 +599,7 @@ def main():
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
         train_dataset = lm_datasets["train"]
-        if training_args.resume_from_checkpoint != '':
+        if training_args.resume_from_checkpoint is not None and training_args.resume_from_checkpoint != '':
             train_dataset = train_dataset.map(tensor_mapper)
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -599,7 +599,7 @@ def main():
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
         train_dataset = lm_datasets["train"]
-        if training_args.resume_from_checkpoint is not None and training_args.resume_from_checkpoint != '':
+        if training_args.resume_from_checkpoint is not None and training_args.resume_from_checkpoint != "":
             train_dataset = train_dataset.map(tensor_mapper)
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -599,7 +599,8 @@ def main():
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
         train_dataset = lm_datasets["train"]
-        train_dataset = train_dataset.map(tensor_mapper)
+        if training_args.resume_from_checkpoint != '':
+            train_dataset = train_dataset.map(tensor_mapper)
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))


### PR DESCRIPTION
# What does this PR do?
**Original issue**
resuming for multi card fails

```python ../gaudi_spawn.py --world_size 2 --use_deepspeed run_clm.py --run_name initial_run --model_name_or_path openai-community/gpt2 --dataset_name wikitext --dataset_config_name wikitext-2-raw-v1 --block_size 4096 --per_device_train_batch_size 8 --gradient_accumulation_steps 8 --per_device_eval_batch_size 4 --do_train --do_eval --learning_rate 4e-4 --output_dir resume_exp3_2x --gaudi_config_name Habana/gpt2 --use_habana --use_lazy_mode --use_hpu_graphs_for_inference --gradient_checkpointing --use_cache False --throughput_warmup_steps 3 --deepspeed ds_zero2.json --overwrite_output_dir --num_train_epochs 1 --logging_dir resume_exp3_2x --logging_steps 1 --streaming --max_steps 7 --save_strategy steps --save_steps 5```

```python ../gaudi_spawn.py --world_size 2 --use_deepspeed run_clm.py --run_name initial_run --model_name_or_path openai-community/gpt2 --dataset_name wikitext --dataset_config_name wikitext-2-raw-v1 --block_size 4096 --per_device_train_batch_size 8 --gradient_accumulation_steps 8 --per_device_eval_batch_size 4 --do_train --do_eval --learning_rate 4e-4 --output_dir resume_exp3_2x --gaudi_config_name Habana/gpt2 --use_habana --use_lazy_mode --use_hpu_graphs_for_inference --gradient_checkpointing --use_cache False --throughput_warmup_steps 3 --deepspeed ds_zero2.json --num_train_epochs 1 --logging_dir resume_exp3_2x --logging_steps 1 --streaming --max_steps 60 --save_strategy steps --save_steps 5 --resume_from_checkpoint resume_exp3_2x/checkpoint-5```

The second command fails with error: `RuntimeError: Error when trying to cast Long to Int, Input values range [-5337826792292336652, 7161124111582705975] exceeds Int range [-2147483648, 2147483647]`

**Reason**

When we resume, [this](https://github.com/huggingface/optimum-habana/blob/main/optimum/habana/transformers/trainer.py#L883) code is run: `skip_first_batches`

This calls this [line](https://github.com/huggingface/accelerate/blob/cd7df4117d92f660965d5f737364395b5693a535/src/accelerate/data_loader.py#L1085).

When iterating over the dataloader, we hit this [line](https://github.com/huggingface/accelerate/blob/cd7df4117d92f660965d5f737364395b5693a535/src/accelerate/data_loader.py#L672).

This call finally initializes tensor [here](https://github.com/huggingface/accelerate/blob/cd7df4117d92f660965d5f737364395b5693a535/src/accelerate/utils/operations.py#L240)

This creates a `torch.empty` tensor, which is uninitialized, and with dtype=int64

HPU doesn't support int64, and the uninitialized int64 tensor has large out of bounds number, which cannot be converted to int32, hence the error.

**Solution**
The training dataset is a list of dictionaries, whose values are lists of integers. These lists are converted into int64 inside `Trainer`. To prevent that, I map the dataset into int32 tensors.




<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
