### PR TITLE
Enable Mixtral long sequence handling for Mistral

### DIFF
--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -25,6 +25,7 @@ from typing import List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
 import torch
+import torch.nn.functional as F
 from torch import nn
 from torch.nn import CrossEntropyLoss
 from transformers.cache_utils import Cache, DynamicCache
@@ -132,6 +133,32 @@ class Matmul(torch.nn.Module):
     def forward(self, x, y):
         return torch.matmul(x, y)
 
+#Copy from GaudiMixtralAttentionLongSequence
+class GaudiMistralAttentionLongSequence:
+    @staticmethod
+    def forward(q, k, v, mask, causal, q_block_size):
+        """
+        Support long sequence at prompt phase
+        """
+        q_len = q.size(-2)
+        q_tiles = (q_len // q_block_size) if (q_len % q_block_size == 0) else math.ceil(q_len / q_block_size)
+        q_padding = q_tiles * q_block_size - q_len
+        q = F.pad(q, (0, 0, 0, q_padding), "constant", 0)
+        if mask is not None:
+            mask = F.pad(mask, (0, 0, 0, q_padding), "constant", -10000.0)
+        attn_output = torch.zeros_like(q)
+
+        for i in range(q_tiles):
+            s, e = i * q_block_size, (i + 1) * q_block_size
+            row_q = q[:, :, s:e, :]
+            row_mask = mask[:, :, s:e, :]
+            row_o = attn_output[:, :, s:e, :]
+            row_o.fill_(FusedSDPA.apply(row_q, k, v, row_mask, 0.0, causal, None))
+
+        if q_padding != 0:
+            attn_output = attn_output[:, :, :-q_padding, :]
+
+        return attn_output
 
 def gaudi_mistral_repeat_kv(
     query_states: torch.Tensor,
@@ -201,6 +228,7 @@ class GaudiMistralAttention(MistralAttention):
         self.inp_seq_len = -1
         self._init_rope()
         self.norm_factor = 1.0 / math.sqrt(self.head_dim)
+        self.block_size = 1024
 
     def _init_rope(self):
         """
@@ -342,8 +370,8 @@ class GaudiMistralAttention(MistralAttention):
         else:
             past_key_value = None
 
-        if use_flash_attention and FusedSDPA:
-            import habana_frameworks.torch.hpu as ht
+        import habana_frameworks.torch.hpu as ht
+        if FusedSDPA and use_flash_attention:
 
             if q_len == 1:
                 # next token
@@ -365,6 +393,17 @@ class GaudiMistralAttention(MistralAttention):
                         attn_output = self.fused_scaled_dot_product_attention(
                             query_states, key_states, value_states, attention_mask, 0.0, False, None
                         )
+        if FusedSDPA and not self.training and q_len == key_states.size(-2) and q_len > 8192:
+                htcore.mark_step()
+                attn_output = GaudiMistralAttentionLongSequence.forward(
+                    query_states,
+                    key_states,
+                    value_states,
+                    attention_mask,
+                    False,
+                    self.block_size,
+                )
+                htcore.mark_step()
         else:
             # repeat k/v heads if n_kv_heads < n_heads
             query_states, key_states, value_states, attention_mask = gaudi_mistral_repeat_kv(


### PR DESCRIPTION
# What does this PR do?
Currently due to the fp8 accuracy with flash_attention for 32K input, we are not able to achieve good perf/memory save for Mistral model. We are adding the mixtral special handling for long sequence so we can have better performance in the meanwhile. 

**1)bf16 + flash attention** 
Throughput (including tokenization) = 37.70360561265766 tokens/second
Number of HPU graphs                = 15
Memory allocated                    = 47.62 GB
Max memory allocated                = 91.18 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 167.49514615396038 seconds

**2) fp8 + flash attention(accuracy issue)**

Throughput (including tokenization) = 49.1110288753893 tokens/second
Number of HPU graphs                = 85
Memory allocated                    = 25.16 GB
Max memory allocated                = 68.73 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 202.75394477398368 seconds

**3) fp8 + current patch (without flash attention)**
Throughput (including tokenization) = 40.602191522997366 tokens/second
Number of HPU graphs                = 118
Memory allocated                    = 24.26 GB
Max memory allocated                = 94.55 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 165.1657100150187 seconds

Also in TGI, it shows better perf . 


































































