### PR TITLE
Fix Starcoder2 language modeling support

### DIFF
--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -607,7 +607,7 @@ def main():
         padding_val = True
         add_special_tokens_val = True
         if tokenizer.pad_token is None:
-            tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+            tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
     def tokenize(prompt, add_eos_token=True):
         results = tokenizer(

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -600,13 +600,23 @@ def main():
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id
 
+    padding_val = False
+    add_special_tokens_val = False
+
+    if model.config.model_type == "starcoder2":
+        padding_val = True
+        add_special_tokens_val = True
+        if tokenizer.pad_token is None:
+            tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+
     def tokenize(prompt, add_eos_token=True):
         results = tokenizer(
             prompt,
             truncation=True,
             max_length=data_args.max_seq_length,
-            padding=False,
+            padding=padding_val,
             return_tensors=None,
+            add_special_tokens=add_special_tokens_val,
         )
         for i in range(len(results["input_ids"])):
             if (

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -475,6 +475,10 @@ def main():
         )
 
         if "validation" not in raw_datasets.keys() and training_args.do_eval:
+            if not data_args.validation_split_percentage:
+                raise ValueError(
+                    "Cannot find 'validation' key in dataset, please set --validation_split_percentage or use a different dataset"
+                )
             raw_datasets["validation"] = load_dataset(
                 data_args.dataset_name,
                 data_args.dataset_config_name,
@@ -604,10 +608,11 @@ def main():
     add_special_tokens_val = False
 
     if model.config.model_type == "starcoder2":
+        add_special_tokens_val = False
         padding_val = True
-        add_special_tokens_val = True
         if tokenizer.pad_token is None:
             tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+            add_special_tokens_val = True
 
     def tokenize(prompt, add_eos_token=True):
         results = tokenizer(

--- a/tests/baselines/starcoder2_3b.json
+++ b/tests/baselines/starcoder2_3b.json
@@ -1,20 +1,28 @@
 {
     "gaudi2": {
-    "wikitext": {
+    "timdettmers/openassistant-guanaco": {
         "num_train_epochs": 2,
         "eval_batch_size": 4,
         "distribution": {
             "multi_card": {
                 "learning_rate": 1e-4,
                 "train_batch_size": 16,
-                "perplexity": 13.0461,
-                "train_runtime": 190.696,
-                "train_samples_per_second": 89.877,
+                "perplexity": 4.9335,
+                "train_runtime": 266.99,
+                "train_samples_per_second": 66.376,
                 "extra_arguments": [
-                    "--dataset_config_name wikitext-2-raw-v1",
                     "--dataset_concatenation",
                     "--gradient_accumulation_steps 4",
-                    "--use_hpu_graphs_for_inference"
+                    "--bf16 True ",
+                    "--num_train_epochs 2 ",
+                    "--per_device_train_batch_size 2 ",
+                    "--per_device_eval_batch_size 2 ",
+                    "--gradient_accumulation_steps 4 ",
+                    "--dataset_concatenation ",
+                    "--use_habana ",
+                    "--use_lazy_mode ",
+                    "--lora_target_modules q_proj o_proj k_proj v_proj gate_proj up_proj down_proj",
+                    "--validation_split_percentage 10"
                                 ]
                 }
         }

--- a/tests/baselines/starcoder2_3b.json
+++ b/tests/baselines/starcoder2_3b.json
@@ -1,0 +1,23 @@
+{
+    "gaudi2": {
+    "wikitext": {
+        "num_train_epochs": 2,
+        "eval_batch_size": 4,
+        "distribution": {
+            "multi_card": {
+                "learning_rate": 1e-4,
+                "train_batch_size": 16,
+                "perplexity": 13.0461,
+                "train_runtime": 190.696,
+                "train_samples_per_second": 89.877,
+                "extra_arguments": [
+                    "--dataset_config_name wikitext-2-raw-v1",
+                    "--dataset_concatenation",
+                    "--gradient_accumulation_steps 4",
+                    "--use_hpu_graphs_for_inference"
+                                ]
+                }
+        }
+    }
+}
+}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -206,6 +206,7 @@ class ExampleTestMeta(type):
             "codellama/CodeLlama-13b-Instruct-hf",
             "MIT/ast-finetuned-speech-commands-v2",
             "meta-llama/LlamaGuard-7b",
+            "bigcode/starcoder2-3b",
         ]
 
         if fsdp and not IS_GAUDI2:
@@ -248,6 +249,8 @@ class ExampleTestMeta(type):
         elif "LlamaGuard" in model_name and deepspeed and IS_GAUDI2:
             return True
         elif "ast-finetuned-speech-commands-v2" in model_name and IS_GAUDI2:
+            return True
+        elif "starcoder2" in model_name and IS_GAUDI2 and not fsdp:
             return True
 
         return False

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -154,7 +154,7 @@ _SCRIPT_TO_MODEL_MAPPING = {
     "run_lora_clm": _get_supported_models_for_script(
         MODELS_TO_TEST_MAPPING,
         MODEL_FOR_CAUSAL_LM_MAPPING,
-        ["llama", "falcon"],
+        ["llama", "falcon", "starcoder2"],
     ),
     "run_speech_recognition_seq2seq": _get_supported_models_for_script(
         MODELS_TO_TEST_MAPPING,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,6 +60,7 @@ MODELS_TO_TEST_MAPPING = {
     "llama_guard": [("meta-llama/LlamaGuard-7b", "Habana/llama")],
     "code_llama": [("codellama/CodeLlama-13b-Instruct-hf", "Habana/llama")],
     "protst": [("mila-intel/protst-esm1b-for-sequential-classification", "Habana/gpt2")],
+    "starcoder2":  [("bigcode/starcoder2-3b", "Habana/gpt2")],
 }
 
 MODELS_TO_TEST_FOR_QUESTION_ANSWERING = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,7 +60,7 @@ MODELS_TO_TEST_MAPPING = {
     "llama_guard": [("meta-llama/LlamaGuard-7b", "Habana/llama")],
     "code_llama": [("codellama/CodeLlama-13b-Instruct-hf", "Habana/llama")],
     "protst": [("mila-intel/protst-esm1b-for-sequential-classification", "Habana/gpt2")],
-    "starcoder2":  [("bigcode/starcoder2-3b", "Habana/gpt2")],
+    "starcoder2": [("bigcode/starcoder2-3b", "Habana/gpt2")],
 }
 
 MODELS_TO_TEST_FOR_QUESTION_ANSWERING = [


### PR DESCRIPTION
# What does this PR do?

- Fixes support for Starcoder2 with language-modeling task that fails with:
     ```
      ValueError: Asking to pad but the tokenizer does not have a padding token. Please select a token to use as `pad_token`   `(tokenizer.pad_token = tokenizer.eos_token e.g.)` or add a new pad token via `tokenizer.add_special_tokens({'pad_token': '[PAD]'})`.
     ```

#### Test details (Multi Card run)
- Command:
```
mpirun -n 8 --bind-to core --map-by socket:PE=10 --rank-by core --report-bindings --allow-run-as-root \
/usr/bin/python3 <>/examples/language-modeling/run_lora_clm.py --model_name_or_path bigcode/starcoder2-3b \
--gaudi_config_name Habana/gpt2 \
--dataset_name timdettmers/openassistant-guanaco \
--do_train --output_dir /tmp/tmp8vbupg6u \
--overwrite_output_dir \
--per_device_train_batch_size 16 \
--per_device_eval_batch_size 4 \
--num_train_epochs 2 \
--use_habana \
--throughput_warmup_steps 3 \
--save_strategy no \
--use_lazy_mode \
--do_eval \
--dataset_concatenation \
--gradient_accumulation_steps 4 \
--bf16 True \
--num_train_epochs 2 \
--per_device_train_batch_size 2 \
--per_device_eval_batch_size 2 \
--gradient_accumulation_steps 4 \
--learning_rate 1e-4 \
--dataset_concatenation \
--use_habana \
--use_lazy_mode \
--throughput_warmup_steps 0 \
--lora_target_modules q_proj o_proj k_proj v_proj gate_proj up_proj down_proj \
--validation_split_percentage 10
```
- Output:
```
***** train metrics *****
  epoch                       =      1.9928
  max_memory_allocated (GB)   =       22.75
  memory_allocated (GB)       =       11.56
  total_flos                  = 145745136GF
  total_memory_available (GB) =       94.62
  train_loss                  =      2.4956
  train_runtime               =  0:04:27.67
  train_samples_per_second    =      66.208
  train_steps_per_second      =       1.031
06/10/2024 16:35:11 - INFO - __main__ -   *** Evaluate ***
[INFO|trainer.py:1779] 2024-06-10 16:35:11,651 >> ***** Running Evaluation *****
[INFO|trainer.py:1781] 2024-06-10 16:35:11,651 >>   Num examples = 518
[INFO|trainer.py:1784] 2024-06-10 16:35:11,651 >>   Batch size = 2
100%|██████████| 33/33 [00:01<00:00, 19.33it/s]***** eval metrics *****
  epoch                       =     1.9928
  eval_accuracy               =      0.429
  eval_loss                   =     1.5961
  eval_runtime                = 0:00:07.32
  eval_samples                =        518
  eval_samples_per_second     =     70.738
  eval_steps_per_second       =      4.506
  max_memory_allocated (GB)   =      22.75
  memory_allocated (GB)       =      11.56
  perplexity                  =     4.9335
  total_memory_available (GB) =      94.62
100%|██████████| 33/33 [00:03<00:00,  9.33it/s]
```
- Test result:
```
1 passed, 45 deselected in 325.10s (0:05:25) 
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
