### PR TITLE
fix bug of model `infloat/e5-mistral-7b-instruct` return error 'MistralConfig' object has no attribute 'rope_scaling'`'

### DIFF
--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -31,7 +31,7 @@ from torch.nn import CrossEntropyLoss
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask_for_sdpa
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
-from transformers.models.mistral.configuration_mistral import MistralConfig
+from .configuration_mistral import MistralConfig
 from transformers.models.mistral.modeling_mistral import (
     MistralAttention,
     MistralDecoderLayer,
@@ -222,6 +222,7 @@ def gaudi_mistral_rmsnorm_forward(self, hidden_states):
 class GaudiMistralAttention(MistralAttention):
     def __init__(self, config: MistralConfig, layer_idx: Optional[int] = None):
         super().__init__(config, layer_idx)
+        self.config = MistralConfig(config)
         self.k_cache = KVCache()
         self.v_cache = KVCache()
         self.matmul_qk = Matmul()
@@ -461,6 +462,7 @@ class GaudiMistralAttention(MistralAttention):
 class GaudiMistralDecoderLayer(MistralDecoderLayer):
     def __init__(self, config: MistralConfig, layer_idx: int):
         super(MistralDecoderLayer, self).__init__()
+
         self.hidden_size = config.hidden_size
 
         self.self_attn = GaudiMistralAttention(config, layer_idx)


### PR DESCRIPTION
fix the bug that when loading model `infloat/e5-mistral-7b-instruct`, optimum habana returns error like
`File "/usr/src/backends/python/server/text_embeddings_server/models/__init__.py", line 69, in get_model
    return DefaultModel(model_path, device, dtype)

  File "/usr/src/backends/python/server/text_embeddings_server/models/default_model.py", line 24, in __init__
    model = AutoModel.from_pretrained(model_path).to(dtype).to(device)

  File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/auto_factory.py", line 563, in from_pretrained
    return model_class.from_pretrained(

  File "/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py", line 3550, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)

  File "/usr/local/lib/python3.10/dist-packages/transformers/models/mistral/modeling_mistral.py", line 916, in __init__
    [MistralDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
                                                                                                                                                                                                                                                                                              File "/usr/local/lib/python3.10/dist-packages/transformers/models/mistral/modeling_mistral.py", line 916, in <listcomp>
    [MistralDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]

  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mistral/modeling_mistral.py", line 470, in __init__
    self.self_attn = GaudiMistralAttention(config, layer_idx)                                                                                                                                                                                                                               
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mistral/modeling_mistral.py", line 232, in __init__
    self._init_rope()

  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mistral/modeling_mistral.py", line 243, in _init_rope
    if self.config.rope_scaling is None:

  File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 263, in __getattribute__
    return super().__getattribute__(key)

AttributeError: 'MistralConfig' object has no attribute 'rope_scaling'`