### PR TITLE
fix wrongly all_gather for mixtral finetune

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -367,7 +367,7 @@ def gaudi_mixtral_block_sparse_moe_forward(self, hidden_states: torch.Tensor) ->
     # router_logits: (batch * sequence_length, n_experts)
     router_logits = self.gate(hidden_states)
 
-    if is_deepspeed_available():
+    if is_deepspeed_available() and (not self.training):
         from deepspeed import comm as dist
 
         if dist.is_initialized():


### PR DESCRIPTION
# What does this PR do?
When enabling finetune for Mixtral-7x8b, the train_loss is totally wrong when running with deepspeed on 8 cards. We found these all_gather code were hard coded in the model code, it lead to training totally wrong.