### PR TITLE
Workarounds for failures in using HF Transformers auto classes in Classification sample 

### DIFF
--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -357,13 +357,19 @@ def main():
         ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
         use_safetensors=model_args.use_safetensors
     )
-    image_processor = AutoImageProcessor.from_pretrained(
-        model_args.image_processor_name or model_args.model_name_or_path,
-        cache_dir=model_args.cache_dir,
-        revision=model_args.model_revision,
-        token=model_args.token,
-        trust_remote_code=model_args.trust_remote_code,
-    )
+
+    try:
+        image_processor = AutoImageProcessor.from_pretrained(
+            model_args.image_processor_name or model_args.model_name_or_path,
+            cache_dir=model_args.cache_dir,
+            revision=model_args.model_revision,
+            token=model_args.token,
+            trust_remote_code=model_args.trust_remote_code,
+        )
+    except EnvironmentError as e:
+        logger.warning(str(e))
+        if not model_args.image_processor_name:
+            logger.info('Specify custom processor config file or URL using --image_processor_name option')
 
     # Define torchvision transforms to be applied to each image.
     if "shortest_edge" in image_processor.size:

--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -189,6 +189,10 @@ class ModelArguments:
         default=False,
         metadata={"help": "Will enable to load a pretrained model whose head dimensions are different."},
     )
+    use_safetensors: bool = field(
+        default=None,
+        metadata={"help": "Use safetensors file to load the model."},
+    )
 
 
 def main():
@@ -351,6 +355,7 @@ def main():
         token=model_args.token,
         trust_remote_code=model_args.trust_remote_code,
         ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
+        use_safetensors=model_args.use_safetensors
     )
     image_processor = AutoImageProcessor.from_pretrained(
         model_args.image_processor_name or model_args.model_name_or_path,


### PR DESCRIPTION
# What does this PR do?

This PR provides options to workaround failures seen in the image-classification example when invoking the HF Transformer autoclass pretrained functions, while running with certain classification models on HF.

Specifically, two cases are handled:
1) Cases where the model's safetensor file format is not compatible with the HF Transformer lib expectation. (a `metadata` field is expected).
2) Print warning and directions to workaround if `AutoImageProcessor.from_pretrained` fails on account of a missing `preprocessor_config.json` file.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes GS-123

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
