### PR TITLE
Ensure KV cache is not returned as output tensor during decode phase for Falcon

### DIFF
--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -338,7 +338,7 @@ class GaudiFalconAttention(FalconAttention):
                             dtype=self.query_key_value.weight.dtype,
                             device=self.query_key_value.weight.device,
                         )
-                        layer_past = (past_key, past_value)
+                        layer_past = [past_key, past_value]
                     key_layer = self.k_cache.update(
                         layer_past[0], key_layer, -2, token_idx, self.inp_seq_len
                     )  # k_layer bs*1, q_len, head_dim
@@ -358,6 +358,11 @@ class GaudiFalconAttention(FalconAttention):
             kv_length = key_layer.shape[-2]
         else:
             kv_length = present[0][-2] if reuse_cache else present[0].shape[-2]
+
+        if (not reuse_cache) and (token_idx is not None) and (cache_idx is not None) and (query_length == 1):
+            # Return only past key value shapes and not the tensors during decode phase (q len is 1)
+            # to avoid making past key values as persistent output tensors of HPU graphs.
+            present = (present[0].shape, present[1].shape)
 
         if alibi is None:
             if output_attentions:
@@ -871,6 +876,7 @@ class GaudiFalconForCausalLM(FalconForCausalLM):
         **kwargs,
     ) -> dict:
         reuse_cache = kwargs.get("reuse_cache")
+        bucket_internal = kwargs.get("bucket_internal")
         if past_key_values is not None:
             if token_idx is not None:
                 input_ids = torch.index_select(input_ids, 1, token_idx - 1)
@@ -885,8 +891,9 @@ class GaudiFalconForCausalLM(FalconForCausalLM):
                     remove_prefix_length = input_ids.shape[1] - 1
 
                 input_ids = input_ids[:, remove_prefix_length:]
-        elif reuse_cache and token_idx is not None:
-            # With reuse_cache, KV cache is pre allocated hence for the 1st token we can slice the inputs till token idx for the fwd pass
+        elif (reuse_cache or bucket_internal) and token_idx is not None:
+            # KV cache is pre allocated with reuse cache or will be padded with bucket internal
+            # hence for the 1st token we can slice the inputs till token idx for the fwd pass.
             input_ids = input_ids[:, :token_idx]
             attention_mask = attention_mask[:, :token_idx]
 


### PR DESCRIPTION
This PR follows the change for llama in https://github.com/HabanaAI/optimum-habana-fork/pull/154/files
This increased the maximum batch size of BF16 falcon180b inference from 250 to 316

updated command (remove --reuse_cache)
python ../gaudi_spawn.py
--use_deepspeed --world_size 8 run_generation.py
--model_name_or_path /root/data/falcon/falcon-180b/snapshots/d2ea5531862d4fe907280234990e6380d2befd97/
--use_hpu_graphs
--use_kv_cache
--bf16
--batch_size 316
--max_new_tokens 128
--max_input_tokens 128
--limit_hpu_graphs
--n_iterations 3
--trim_logits
--bucket_internal
--bucket_size 128
--prompt "I've always managed to dodge the bullet and avoid the addictive pull of Pokemon. Leave it to a button-mashing brawler with plastic figurine accessories to finally get me hooked. At first glance, Pokemon Rumble U isn't much to look at. With its simplistic controls and repetitive gameplay, you might feel inclined to dismiss it as yet another cash-in of the popular Nintendo franchise. But despite its faults, there's actually much more to Rumble U than meets the eye, making this a satisfying and"


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
