### PR TITLE
Fix decoder only generation

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -140,7 +140,10 @@ def get_final_stopping_criteria(x):
     if isinstance(x, bool):
         return x
     elif torch.is_tensor(x):
-        return all(x)
+        if x.dim() > 0:
+            return all(x)
+        else:
+            return x
     else:
         raise TypeError(f"The stopping criteria should be either a boolean or a torch.tensor but got {type(x)}.")
 
@@ -297,6 +300,7 @@ class GaudiGenerationMixin(GenerationMixin):
                     key != "token_idx"
                     and key != "decoder_input_ids"
                     and key != "cache_position"
+                    and key != "inputs_embeds_offset"
                     and dict_to_expand[key] is not None
                     and isinstance(dict_to_expand[key], torch.Tensor)
                 ):
@@ -914,14 +918,44 @@ class GaudiGenerationMixin(GenerationMixin):
                 # only pad if bucket_size < -1. If we are bucketing (bucket_size > 0), then that is taken care in greedy_search()
                 if not is_greedy_or_beam_and_bucket:
                     # token_idx is the current index in the generation process, it is incremented each time a new token is generated
-                    token_idx = inputs_tensor.shape[-1]
-                    model_kwargs["token_idx"] = torch.tensor(token_idx, device=inputs_tensor.device)
-                    model_kwargs["token_idx_cpu"] = token_idx
+                    token_idx = inputs_tensor.shape[1]
                     if generation_config.max_new_tokens is None:
                         generation_config.max_new_tokens = generation_config.max_length - token_idx
-                    inputs_tensor = torch.nn.functional.pad(
-                        inputs_tensor, (0, generation_config.max_new_tokens), value=generation_config.pad_token_id
-                    )
+                    if "inputs_embeds" in model_kwargs:
+                        if "input_ids" in model_kwargs:
+                            inputs_embeds_offset = (
+                                model_kwargs["input_ids"].shape[1] - model_kwargs["inputs_embeds"].shape[1]
+                            )
+                        else:
+                            inputs_embeds_offset = -model_kwargs["inputs_embeds"].shape[1]
+
+                        model_kwargs["inputs_embeds_offset"] = torch.tensor(
+                            inputs_embeds_offset, device=inputs_tensor.device
+                        )
+                        model_kwargs["inputs_embeds"] = torch.nn.functional.pad(
+                            model_kwargs["inputs_embeds"],
+                            (0, 0, 0, generation_config.max_new_tokens),
+                            value=generation_config.pad_token_id,
+                        )
+
+                    if model_input_name == "inputs_embeds":
+                        inputs_tensor = torch.nn.functional.pad(
+                            inputs_tensor,
+                            (0, 0, 0, generation_config.max_new_tokens),
+                            value=generation_config.pad_token_id,
+                        )
+                        model_kwargs["input_ids"] = torch.nn.functional.pad(
+                            model_kwargs["input_ids"],
+                            (0, generation_config.max_new_tokens),
+                            value=generation_config.pad_token_id,
+                        )
+                    else:
+                        inputs_tensor = torch.nn.functional.pad(
+                            inputs_tensor, (0, generation_config.max_new_tokens), value=generation_config.pad_token_id
+                        )
+                    model_kwargs["token_idx"] = torch.tensor(token_idx, device=inputs_tensor.device)
+                    model_kwargs["token_idx_cpu"] = token_idx
+
                     for other_inputs in ["attention_mask", "token_type_ids"]:
                         if model_kwargs.get(other_inputs) is not None:
                             model_kwargs[other_inputs] = torch.nn.functional.pad(
@@ -1612,8 +1646,6 @@ class GaudiGenerationMixin(GenerationMixin):
 
         # keep track of which sequences are already finished
         batch_size, cur_len = input_ids.shape
-        if "inputs_embeds" in model_kwargs:
-            cur_len = model_kwargs["inputs_embeds"].shape[1]
 
         if not ignore_eos:
             unfinished_sequences = torch.ones(batch_size, dtype=torch.long, device=input_ids.device)
@@ -1640,7 +1672,10 @@ class GaudiGenerationMixin(GenerationMixin):
         top_k_ids = None
         if token_idx is not None:
             # Update cur_len in case of static shapes
-            cur_len = token_idx.item()
+            if "inputs_embeds_offset" in model_kwargs:
+                cur_len = (token_idx + model_kwargs["inputs_embeds_offset"]).item()
+            else:
+                cur_len = token_idx.item()
 
         time_to_first_token_done = False
         model_kwargs["pad_done"] = False
@@ -1756,8 +1791,13 @@ class GaudiGenerationMixin(GenerationMixin):
                         pad_amount = input_ids.shape[-1] - top_k_ids.shape[-1]
                         top_k_ids = torch.nn.functional.pad(top_k_ids, (0, pad_amount), value=pad_token_id)
 
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"] - 1
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx - 1
+                )
                 top_k_probs, top_k_prob_ids = torch.topk(next_probs, dim=-1, k=top_k)
-                top_k_ids[:, :, token_idx - 1] = top_k_prob_ids
+                top_k_ids[:, :, idx] = top_k_prob_ids
             else:
                 top_k_probs, top_k_ids = torch.topk(next_probs, dim=-1, k=top_k)
 
@@ -1883,8 +1923,14 @@ class GaudiGenerationMixin(GenerationMixin):
             # the degeneration penalty; (4) logits for selecting next top-k candidates; (5) selected tokens scores
             # (model confidence minus degeneration penalty); (6) decoder hidden_states
             top_k_indices = torch.arange(len(top_k_ids), device=input_ids.device)
+
             if token_idx is not None:
-                next_tokens = top_k_ids[top_k_indices, selected_idx, token_idx - 1]
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"] - 1
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx - 1
+                )
+                next_tokens = top_k_ids[top_k_indices, selected_idx, idx]
             else:
                 next_tokens = top_k_ids[top_k_indices, selected_idx]
             next_hidden = torch.stack(torch.split(next_hidden.squeeze(dim=1), top_k))
@@ -1976,9 +2022,12 @@ class GaudiGenerationMixin(GenerationMixin):
             # update generated ids, model inputs, and length for next step
             if token_idx is not None:
                 # Use token_idx-1 since token index is incremented twice in first iteration
-                input_ids.index_copy_(
-                    1, token_idx - 1, next_tokens.unsqueeze(-1) if next_tokens.dim() == 1 else next_tokens
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"] - 1
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx - 1
                 )
+                input_ids.index_copy_(1, idx, next_tokens.unsqueeze(-1) if next_tokens.dim() == 1 else next_tokens)
             else:
                 input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
 
@@ -2217,7 +2266,10 @@ class GaudiGenerationMixin(GenerationMixin):
         token_idx = model_kwargs.get("token_idx", None)
         if token_idx is not None:
             # Update cur_len in case of static shapes
-            cur_len = token_idx.item()
+            if "inputs_embeds_offset" in model_kwargs:
+                cur_len = (token_idx + model_kwargs["inputs_embeds_offset"]).item()
+            else:
+                cur_len = token_idx.item()
 
         time_to_first_token_done = False
         model_kwargs["pad_done"] = False
@@ -2319,9 +2371,12 @@ class GaudiGenerationMixin(GenerationMixin):
                 next_tokens = next_tokens.to(input_ids.dtype)
 
             if token_idx is not None:
-                input_ids.index_copy_(
-                    1, token_idx, next_tokens.unsqueeze(-1) if next_tokens.dim() == 1 else next_tokens
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"]
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx
                 )
+                input_ids.index_copy_(1, idx, next_tokens.unsqueeze(-1) if next_tokens.dim() == 1 else next_tokens)
             else:
                 input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
 
@@ -2514,7 +2569,11 @@ class GaudiGenerationMixin(GenerationMixin):
         token_idx = model_kwargs.get("token_idx", None)
         if token_idx is not None:
             # Update cur_len in case of static shapes
-            cur_len = token_idx.item()
+            if "inputs_embeds_offset" in model_kwargs:
+                cur_len = (token_idx + model_kwargs["inputs_embeds_offset"]).item()
+            else:
+                cur_len = token_idx.item()
+
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         if num_beams * batch_size != batch_beam_size:
@@ -2729,7 +2788,12 @@ class GaudiGenerationMixin(GenerationMixin):
             )  # (batch_size * num_beams, vocab_size)
 
             if token_idx is not None:
-                next_token_scores_processed = logits_processor(input_ids[:, :token_idx], next_token_scores)
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"]
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx
+                )
+                next_token_scores_processed = logits_processor(input_ids[:, :idx], next_token_scores)
             else:
                 next_token_scores_processed = logits_processor(input_ids, next_token_scores)
             if do_sample:
@@ -2836,8 +2900,13 @@ class GaudiGenerationMixin(GenerationMixin):
 
             if token_idx is not None:
                 input_ids = torch.index_select(input_ids, 0, beam_idx)
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"]
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx
+                )
                 input_ids.index_copy_(
-                    1, token_idx, beam_next_tokens.unsqueeze(-1) if beam_next_tokens.dim() == 1 else beam_next_tokens
+                    1, idx, beam_next_tokens.unsqueeze(-1) if beam_next_tokens.dim() == 1 else beam_next_tokens
                 )
             else:
                 input_ids = torch.cat([input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
@@ -3091,12 +3160,15 @@ class GaudiGenerationMixin(GenerationMixin):
         num_beams = constrained_beam_scorer.num_beams
 
         batch_beam_size, cur_len = input_ids.shape
-        if "inputs_embeds" in model_kwargs:
-            cur_len = model_kwargs["inputs_embeds"].shape[1]
+
         token_idx = model_kwargs.get("token_idx", None)
         if token_idx is not None:
             # Update cur_len in case of static shapes
-            cur_len = token_idx.item()
+            if "inputs_embeds_offset" in model_kwargs:
+                cur_len = (token_idx + model_kwargs["inputs_embeds_offset"]).item()
+            else:
+                cur_len = token_idx.item()
+
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         if num_beams * batch_size != batch_beam_size:
@@ -3238,8 +3310,14 @@ class GaudiGenerationMixin(GenerationMixin):
 
             if token_idx is not None:
                 input_ids = input_ids[beam_idx, :]
+                idx = (
+                    token_idx + model_kwargs["inputs_embeds_offset"]
+                    if "inputs_embeds_offset" in model_kwargs
+                    else token_idx
+                )
+
                 input_ids.index_copy_(
-                    1, token_idx, beam_next_tokens.unsqueeze(-1) if beam_next_tokens.dim() == 1 else beam_next_tokens
+                    1, idx, beam_next_tokens.unsqueeze(-1) if beam_next_tokens.dim() == 1 else beam_next_tokens
                 )
             else:
                 input_ids = torch.cat([input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
@@ -3441,7 +3519,10 @@ class GaudiGenerationMixin(GenerationMixin):
 
             if token_idx is not None:
                 # Update cur_len in case of static shapes
-                cur_len = token_idx.item()
+                if "inputs_embeds_offset" in model_kwargs:
+                    cur_len = (token_idx + model_kwargs["inputs_embeds_offset"]).item()
+                else:
+                    cur_len = token_idx.item()
             else:
                 cur_len = input_ids.shape[-1]
 

--- a/optimum/habana/transformers/models/blip/modeling_blip_text.py
+++ b/optimum/habana/transformers/models/blip/modeling_blip_text.py
@@ -505,7 +505,10 @@ def gaudi_BlipTextLMHead_prepare_inputs_for_generation(
     # cut decoder_input_ids if past_key_values is used
     if past_key_values is not None:
         if token_idx is not None:
-            input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+            idx = token_idx - 1
+            if "inputs_embeds_offset" in model_kwargs:
+                idx = idx + model_kwargs["inputs_embeds_offset"]
+            input_ids = torch.index_select(input_ids, 1, idx)
         else:
             past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/blip/modeling_blip_text.py
+++ b/optimum/habana/transformers/models/blip/modeling_blip_text.py
@@ -505,9 +505,7 @@ def gaudi_BlipTextLMHead_prepare_inputs_for_generation(
     # cut decoder_input_ids if past_key_values is used
     if past_key_values is not None:
         if token_idx is not None:
-            idx = token_idx - 1
-            if "inputs_embeds_offset" in model_kwargs:
-                idx = idx + model_kwargs["inputs_embeds_offset"]
+            idx = token_idx + model_kwargs.get("inputs_embeds_offset", 0) - 1
             input_ids = torch.index_select(input_ids, 1, idx)
         else:
             past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/bloom/modeling_bloom.py
+++ b/optimum/habana/transformers/models/bloom/modeling_bloom.py
@@ -489,7 +489,10 @@ class GaudiBloomForCausalLM(BloomForCausalLM):
             if token_idx is None:
                 input_ids = input_ids[:, -1].unsqueeze(-1)
             else:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
 
             # the cache may be in the stardard format (e.g. in contrastive search), convert to bloom's format if needed
             if past_key_values[0][0].shape[0] == input_ids.shape[0]:

--- a/optimum/habana/transformers/models/bloom/modeling_bloom.py
+++ b/optimum/habana/transformers/models/bloom/modeling_bloom.py
@@ -489,9 +489,7 @@ class GaudiBloomForCausalLM(BloomForCausalLM):
             if token_idx is None:
                 input_ids = input_ids[:, -1].unsqueeze(-1)
             else:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
             # the cache may be in the stardard format (e.g. in contrastive search), convert to bloom's format if needed

--- a/optimum/habana/transformers/models/codegen/modeling_codegen.py
+++ b/optimum/habana/transformers/models/codegen/modeling_codegen.py
@@ -320,9 +320,7 @@ class GaudiCodeGenForCausalLM(CodeGenForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
                 if token_type_ids is not None:

--- a/optimum/habana/transformers/models/codegen/modeling_codegen.py
+++ b/optimum/habana/transformers/models/codegen/modeling_codegen.py
@@ -320,7 +320,11 @@ class GaudiCodeGenForCausalLM(CodeGenForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
+
                 if token_type_ids is not None:
                     token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1)
             else:

--- a/optimum/habana/transformers/models/decilm/modeling_decilm.py
+++ b/optimum/habana/transformers/models/decilm/modeling_decilm.py
@@ -373,9 +373,7 @@ class DeciLMForCausalLM(LlamaForCausalLM, DeciLMPreTrainedModel):
         past_length = 0
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if isinstance(past_key_values, Cache):

--- a/optimum/habana/transformers/models/decilm/modeling_decilm.py
+++ b/optimum/habana/transformers/models/decilm/modeling_decilm.py
@@ -373,7 +373,10 @@ class DeciLMForCausalLM(LlamaForCausalLM, DeciLMPreTrainedModel):
         past_length = 0
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if isinstance(past_key_values, Cache):
                     past_length = cache_position[0] if cache_position is not None else past_key_values.get_seq_length()

--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -983,9 +983,7 @@ class GaudiFalconForCausalLM(FalconForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -983,7 +983,10 @@ class GaudiFalconForCausalLM(FalconForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/gemma/modeling_gemma.py
+++ b/optimum/habana/transformers/models/gemma/modeling_gemma.py
@@ -408,7 +408,10 @@ class GaudiGemmaForCausalLM(GemmaForCausalLM):
                     input_ids = input_ids[:, cache_position]
             else:
                 # past_length += token_idx
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/optimum/habana/transformers/models/gemma/modeling_gemma.py
+++ b/optimum/habana/transformers/models/gemma/modeling_gemma.py
@@ -408,9 +408,7 @@ class GaudiGemmaForCausalLM(GemmaForCausalLM):
                     input_ids = input_ids[:, cache_position]
             else:
                 # past_length += token_idx
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:

--- a/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
+++ b/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
@@ -476,7 +476,10 @@ class GaudiGPT2LMHeadModel(GPT2LMHeadModel):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 
@@ -609,7 +612,10 @@ class GaudiGPT2DoubleHeadsModel(GPT2DoubleHeadsModel):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
+++ b/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
@@ -476,9 +476,7 @@ class GaudiGPT2LMHeadModel(GPT2LMHeadModel):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -558,7 +558,10 @@ class GaudiGPTBigCodeForCausalLM(GPTBigCodeForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
                 if token_type_ids is not None:
                     token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1)
             else:

--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -558,9 +558,7 @@ class GaudiGPTBigCodeForCausalLM(GPTBigCodeForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
                 if token_type_ids is not None:
                     token_type_ids = torch.index_select(token_type_ids, 1, token_idx - 1)

--- a/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -379,7 +379,10 @@ class GaudiGPTNeoXForCausalLM(GPTNeoXForCausalLM):
         # cut decoder_input_ids if past is used
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -379,9 +379,7 @@ class GaudiGPTNeoXForCausalLM(GPTNeoXForCausalLM):
         # cut decoder_input_ids if past is used
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/gptj/modeling_gptj.py
+++ b/optimum/habana/transformers/models/gptj/modeling_gptj.py
@@ -563,7 +563,10 @@ class GaudiGPTJForCausalLM(GPTJForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/gptj/modeling_gptj.py
+++ b/optimum/habana/transformers/models/gptj/modeling_gptj.py
@@ -563,9 +563,7 @@ class GaudiGPTJForCausalLM(GPTJForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1346,9 +1346,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1346,7 +1346,10 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1
                     input_ids = input_ids[:, -cache_position.shape[0] :]

--- a/optimum/habana/transformers/models/mamba/modeling_mamba.py
+++ b/optimum/habana/transformers/models/mamba/modeling_mamba.py
@@ -61,7 +61,10 @@ def gaudi_MambaForCausalLM_prepare_inputs_for_generation(
                 # the length of `cache_params.conv_states`, which is `config.conv_kernel`
                 cache_position = torch.arange(0, self.config.conv_kernel, device=input_ids.device)
         else:
-            input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+            idx = token_idx - 1
+            if "inputs_embeds_offset" in kwargs:
+                idx = idx + kwargs["inputs_embeds_offset"]
+            input_ids = torch.index_select(input_ids, 1, idx)
     else:
         if token_idx is not None:
             input_ids = torch.index_select(input_ids, 1, torch.arange(token_idx_cpu, device=input_ids.device))

--- a/optimum/habana/transformers/models/mamba/modeling_mamba.py
+++ b/optimum/habana/transformers/models/mamba/modeling_mamba.py
@@ -61,9 +61,7 @@ def gaudi_MambaForCausalLM_prepare_inputs_for_generation(
                 # the length of `cache_params.conv_states`, which is `config.conv_kernel`
                 cache_position = torch.arange(0, self.config.conv_kernel, device=input_ids.device)
         else:
-            idx = token_idx - 1
-            if "inputs_embeds_offset" in kwargs:
-                idx = idx + kwargs["inputs_embeds_offset"]
+            idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
             input_ids = torch.index_select(input_ids, 1, idx)
     else:
         if token_idx is not None:

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -810,7 +810,10 @@ class GaudiMistralForCausalLM(MistralForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
         elif reuse_cache and token_idx is not None:
             # With reuse_cache, KV cache is pre allocated hence for the 1st token we can slice the inputs till token idx for the fwd pass
             input_ids = input_ids[:, :token_idx]

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -810,9 +810,7 @@ class GaudiMistralForCausalLM(MistralForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
         elif reuse_cache and token_idx is not None:
             # With reuse_cache, KV cache is pre allocated hence for the 1st token we can slice the inputs till token idx for the fwd pass

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -841,9 +841,7 @@ class GaudiMixtralForCausalLM(MixtralForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -841,7 +841,10 @@ class GaudiMixtralForCausalLM(MixtralForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1
                     input_ids = input_ids[:, -cache_position.shape[0] :]

--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -354,9 +354,7 @@ class GaudiMptForCausalLM(MptForCausalLM):
 
                 input_ids = input_ids[:, remove_prefix_length:]
             else:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
             # Converting back to tuples as it should be, so there's no type mismatch when calling graph

--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -354,7 +354,11 @@ class GaudiMptForCausalLM(MptForCausalLM):
 
                 input_ids = input_ids[:, remove_prefix_length:]
             else:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
+
             # Converting back to tuples as it should be, so there's no type mismatch when calling graph
             past_key_values = tuple([tuple(kv) for kv in past_key_values])
         elif bucket_internal and token_idx is not None:

--- a/optimum/habana/transformers/models/opt/modeling_opt.py
+++ b/optimum/habana/transformers/models/opt/modeling_opt.py
@@ -507,7 +507,10 @@ class GaudiOPTForCausalLM(OPTForCausalLM):
     ):
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/opt/modeling_opt.py
+++ b/optimum/habana/transformers/models/opt/modeling_opt.py
@@ -507,9 +507,7 @@ class GaudiOPTForCausalLM(OPTForCausalLM):
     ):
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 past_length = past_key_values[0][0].shape[2]

--- a/optimum/habana/transformers/models/persimmon/modeling_persimmon.py
+++ b/optimum/habana/transformers/models/persimmon/modeling_persimmon.py
@@ -425,7 +425,10 @@ class GaudiPersimmonForCausalLM(PersimmonForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/optimum/habana/transformers/models/persimmon/modeling_persimmon.py
+++ b/optimum/habana/transformers/models/persimmon/modeling_persimmon.py
@@ -425,9 +425,7 @@ class GaudiPersimmonForCausalLM(PersimmonForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:

--- a/optimum/habana/transformers/models/phi/modeling_phi.py
+++ b/optimum/habana/transformers/models/phi/modeling_phi.py
@@ -627,7 +627,10 @@ class GaudiPhiForCausalLM(PhiForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1
                     input_ids = input_ids[:, -cache_position.shape[0] :]

--- a/optimum/habana/transformers/models/phi/modeling_phi.py
+++ b/optimum/habana/transformers/models/phi/modeling_phi.py
@@ -627,9 +627,7 @@ class GaudiPhiForCausalLM(PhiForCausalLM):
         # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -859,9 +859,7 @@ class GaudiQwen2ForCausalLM(Qwen2ForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -859,7 +859,10 @@ class GaudiQwen2ForCausalLM(Qwen2ForCausalLM):
         bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1
                     input_ids = input_ids[:, -cache_position.shape[0] :]

--- a/optimum/habana/transformers/models/stablelm/modeling_stablelm.py
+++ b/optimum/habana/transformers/models/stablelm/modeling_stablelm.py
@@ -454,7 +454,10 @@ class GaudiStableLmForCausalLM(StableLmForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/optimum/habana/transformers/models/stablelm/modeling_stablelm.py
+++ b/optimum/habana/transformers/models/stablelm/modeling_stablelm.py
@@ -454,9 +454,7 @@ class GaudiStableLmForCausalLM(StableLmForCausalLM):
                 ):  # Default case (the "else", a no op, is Exception 2)
                     input_ids = input_ids[:, cache_position]
             else:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
 
         if attention_mask is not None and position_ids is None:

--- a/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
@@ -827,9 +827,7 @@ class GaudiStarcoder2ForCausalLM(Starcoder2ForCausalLM):
         reuse_cache = kwargs.get("reuse_cache")
         if past_key_values is not None:
             if token_idx is not None:
-                idx = token_idx - 1
-                if "inputs_embeds_offset" in kwargs:
-                    idx = idx + kwargs["inputs_embeds_offset"]
+                idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
                 input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1

--- a/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
@@ -827,7 +827,10 @@ class GaudiStarcoder2ForCausalLM(Starcoder2ForCausalLM):
         reuse_cache = kwargs.get("reuse_cache")
         if past_key_values is not None:
             if token_idx is not None:
-                input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+                idx = token_idx - 1
+                if "inputs_embeds_offset" in kwargs:
+                    idx = idx + kwargs["inputs_embeds_offset"]
+                input_ids = torch.index_select(input_ids, 1, idx)
             else:
                 if inputs_embeds is not None:  # Exception 1
                     input_ids = input_ids[:, -cache_position.shape[0] :]

--- a/optimum/habana/transformers/models/t5/modeling_t5.py
+++ b/optimum/habana/transformers/models/t5/modeling_t5.py
@@ -609,7 +609,10 @@ def gaudi_T5ForConditionalGeneration_prepare_inputs_for_generation(
     # cut decoder_input_ids if past_key_values is used
     if past_key_values is not None:
         if token_idx is not None:
-            input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+            idx = token_idx - 1
+            if "inputs_embeds_offset" in kwargs:
+                idx = idx + kwargs["inputs_embeds_offset"]
+            input_ids = torch.index_select(input_ids, 1, idx)
         else:
             past_length = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/t5/modeling_t5.py
+++ b/optimum/habana/transformers/models/t5/modeling_t5.py
@@ -609,9 +609,7 @@ def gaudi_T5ForConditionalGeneration_prepare_inputs_for_generation(
     # cut decoder_input_ids if past_key_values is used
     if past_key_values is not None:
         if token_idx is not None:
-            idx = token_idx - 1
-            if "inputs_embeds_offset" in kwargs:
-                idx = idx + kwargs["inputs_embeds_offset"]
+            idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
             input_ids = torch.index_select(input_ids, 1, idx)
         else:
             past_length = past_key_values[0][0].shape[2]

--- a/tests/transformers/tests/generation/test_utils.py
+++ b/tests/transformers/tests/generation/test_utils.py
@@ -2185,7 +2185,7 @@ class GenerationTesterMixin:
             )
             self.assertListEqual(
                 outputs_from_embeds[:, inputs_embeds.shape[1] :].tolist(),
-                outputs_from_embeds_wo_ids[:, 1:].tolist(),
+                outputs_from_embeds_wo_ids.tolist(),
             )
 
     def _check_outputs(self, output, input_ids, config, use_cache=False, num_return_sequences=1):


### PR DESCRIPTION
# What does this PR do?

Fixes issues with decoder-only generation. Multiple issues were found and corrected.

```
root@idc705326-7:/optimum-habana# GAUDI2_CI=1  RUN_SLOW=1 python -m pytest tests/transformers/tests/models/ -k test_generate_from_inputs_embeds_decoder_only
============================================================================================================== test session starts ==============================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.4.0
rootdir: /optimum-habana
configfile: setup.cfg
collected 1218 items / 1210 deselected / 8 selected

tests/transformers/tests/models/bert/test_modeling_bert.py .                                                                                                                                                                              [ 12%]
tests/transformers/tests/models/falcon/test_modeling_falcon.py .                                                                                                                                                                          [ 25%]
tests/transformers/tests/models/gpt2/test_modeling_gpt2.py .                                                                                                                                                                              [ 37%]
tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py .                                                                                                                                                                      [ 50%]
tests/transformers/tests/models/gptj/test_modeling_gptj.py .                                                                                                                                                                              [ 62%]
tests/transformers/tests/models/llama/test_modeling_llama.py .                                                                                                                                                                            [ 75%]
tests/transformers/tests/models/roberta/test_modeling_roberta.py .                                                                                                                                                                        [ 87%]
tests/transformers/tests/models/t5/test_modeling_t5.py .                                                                                                                                                                                  [100%]

=============================================================================================================== warnings summary ================================================================================================================
../usr/local/lib/python3.10/dist-packages/transformers/utils/generic.py:462
  /usr/local/lib/python3.10/dist-packages/transformers/utils/generic.py:462: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

../usr/local/lib/python3.10/dist-packages/transformers/utils/generic.py:319
../usr/local/lib/python3.10/dist-packages/transformers/utils/generic.py:319
  /usr/local/lib/python3.10/dist-packages/transformers/utils/generic.py:319: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

tests/transformers/tests/test_modeling_common.py:2044
  /optimum-habana/tests/transformers/tests/test_modeling_common.py:2044: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2082
  /optimum-habana/tests/transformers/tests/test_modeling_common.py:2082: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2118
  /optimum-habana/tests/transformers/tests/test_modeling_common.py:2118: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/models/gpt2/test_modeling_gpt2.py::GPT2ModelTest::test_generate_from_inputs_embeds_decoder_only
tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_generate_from_inputs_embeds_decoder_only
tests/transformers/tests/models/gptj/test_modeling_gptj.py::GPTJModelTest::test_generate_from_inputs_embeds_decoder_only
tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_generate_from_inputs_embeds_decoder_only
  /usr/local/lib/python3.10/dist-packages/transformers/generation/utils.py:1178: UserWarning: Using the model-agnostic default `max_length` (=20) to control the generation length. We recommend setting `max_new_tokens` to control the maximum length of the generation.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 8 passed, 1210 deselected, 10 warnings in 11.21s ================================================================================================
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
