### PR TITLE
unset length penalty in summarization example

### DIFF
--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -759,6 +759,11 @@ def main():
 
     # Override the decoding parameters of Seq2SeqTrainer
     training_args.generation_config = copy.deepcopy(model.generation_config)
+    try:
+        # unset length_penalty since it is not used in this example
+        training_args.generation_config.length_penalty = None
+    except AttributeError:
+        pass
     if training_args.generation_max_length is not None:
         training_args.generation_config.max_length = training_args.generation_max_length
     else:


### PR DESCRIPTION
# What does this PR do?

It unsets the `length_penalty` value from the `generation_config`. 

Fixes # (issue)

When using the model `csebuetnlp/mT5_multilingual_XLSum` the user might see the following error:

```
ValueError: [UserWarning('`num_beams` is set to 1. However, `length_penalty` is set to `0.6` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.')]
```

Since  `length_penalty` is not an input for this example, we are going to unset it to avoid the conflict with  `num_beams`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
