### PR TITLE
Fix lm_evaluation_harness to specific commit (#240)

### DIFF
--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,1 +1,1 @@
-git+https://github.com/polisettyvarma/lm-evaluation-harness.git@lm_harness_fixes
+https://github.com/polisettyvarma/lm-evaluation-harness/archive/3cdc8daadad9f4559ae6cdfae96f1d83d6b3c1f4.zip


### PR DESCRIPTION
* Fix lm_evaluation_harness to specific commit

* Different commit in requirements_lm_eval

Why this change?
1. We should have fixed reference instead of branch which could change in the future
2. By fixing to specific commit hash we make pip download requirements.txt a lot faster