### PR TITLE
Fix a return value issue casued by PR 973

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -149,7 +149,7 @@ class HabanaModelAdapter(lm_eval.base.BaseLM):
 
 def main():
     args = setup_lm_eval_parser()
-    model, tokenizer, generation_config = initialize_model(args, logger)
+    model, _, tokenizer, generation_config = initialize_model(args, logger)
 
     lm_tasks = lm_eval.tasks.get_task_dict(args.tasks)
     with torch.no_grad():


### PR DESCRIPTION
# What does this PR do?

Fix a minor issue caused by initialize_model in utils.py 
In https://github.com/huggingface/optimum-habana/blob/306981885de235a5be0c52ac07682d22f0c17bd7/examples/text-generation/run_lm_eval.py#L152 three values are expected, but the function after PR https://github.com/huggingface/optimum-habana/pull/973 returns four values of `model, assistant_model, tokenizer, generation_config` 

Fixes a `ValueError` issue 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
