### PR TITLE
Fix for ImportError: cannot import name 'top_k_top_p_filtering'

### DIFF
--- a/examples/trl/requirements.txt
+++ b/examples/trl/requirements.txt
@@ -1,4 +1,4 @@
-trl == 0.7.8
+trl == 0.8.6
 peft == 0.6.2
 datasets
 wandb


### PR DESCRIPTION
Upgrading the TRL version to the latest fixes the import issue seen when running TRL related CI tests on new transformer.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
