### PR TITLE
Fix text-generation example

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -20,7 +20,6 @@ import math
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
-import habana_frameworks.torch.hpu as torch_hpu
 import torch
 import torch.distributed as dist
 from transformers.generation.beam_constraints import DisjunctiveConstraint, PhrasalConstraint
@@ -1590,6 +1589,8 @@ class GaudiGenerationMixin(GenerationMixin):
             if hb_gen_time is not None:
                 if not time_to_first_token_done:
                     time_to_first_token_done = True
+                    import habana_frameworks.torch.hpu as torch_hpu
+
                     torch_hpu.synchronize()
                 hb_gen_time.step()
             if this_peer_finished and not synced_gpus:
@@ -1971,6 +1972,8 @@ class GaudiGenerationMixin(GenerationMixin):
             if hb_gen_time is not None:
                 if not time_to_first_token_done:
                     time_to_first_token_done = True
+                    import habana_frameworks.torch.hpu as torch_hpu
+
                     torch_hpu.synchronize()
                 hb_gen_time.step()
             if this_peer_finished and not synced_gpus:
@@ -2537,6 +2540,8 @@ class GaudiGenerationMixin(GenerationMixin):
             if hb_gen_time is not None:
                 if not time_to_first_token_done:
                     time_to_first_token_done = True
+                    import habana_frameworks.torch.hpu as torch_hpu
+
                     torch_hpu.synchronize()
                 hb_gen_time.step()
         hb_profer.stop()
@@ -3253,6 +3258,8 @@ class GaudiGenerationMixin(GenerationMixin):
             if hb_gen_time is not None:
                 if not time_to_first_token_done:
                     time_to_first_token_done = True
+                    import habana_frameworks.torch.hpu as torch_hpu
+
                     torch_hpu.synchronize()
                 hb_gen_time.step()
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

#1019 added the import `import habana_frameworks.torch.hpu as torch_hpu` at the top of `optimum/habana/transformers/generation/utils.py`. This makes the text-generation example use DeepSpeed even for 1x commands, for instance:
```
python run_generation.py --model_name_or_path mistralai/Mistral-7B-v0.3 --use_hpu_graphs --use_kv_cache --limit_hpu_graphs --bucket_size 128 --max_new_tokens 128 --batch_size 1 --bf16
```
Also, env variables like `PT_HPU_ENABLE_LAZY_COLLECTIVES` seem to be set before they are set in the example, leading to an error. For example with OPT:
```
GAUDI2_CI=1 pytest tests/test_text_generation_example.py -k "opt"
```
leading to
```
RuntimeError: collective nonSFG is not supported during hpu graph capturing
```

The `__init__.py` of `habana_frameworks.torch` imports `habana_frameworks.torch.distributed.hccl` which will call `initialize_distributed_hpu`. I suspect this is the reason for this issue, as it must set some env variables like `WORLD_SIZE`.

This PR moves this import to the place where it is needed in the code to fix this problem.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
