### PR TITLE
sdxl-trainig: fixed ci, changed gated dataset, fixes for non-square datasets

### DIFF
--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -230,11 +230,11 @@ python ../../gaudi_spawn.py --world_size 8 --use_mpi train_text_to_image_sdxl.py
 
 ### Single-card Training on Gaudi1
 ```bash
-PT_HPU_MAX_COMPOUND_OP_SIZE=5 python train_text_to_image_sdxl.py \
+python train_text_to_image_sdxl.py \
   --pretrained_model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
   --pretrained_vae_model_name_or_path madebyollin/sdxl-vae-fp16-fix \
   --dataset_name lambdalabs/naruto-blip-captions \
-  --resolution 512 \
+  --resolution 256 \
   --center_crop \
   --random_flip \
   --proportion_empty_prompts=0.2 \

--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -168,8 +168,8 @@ pip install -r requirements.txt
 ```bash
 python train_text_to_image_sdxl.py \
   --pretrained_model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
-  --pretrained_vae_model_name_or_path stabilityai/sdxl-vae \
-  --dataset_name lambdalabs/pokemon-blip-captions \
+  --pretrained_vae_model_name_or_path madebyollin/sdxl-vae-fp16-fix \
+  --dataset_name lambdalabs/naruto-blip-captions \
   --resolution 512 \
   --crop_resolution 512 \
   --center_crop \
@@ -181,14 +181,14 @@ python train_text_to_image_sdxl.py \
   --max_grad_norm 1 \
   --lr_scheduler constant \
   --lr_warmup_steps 0 \
-  --output_dir sdxl-pokemon-model \
+  --output_dir sdxl_model_output \
   --gaudi_config_name Habana/stable-diffusion \
   --throughput_warmup_steps 3 \
   --dataloader_num_workers 8 \
   --bf16 \
   --use_hpu_graphs_for_training \
   --use_hpu_graphs_for_inference \
-  --validation_prompt="a robotic cat with wings" \
+  --validation_prompt="a cute Sundar Pichai creature" \
   --validation_epochs 48 \
   --checkpointing_steps 2500 \
   --logging_step 10 \
@@ -201,8 +201,8 @@ python train_text_to_image_sdxl.py \
 PT_HPU_RECIPE_CACHE_CONFIG=/tmp/stdxl_recipe_cache,True,1024  \
 python ../../gaudi_spawn.py --world_size 8 --use_mpi train_text_to_image_sdxl.py \
   --pretrained_model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
-  --pretrained_vae_model_name_or_path stabilityai/sdxl-vae \
-  --dataset_name lambdalabs/pokemon-blip-captions \
+  --pretrained_vae_model_name_or_path madebyollin/sdxl-vae-fp16-fix \
+  --dataset_name lambdalabs/naruto-blip-captions \
   --resolution 512 \
   --crop_resolution 512 \
   --center_crop \
@@ -214,17 +214,17 @@ python ../../gaudi_spawn.py --world_size 8 --use_mpi train_text_to_image_sdxl.py
   --max_grad_norm 1 \
   --lr_scheduler constant \
   --lr_warmup_steps 0 \
-  --output_dir sdxl-pokemon-model \
+  --output_dir sdxl_model_output \
   --gaudi_config_name Habana/stable-diffusion \
   --throughput_warmup_steps 3 \
   --dataloader_num_workers 8 \
   --bf16 \
   --use_hpu_graphs_for_training \
   --use_hpu_graphs_for_inference \
-  --validation_prompt="a robotic cat with wings" \
+  --validation_prompt="a cute Sundar Pichai creature" \
   --validation_epochs 48 \
   --checkpointing_steps 336 \
-  --mediapipe dataset_sdxl_pokemon \
+  --mediapipe dataset_sdxl_mediapipe \
   --adjust_throughput
 ```
 
@@ -232,8 +232,8 @@ python ../../gaudi_spawn.py --world_size 8 --use_mpi train_text_to_image_sdxl.py
 ```bash
 PT_HPU_MAX_COMPOUND_OP_SIZE=5 python train_text_to_image_sdxl.py \
   --pretrained_model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
-  --pretrained_vae_model_name_or_path stabilityai/sdxl-vae \
-  --dataset_name lambdalabs/pokemon-blip-captions \
+  --pretrained_vae_model_name_or_path madebyollin/sdxl-vae-fp16-fix \
+  --dataset_name lambdalabs/naruto-blip-captions \
   --resolution 512 \
   --center_crop \
   --random_flip \
@@ -245,7 +245,7 @@ PT_HPU_MAX_COMPOUND_OP_SIZE=5 python train_text_to_image_sdxl.py \
   --max_grad_norm 1 \
   --lr_scheduler constant \
   --lr_warmup_steps 0 \
-  --output_dir sdxl-pokemon-model \
+  --output_dir sdxl_model_output \
   --gaudi_config_name Habana/stable-diffusion \
   --throughput_warmup_steps 3 \
   --use_hpu_graphs_for_training \
@@ -387,7 +387,7 @@ You can launch training using:
 export MODEL_NAME="stabilityai/stable-diffusion-xl-base-1.0"
 export INSTANCE_DIR="dog"
 export OUTPUT_DIR="lora-trained-xl"
-export VAE_PATH="stabilityai/sdxl-vae"
+export VAE_PATH="madebyollin/sdxl-vae-fp16-fix"
 
 python ../../gaudi_spawn.py --world_size 8 --use_mpi train_dreambooth_lora_sdxl.py \
   --pretrained_model_name_or_path=$MODEL_NAME  \

--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -188,7 +188,7 @@ python train_text_to_image_sdxl.py \
   --bf16 \
   --use_hpu_graphs_for_training \
   --use_hpu_graphs_for_inference \
-  --validation_prompt="a cute Sundar Pichai creature" \
+  --validation_prompt="a cute naruto creature" \
   --validation_epochs 48 \
   --checkpointing_steps 2500 \
   --logging_step 10 \
@@ -221,7 +221,7 @@ python ../../gaudi_spawn.py --world_size 8 --use_mpi train_text_to_image_sdxl.py
   --bf16 \
   --use_hpu_graphs_for_training \
   --use_hpu_graphs_for_inference \
-  --validation_prompt="a cute Sundar Pichai creature" \
+  --validation_prompt="a cute naruto creature" \
   --validation_epochs 48 \
   --checkpointing_steps 336 \
   --mediapipe dataset_sdxl_mediapipe \

--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -250,6 +250,7 @@ python train_text_to_image_sdxl.py \
   --throughput_warmup_steps 3 \
   --use_hpu_graphs_for_training \
   --use_hpu_graphs_for_inference \
+  --checkpointing_steps 3000 \
   --bf16
 ```
 

--- a/examples/stable-diffusion/training/train_text_to_image_sdxl.py
+++ b/examples/stable-diffusion/training/train_text_to_image_sdxl.py
@@ -934,21 +934,16 @@ def main(args):
         for image in images:
             original_sizes.append((image.height, image.width))
             image = train_resize(image)
-            if args.crop_resolution < args.resolution:
-                if args.center_crop:
-                    y1 = max(0, int(round((image.height - args.resolution) / 2.0)))
-                    x1 = max(0, int(round((image.width - args.resolution) / 2.0)))
-                    image = train_crop(image)
-                else:
-                    y1, x1, h, w = train_crop.get_params(image, (args.resolution, args.resolution))
-                    image = crop(image, y1, x1, h, w)
-            else:
-                x1 = 0
-                y1 = 0
             if args.random_flip and random.random() < 0.5:
                 # flip
-                x1 = image.width - x1
                 image = train_flip(image)
+            if args.center_crop:
+                y1 = max(0, int(round((image.height - args.resolution) / 2.0)))
+                x1 = max(0, int(round((image.width - args.resolution) / 2.0)))
+                image = train_crop(image)
+            else:
+                y1, x1, h, w = train_crop.get_params(image, (args.resolution, args.resolution))
+                image = crop(image, y1, x1, h, w)
             crop_top_left = (y1, x1)
             crop_top_lefts.append(crop_top_left)
             image = train_transforms(image)

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -26,7 +26,6 @@ from typing import Union
 from unittest import TestCase, skipUnless
 
 import numpy as np
-import pytest
 import requests
 import safetensors
 import torch
@@ -1795,8 +1794,11 @@ class TrainTextToImage(TestCase):
             self.assertEqual(return_code, 0)
 
             # save_pretrained smoke test
-            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "checkpoint-2", "unet", "diffusion_pytorch_model.safetensors")))
+            self.assertTrue(
+                os.path.isfile(os.path.join(tmpdir, "checkpoint-2", "unet", "diffusion_pytorch_model.safetensors"))
+            )
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "checkpoint-2", "unet", "config.json")))
+
 
 class TrainControlNet(TestCase):
     """

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -1749,7 +1749,6 @@ class TrainTextToImage(TestCase):
         self.assertEqual(return_code, 0)
 
     @slow
-    @pytest.mark.skip(reason="The dataset used in this test is not available at the moment.")
     def test_train_text_to_image_sdxl(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path_to_script = (
@@ -1764,11 +1763,10 @@ class TrainTextToImage(TestCase):
                  python3
                  {path_to_script}
                  --pretrained_model_name_or_path stabilityai/stable-diffusion-xl-base-1.0
-                 --pretrained_vae_model_name_or_path stabilityai/sdxl-vae
-                 --dataset_name lambdalabs/pokemon-blip-captions
-                 --resolution 512
-                 --crop_resolution 512
-                 --center_crop
+                 --pretrained_vae_model_name_or_path madebyollin/sdxl-vae-fp16-fix
+                 --dataset_name lambdalabs/naruto-blip-captions
+                 --resolution 64
+                 --crop_resolution 64
                  --random_flip
                  --proportion_empty_prompts=0.2
                  --train_batch_size 16
@@ -1782,7 +1780,10 @@ class TrainTextToImage(TestCase):
                  --use_hpu_graphs_for_training
                  --use_hpu_graphs_for_inference
                  --bf16
+                 --adjust_throughput
+                 --center_crop
                  --max_train_steps 2
+                 --checkpointing_steps 2
                  --output_dir {tmpdir}
                 """.split()
 
@@ -1794,9 +1795,8 @@ class TrainTextToImage(TestCase):
             self.assertEqual(return_code, 0)
 
             # save_pretrained smoke test
-            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "unet", "diffusion_pytorch_model.safetensors")))
-            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
-
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "checkpoint-2", "unet", "diffusion_pytorch_model.safetensors")))
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "checkpoint-2", "unet", "config.json")))
 
 class TrainControlNet(TestCase):
     """


### PR DESCRIPTION
# What does this PR do?
Mirrors the changes here https://github.com/huggingface/diffusers/commit/8edaf3b79c564a56fbffb003ee74ac92e9162a73

@regisss  @dsocek  @libinta 
Hi team, 
Opening this PR to fix up some SDXL issues related to gated dataset. Tests are completed and provided in below. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
gated dataset for sdxl training 


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?

## Tests
### 1x HPU 
```bash
------------------------------------------------------------------------------
{'attention_type', 'reverse_transformer_layers_per_block', 'dropout'} was not found in config. Values will be initialized to default values.
Repo card metadata block was not found. Setting CardData to empty.
06/04/2024 15:04:42 - WARNING - huggingface_hub.repocard - Repo card metadata block was not found. Setting CardData to empty.
Map: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1221/1221 [01:03<00:00, 19.16 examples/s]
06/04/2024 15:05:49 - INFO - __main__ - ***** Running training *****
06/04/2024 15:05:49 - INFO - __main__ -   Num examples = 1221
06/04/2024 15:05:49 - INFO - __main__ -   Num Epochs = 33
06/04/2024 15:05:49 - INFO - __main__ -   Instantaneous batch size per device = 16
06/04/2024 15:05:49 - INFO - __main__ -   Total train batch size (w. parallel, distributed & accumulation) = 16
06/04/2024 15:05:49 - INFO - __main__ -   Gradient Accumulation steps = 1
06/04/2024 15:05:49 - INFO - __main__ -   Total optimization steps = 2500
|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2500/2500 [37:34<00:00,  2.11it/s, lr=1e-5, mem_used=91.7, step_loss=0.0766]06/04/2024 15:43:23 - INFO - accelerate.accelerator - Saving current state to sdxl-pokemon-model/checkpoint-2500
Configuration saved in sdxl-pokemon-model/checkpoint-2500/unet/config.json
Model weights saved in sdxl-pokemon-model/checkpoint-2500/unet/diffusion_pytorch_model.safetensors
```

### 8x HPU  
```bash
Map: 100%|██████████| 1221/1221 [00:02<00:00, 470.95 examples/s]
Map: 100%|██████████| 1221/1221 [00:02<00:00, 467.38 examples/s]
Map: 100%|██████████| 1221/1221 [00:02<00:00, 462.32 examples/s]
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
MediaPipe device GAUDI2 device_type GAUDI2 device_id 0 pipe_name SDXLMediaPipe:0
06/04/2024 17:12:23 - INFO - media_pipe_imgdir - Finding largest file ...
06/04/2024 17:12:23 - INFO - __main__ - ***** Running training *****
06/04/2024 17:12:23 - INFO - __main__ -   Num examples = 1221
06/04/2024 17:12:23 - INFO - __main__ -   Num Epochs = 38
06/04/2024 17:12:23 - INFO - __main__ -   Instantaneous batch size per device = 16
06/04/2024 17:12:23 - INFO - __main__ -   Total train batch size (w. parallel, distributed & accumulation) = 128
06/04/2024 17:12:23 - INFO - __main__ -   Gradient Accumulation steps = 1
06/04/2024 17:12:23 - INFO - __main__ -   Total optimization steps = 336
Steps:   0%|          | 0/336 [00:00<?, ?it/s]Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:24 - INFO - media_pipe_imgdir - Finding largest file ...
06/04/2024 17:12:24 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:25 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:26 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:29 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:31 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
06/04/2024 17:12:37 - INFO - media_pipe_imgdir - Finding largest file ...
Warning: Decoder updated User configured Interpolation from Bilinear to Bicubic
Steps: 100%|██████████| 336/336 [22:55<00:00,  1.92it/s, lr=1e-5, mem_used=86.2, step_loss=0.101]06/04/2024 17:35:18 - INFO - accelerate.accelerator - Saving current state to sdxl_model_output/checkpoint-336
Configuration saved in sdxl_model_output/checkpoint-336/unet/config.json
Model weights saved in sdxl_model_output/checkpoint-336/unet/diffusion_pytorch_model.safetensors
```

### CI
```bash
You are using a model of type clip_text_model to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
You are using a model of type clip_text_model to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
{'thresholding', 'dynamic_thresholding_ratio', 'clip_sample_range', 'variance_type', 'rescale_betas_zero_snr'} was not found in config. Values will be initialized to default values.
============================= HABANA PT BRIDGE CONFIGURATION ===========================
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH =
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG =
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
---------------------------: System Configuration :---------------------------
Num CPU Cores : 160
CPU RAM       : 1056375232 KB
------------------------------------------------------------------------------
{'attention_type', 'reverse_transformer_layers_per_block', 'dropout'} was not found in config. Values will be initialized to default values.
Repo card metadata block was not found. Setting CardData to empty.
06/04/2024 18:05:04 - WARNING - huggingface_hub.repocard - Repo card metadata block was not found. Setting CardData to empty.
Map:   0%|                                                                                                                                                                                             | 0/1221 [00:00<?, ? examples/s]Map: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1221/1221 [00:56<00:00, 21.59 examples/s]
06/04/2024 18:06:03 - INFO - __main__ - ***** Running training *****
06/04/2024 18:06:03 - INFO - __main__ -   Num examples = 1221
06/04/2024 18:06:03 - INFO - __main__ -   Num Epochs = 1
06/04/2024 18:06:03 - INFO - __main__ -   Instantaneous batch size per device = 16
06/04/2024 18:06:03 - INFO - __main__ -   Total train batch size (w. parallel, distributed & accumulation) = 16
06/04/2024 18:06:03 - INFO - __main__ -   Gradient Accumulation steps = 1
06/04/2024 18:06:03 - INFO - __main__ -   Total optimization steps = 2
Steps: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [06:20<00:00, 192.97s/it, lr=1e-5, mem_used=25, step_loss=0.342]06/04/2024 18:12:23 - INFO - accelerate.accelerator - Saving current state to /tmp/tmp2m2qr9t8/checkpoint-2
Configuration saved in /tmp/tmp2m2qr9t8/checkpoint-2/unet/config.json
Model weights saved in /tmp/tmp2m2qr9t8/checkpoint-2/unet/diffusion_pytorch_model.safetensors
06/04/2024 18:17:37 - INFO - accelerate.checkpointing - Optimizer state saved in /tmp/tmp2m2qr9t8/checkpoint-2/optimizer.bin
06/04/2024 18:17:37 - INFO - accelerate.checkpointing - Scheduler state saved in /tmp/tmp2m2qr9t8/checkpoint-2/scheduler.bin
06/04/2024 18:17:37 - INFO - accelerate.checkpointing - Sampler state for dataloader 0 saved in /tmp/tmp2m2qr9t8/checkpoint-2/sampler.bin
06/04/2024 18:17:37 - INFO - accelerate.checkpointing - Random states saved in /tmp/tmp2m2qr9t8/checkpoint-2/random_states_0.pkl
06/04/2024 18:17:37 - INFO - __main__ - Saved state to /tmp/tmp2m2qr9t8/checkpoint-2
Steps: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [11:34<00:00, 347.22s/it, lr=1e-5, mem_used=25.1, step_loss=0.387]
PASSED

========================================================================================================== warnings summary ===========================================================================================================
../../usr/local/lib/python3.10/dist-packages/diffusers/utils/outputs.py:63
../../usr/local/lib/python3.10/dist-packages/diffusers/utils/outputs.py:63
  /usr/local/lib/python3.10/dist-packages/diffusers/utils/outputs.py:63: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    torch.utils._pytree._register_pytree_node(

../../usr/local/lib/python3.10/dist-packages/lightning_utilities/core/imports.py:14
  /usr/local/lib/python3.10/dist-packages/lightning_utilities/core/imports.py:14: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2825
  /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2825: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 2 passed, 60 deselected, 4 warnings in 777.32s (0:12:57) =======================================================================================
```
