### PR TITLE
Fixed  'MixtralConfig' object has no attribute 'rope_scaling'

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -220,6 +220,7 @@ class GaudiMixtralAttentionLongSequence:
 class GaudiMixtralAttention(MixtralAttention):
     def __init__(self, config: MixtralConfig, layer_idx: Optional[int] = None):
         super().__init__(config, layer_idx)
+        self.config = MixtralConfig(config)
         self._init_rope()
         self.k_cache = KVCache()
         self.v_cache = KVCache()


### PR DESCRIPTION
Fixed  'MixtralConfig' object has no attribute 'rope_scaling' while mistralai/Mixtral-8x7B-v0.1 training with examples/language-modeling/run_clm.py.

# What does this PR do?


Fixes # (issue)
optimum-habana will crash with "AttributeError: 'MixtralConfig' object has no attribute 'rope_scaling'"

Below is the command line:
```
DEEPSPEED_HPU_ZERO3_SYNC_MARK_STEP_REQUIRED=1 python ../gaudi_spawn.py --world_size 8 --use_deepspeed \
run_clm.py --model_name_or_path mistralai/Mixtral-8x7B-v0.1 \
--dataset_name wikitext --dataset_config_name wikitext-2-raw-v1 \
--per_device_train_batch_size 1 --per_device_eval_batch_size 1 --do_train --do_eval \
--learning_rate 4e-4 --output_dir ./test-clm_streaming --gaudi_config_name Habana/gpt2 \
--use_habana --use_lazy_mode --use_cache False --throughput_warmup_steps 3 --max_steps 2 \
--block_size 512 --deepspeed ../../tests/configs/deepspeed_zero_3_gaudi1.json \
--overwrite_output_dir --gradient_checkpointing
```

And crash stack:
```
Traceback (most recent call last):
  File "/workspace/optimum-habana/examples/language-modeling/run_clm.py", line 692, in <module>
    main()
  File "/workspace/optimum-habana/examples/language-modeling/run_clm.py", line 454, in main
    model = AutoModelForCausalLM.from_pretrained(
...
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mixtral/modeling_mixtral.py", line 223, in __init__
    self._init_rope()
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mixtral/modeling_mixtral.py", line 234, in _init_rope
    if self.config.rope_scaling is None:
  File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 265, in __getattribute__
    return super().__getattribute__(key)
AttributeError: 'MixtralConfig' object has no attribute 'rope_scaling'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
