### PR TITLE
Fix formatting of arg parse help strings in the PEFT example

### DIFF
--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -134,7 +134,7 @@ class ModelArguments:
         default=False,
         metadata={
             "help": (
-                "Whether to run attention softmax layer in bf16 precision for fine-tuning. The current support is limited to Llama only.",
+                "Whether to run attention softmax layer in bf16 precision for fine-tuning. The current support is limited to Llama only."
             )
         },
     )
@@ -142,7 +142,7 @@ class ModelArguments:
         default=False,
         metadata={
             "help": (
-                "Whether to use Habana flash attention for fine-tuning. The current support is limited to Llama only.",
+                "Whether to use Habana flash attention for fine-tuning. The current support is limited to Llama only."
             )
         },
     )
@@ -151,7 +151,7 @@ class ModelArguments:
         metadata={
             "help": (
                 "Whether to enable recompute in Habana flash attention for fine-tuning."
-                " It is applicable only when use_flash_attention is True.",
+                " It is applicable only when use_flash_attention is True."
             )
         },
     )
@@ -160,7 +160,7 @@ class ModelArguments:
         metadata={
             "help": (
                 "Whether to enable causal mask in Habana flash attention for fine-tuning."
-                " It is applicable only when use_flash_attention is True.",
+                " It is applicable only when use_flash_attention is True."
             )
         },
     )
@@ -168,7 +168,7 @@ class ModelArguments:
         default=True,
         metadata={
             "help": (
-                "Whether to use Habana fused-rope for fine-tuning. The current support is limited to Llama only.",
+                "Whether to use Habana fused-rope for fine-tuning. The current support is limited to Llama only."
             )
         },
     )

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -167,9 +167,7 @@ class ModelArguments:
     use_fused_rope: bool = field(
         default=True,
         metadata={
-            "help": (
-                "Whether to use Habana fused-rope for fine-tuning. The current support is limited to Llama only."
-            )
+            "help": ("Whether to use Habana fused-rope for fine-tuning. The current support is limited to Llama only.")
         },
     )
     load_meta_device: bool = field(


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue when running `--help` on the `run_lora_clm.py` example file to see the args. It was giving the following error:
```
# python run_lora_clm.py --help

Traceback (most recent call last):
  File "/tmp/dmsuehir/optimum-habana/examples/language-modeling/run_lora_clm.py", line 759, in <module>
    main()
  File "/tmp/dmsuehir/optimum-habana/examples/language-modeling/run_lora_clm.py", line 346, in main
    ) = parser.parse_args_into_dataclasses()
  File "/usr/local/lib/python3.10/dist-packages/transformers/hf_argparser.py", line 331, in parse_args_into_dataclasses
    namespace, remaining_args = self.parse_known_args(args=args)
  File "/usr/lib/python3.10/argparse.py", line 1878, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.10/argparse.py", line 2091, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.10/argparse.py", line 2031, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.10/argparse.py", line 1955, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python3.10/argparse.py", line 1118, in __call__
    parser.print_help()
  File "/usr/lib/python3.10/argparse.py", line 2579, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python3.10/argparse.py", line 2563, in format_help
    return formatter.format_help()
  File "/usr/lib/python3.10/argparse.py", line 295, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python3.10/argparse.py", line 226, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 226, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 226, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 226, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 551, in _format_action
    if action.help and action.help.strip():
AttributeError: 'tuple' object has no attribute 'strip'
```

The comma after the strings is making the "help" value a tuple instead of string, which is causing this error. This PR is removing those commas.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
