### PR TITLE
Fix AttributeError for wav2vec test

### DIFF
--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1023,6 +1023,7 @@ class Wav2Vec2RobustModelTest(ModelTesterMixin, unittest.TestCase):
             model.config.mask_time_length,
             min_masks=2,
         )
+        mask_time_indices = mask_time_indices.cpu().numpy()
         sampled_negative_indices = _sample_negative_indices(features_shape, 10, mask_time_indices)
 
         mask_time_indices = torch.from_numpy(mask_time_indices).to(torch_device)


### PR DESCRIPTION
resolve runtime error for PYTEST- wav2vec test_model_for_pretraining