### PR TITLE
Update test stopping criteria 4.40

### DIFF
--- a/optimum/habana/transformers/generation/stopping_criteria.py
+++ b/optimum/habana/transformers/generation/stopping_criteria.py
@@ -90,7 +90,7 @@ def needs_tensor_output(token_idx, ignore_eos, eos_token_id) -> bool:
         return not ignore_eos and eos_token_id is not None
     else:
         # token_idx is present, so we have static shapes, so using single boolean
-        False
+        return False
 
 
 def gaudi_StoppingCriteriaList_call(
@@ -101,7 +101,7 @@ def gaudi_StoppingCriteriaList_call(
     )
     is_done = (
         torch.full((input_ids.shape[0],), 0, device=input_ids.device, dtype=torch.int8)
-        if kwargs["out_type_tensor"]
+        if kwargs["needs_tensor_output"]
         else False
     )
     for criteria in self:

--- a/tests/transformers/tests/generation/test_stopping_criteria.py
+++ b/tests/transformers/tests/generation/test_stopping_criteria.py
@@ -17,14 +17,16 @@ import time
 import unittest
 
 from transformers import is_torch_available
-from transformers.testing_utils import require_torch, torch_device
+from transformers.testing_utils import require_torch
 
-from ..test_modeling_common import ids_tensor
+from ..test_modeling_common import ids_tensor, torch_device
 
 
 if is_torch_available():
     import torch
+
     from transformers.generation import (
+        EosTokenCriteria,
         MaxLengthCriteria,
         MaxNewTokensCriteria,
         MaxTimeCriteria,
@@ -53,37 +55,37 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             ]
         )
 
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(9)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(10)
-        self.assertTrue(criteria(input_ids, scores))
+        self.assertTrue(all(criteria(input_ids, scores)))
 
     def test_max_length_criteria(self):
         criteria = MaxLengthCriteria(max_length=10)
 
         input_ids, scores = self._get_tensors(5)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(9)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(10)
-        self.assertTrue(criteria(input_ids, scores))
+        self.assertTrue(all(criteria(input_ids, scores)))
 
     def test_max_new_tokens_criteria(self):
         criteria = MaxNewTokensCriteria(start_length=5, max_new_tokens=5)
 
         input_ids, scores = self._get_tensors(5)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(9)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         input_ids, scores = self._get_tensors(10)
-        self.assertTrue(criteria(input_ids, scores))
+        self.assertTrue(all(criteria(input_ids, scores)))
 
         criteria_list = StoppingCriteriaList([criteria])
         self.assertEqual(criteria_list.max_length, 10)
@@ -92,10 +94,26 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         input_ids, scores = self._get_tensors(5)
 
         criteria = MaxTimeCriteria(max_time=0.1)
-        self.assertFalse(criteria(input_ids, scores))
+        self.assertFalse(all(criteria(input_ids, scores)))
 
         criteria = MaxTimeCriteria(max_time=0.1, initial_timestamp=time.time() - 0.2)
-        self.assertTrue(criteria(input_ids, scores))
+        self.assertTrue(all(criteria(input_ids, scores)))
+
+    def test_eos_token_criteria(self):
+        criteria = EosTokenCriteria(eos_token_id=0)
+
+        input_ids, scores = self._get_tensors(5)
+        input_ids[:, -1] = 0
+        self.assertTrue(all(criteria(input_ids, scores)))
+
+        input_ids, scores = self._get_tensors(5)
+        input_ids[:2, -1] = 0
+        input_ids[2, -1] = 1
+        self.assertListEqual(criteria(input_ids, scores).tolist(), [True, True, False])
+
+        input_ids, scores = self._get_tensors(5)
+        input_ids[:, -1] = 1
+        self.assertListEqual(criteria(input_ids, scores).tolist(), [False, False, False])
 
     def test_validate_stopping_criteria(self):
         validate_stopping_criteria(StoppingCriteriaList([MaxLengthCriteria(10)]), 10)

--- a/tests/transformers/tests/generation/test_stopping_criteria.py
+++ b/tests/transformers/tests/generation/test_stopping_criteria.py
@@ -94,26 +94,31 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         input_ids, scores = self._get_tensors(5)
 
         criteria = MaxTimeCriteria(max_time=0.1)
-        self.assertFalse(all(criteria(input_ids, scores)))
+        self.assertFalse(all(criteria(input_ids, scores, needs_tensor_output=True)))
+        self.assertFalse(criteria(input_ids, scores, needs_tensor_output=False))
 
         criteria = MaxTimeCriteria(max_time=0.1, initial_timestamp=time.time() - 0.2)
-        self.assertTrue(all(criteria(input_ids, scores)))
+        self.assertTrue(all(criteria(input_ids, scores, needs_tensor_output=True)))
+        self.assertTrue(criteria(input_ids, scores, needs_tensor_output=False))
 
     def test_eos_token_criteria(self):
         criteria = EosTokenCriteria(eos_token_id=0)
 
         input_ids, scores = self._get_tensors(5)
         input_ids[:, -1] = 0
-        self.assertTrue(all(criteria(input_ids, scores)))
+        self.assertTrue(all(criteria(input_ids, scores, needs_tensor_output=True)))
+        self.assertTrue(criteria(input_ids, scores, needs_tensor_output=False))
 
         input_ids, scores = self._get_tensors(5)
         input_ids[:2, -1] = 0
         input_ids[2, -1] = 1
-        self.assertListEqual(criteria(input_ids, scores).tolist(), [True, True, False])
+        self.assertListEqual(criteria(input_ids, scores, needs_tensor_output=True).tolist(), [True, True, False])
+        self.assertFalse(criteria(input_ids, scores, needs_tensor_output=False))
 
         input_ids, scores = self._get_tensors(5)
         input_ids[:, -1] = 1
-        self.assertListEqual(criteria(input_ids, scores).tolist(), [False, False, False])
+        self.assertListEqual(criteria(input_ids, scores, needs_tensor_output=True).tolist(), [False, False, False])
+        self.assertFalse(criteria(input_ids, scores, needs_tensor_output=False))
 
     def test_validate_stopping_criteria(self):
         validate_stopping_criteria(StoppingCriteriaList([MaxLengthCriteria(10)]), 10)


### PR DESCRIPTION
# What does this PR do?

Update tests for Transformers v4.40.
- New test function: `test_eos_token_criteria`

Fixes `generation/stopping_criteria.py`:
- `needs_tensor_output` wasn't returning `False` in the `else`.
- Remove the need of `out_type_tensor` in the `gaudi_StoppingCriteriaList_call`. The output of each stopping criteria and the final output needs to be consistent. 



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
