### PR TITLE
Update test generation config to raise `ValueError`

### DIFF
--- a/tests/transformers/tests/generation/test_configuration_utils.py
+++ b/tests/transformers/tests/generation/test_configuration_utils.py
@@ -123,11 +123,11 @@ class GenerationConfigTest(unittest.TestCase):
         """Tests that we refuse to save a generation config that fails validation."""
 
         # setting the temperature alone is invalid, as we also need to set do_sample to True -> throws a warning that
-        # is caught, doesn't save, and raises a warning
+        # is caught, doesn't save, and raises an exception
         config = GenerationConfig()
         config.temperature = 0.5
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with warnings.catch_warnings(record=True) as captured_warnings:
+            with self.assertRaises(ValueError) as exc:
                 config.save_pretrained(tmp_dir)
             self.assertEqual(len(captured_warnings), 1)
             self.assertTrue("Fix these issues to save the configuration." in str(captured_warnings[0].message))
@@ -138,10 +138,9 @@ class GenerationConfigTest(unittest.TestCase):
         config = GenerationConfig()
         config.num_return_sequences = 2
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with warnings.catch_warnings(record=True) as captured_warnings:
+            with self.assertRaises(ValueError) as exc:
                 config.save_pretrained(tmp_dir)
-            self.assertEqual(len(captured_warnings), 1)
-            self.assertTrue("Fix these issues to save the configuration." in str(captured_warnings[0].message))
+            self.assertTrue("Fix these issues to save the configuration." in str(exc.exception))
             self.assertTrue(len(os.listdir(tmp_dir)) == 0)
 
         # final check: no warnings thrown if it is correct, and file is saved

--- a/tests/transformers/tests/generation/test_configuration_utils.py
+++ b/tests/transformers/tests/generation/test_configuration_utils.py
@@ -129,8 +129,7 @@ class GenerationConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertRaises(ValueError) as exc:
                 config.save_pretrained(tmp_dir)
-            self.assertEqual(len(captured_warnings), 1)
-            self.assertTrue("Fix these issues to save the configuration." in str(captured_warnings[0].message))
+            self.assertTrue("Fix these issues to save the configuration." in str(exc.exception))
             self.assertTrue(len(os.listdir(tmp_dir)) == 0)
 
         # greedy decoding throws an exception if we try to return multiple sequences -> throws an exception that is


### PR DESCRIPTION
# What does this PR do?

Update tests that used to throw warnings and now are `ValueError`

<!-- Remove if not applicable -->

Fixes # (issue)

Tests were out-of-date. Check transformers tests [here](https://github.com/huggingface/transformers/blob/91d155ea92da372b319a79dd4eef69533ee15170/tests/generation/test_configuration_utils.py#L183)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
