### PR TITLE
Sasarkar/qwen optimization

### DIFF
--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -328,7 +328,6 @@ class GaudiQwen2Attention(Qwen2Attention):
                     past_value = torch.zeros(
                         key_states.shape, dtype=self.k_proj.weight.dtype, device=key_states.device
                     )
-                    # past_key_value = (past_key, past_value)
                     # Return list instead of tuple
                     past_key_value = [past_key, past_value]
                 key_states = self.k_cache.update(past_key_value[0], key_states, 2, token_idx, self.inp_seq_len)

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -227,7 +227,9 @@ class GaudiQwen2Attention(Qwen2Attention):
         return (self.k_cache.cache.shape, self.v_cache.cache.shape)
 
     # TODO test with this function as well
-    def gaudi_flash_attn_v1(self, query_layer, key_layer, value_layer, attention_mask, dropout_rate, is_casual, scale, softmax_mode):
+    def gaudi_flash_attn_v1(
+        self, query_layer, key_layer, value_layer, attention_mask, dropout_rate, is_casual, scale, softmax_mode
+    ):
         """
         Gaudi version of Flash Attention V1 to support long sequence at prompt phase
         Causal mask is not supported in this optimization
@@ -245,7 +247,9 @@ class GaudiQwen2Attention(Qwen2Attention):
             s, e = i * self.block_size, (i + 1) * self.block_size
             row_q = query_layer[:, :, s:e, :]
             row_mask = attention_mask[:, :, s:e, :]
-            attn_output_partial = self.fused_scaled_dot_product_attention(row_q, key_layer, value_layer, row_mask, dropout_rate, False, None, softmax_mode)
+            attn_output_partial = self.fused_scaled_dot_product_attention(
+                row_q, key_layer, value_layer, row_mask, dropout_rate, False, None, softmax_mode
+            )
             row_o_list.append(attn_output_partial)
         attn_output = torch.cat(row_o_list, dim=-2)
 
@@ -285,7 +289,6 @@ class GaudiQwen2Attention(Qwen2Attention):
             warnings.warn(
                 "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
             )
-        train_with_flash_attention = self.training and self._use_sdpa and not output_attentions and head_mask is None
 
         bsz, q_len, _ = hidden_states.size()
 
@@ -325,7 +328,7 @@ class GaudiQwen2Attention(Qwen2Attention):
                     past_value = torch.zeros(
                         key_states.shape, dtype=self.k_proj.weight.dtype, device=key_states.device
                     )
-                    #past_key_value = (past_key, past_value)
+                    # past_key_value = (past_key, past_value)
                     # Return list instead of tuple
                     past_key_value = [past_key, past_value]
                 key_states = self.k_cache.update(past_key_value[0], key_states, 2, token_idx, self.inp_seq_len)

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -17,7 +17,6 @@
 ###############################################################################
 
 import math
-import os
 import warnings
 from typing import List, Optional, Tuple, Union
 
@@ -188,7 +187,6 @@ class GaudiQwen2Attention(Qwen2Attention):
     def __init__(self, config: Qwen2Config, layer_idx: Optional[int] = None):
         super().__init__(config, layer_idx)
 
-        self.is_fp8 = os.getenv("QUANT_CONFIG", "") != ""
         self.fused_scaled_dot_product_attention = ModuleFusedSDPA(FusedSDPA)
 
         self.matmul_qk = Matmul()

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -17,10 +17,10 @@
 ###############################################################################
 
 import math
+import os
 import warnings
 from typing import List, Optional, Tuple, Union
 
-import os
 import torch
 import torch.nn.functional as F
 import torch.utils.checkpoint
@@ -187,7 +187,7 @@ class KVCache(torch.nn.Module):
 class GaudiQwen2Attention(Qwen2Attention):
     def __init__(self, config: Qwen2Config, layer_idx: Optional[int] = None):
         super().__init__(config, layer_idx)
-        
+
         self.is_fp8 = os.getenv("QUANT_CONFIG", "") != ""
         self.fused_scaled_dot_product_attention = ModuleFusedSDPA(FusedSDPA)
 
@@ -398,7 +398,7 @@ class GaudiQwen2Attention(Qwen2Attention):
 
         if not output_attentions:
             attn_weights = None
-            
+
         if not reuse_cache and token_idx is not None and cache_idx is not None and q_len == 1:
             # Return only past key value shapes and not the tensors during decode phase (q len is 1)
             # to avoid making past key values as persistent output tensors of HPU graphs.


### PR DESCRIPTION
# What does this PR do?

### Description

move fusedsdpa.apply into a separate module, so it can be quantized as documented [here](https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_FP8.html#supported-modules)
similar to falcon opt [here](https://github.com/huggingface/optimum-habana/pull/974)

Also add "no resue cache" change. similar to falcon optimization [here](https://github.com/huggingface/optimum-habana/commit/e778ccb5de8fed0dd8fff355965a9c1a4b8c708a). Originally from [this](https://github.com/huggingface/optimum-habana/pull/1028)


### Tests

**test 1 (for fp8)**

```
QUANT_CONFIG=./quantization_config/maxabs_measure_include_outputs.json python run_generation.py --model_name_or_path /software/data/pytorch/huggingface/Qwen2-7B --use_kv_cache --max_new_tokens 128 --max_input_tokens=128 --bf16 --batch_size 1 --use_hpu_graph --trim_logits --bucket_size 256 --bucket_internal --reuse_cache --use_flash_attention --flash_attention_recompute --flash_attention_causal_mask
 ```

```
QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path /software/data/pytorch/huggingface/Qwen2-7B --use_kv_cache --max_new_tokens 4096 --max_input_tokens=2048 --batch_size 12 --use_hpu_graph --trim_logits --bucket_size 128 --bucket_internal --reuse_cache --use_flash_attention --bf16 --flash_attention_recompute --flash_attention_causal_mask
```

TPS increases from 1278.0 to 1981.4. without flash flags, on main the tps is around 1833

If flash flags is not used, both main and this branch has TPS=1833.1

| bs | with flash flag | branch | tps | memory |
| :---------------- | :------: | ----: |----: |----: |
| 12 | no | main | **1833.1** | ? |
| 12 | yes | main | 1278.0  | ? |
| 12 | no | this branch| 1833.1 | ? |
| 12 | yes | this branch|  **1981.4**  | ? |

**test 2 (no reuse cache)**

``` HABANA_VISIBLE_MODULES=4,5,6,7 python ../gaudi_spawn.py --master 29502 --use_deepspeed --world_size 4 run_generation.py --model_name_or_path /mnt/weka/data/Qwen/Qwen2-72B --use_hpu_graphs --use_kv_cache --max_input_tokens 2048 --max_new_tokens 2048 --batch_size 64 --attn_softmax_bf16 --trim_logits --bf16 --warmup 2 --n_iterations 3 --limit_hpu_graphs --bucket_internal --bucket_size 128 --reuse_cache```


| bs | reusecache | branch | tps | memory |
| :---------------- | :------: | ----: |----: |----: |
| 64 | yes | main | **1310** | 89.9 gb, 73.48 gb |
| 50 | yes | this branch | 1117.99 | 81.13gb, 66.68 gb |
| 64 | yes | this branch | 1304.56 | 90.0 gb, 73.49 gb |
| 64 | no | this branch | 1306.57|  94.52 gb, 50.95 gb |
| 100  | yes | this branch | OOM | - |
| 100  | no | this branch |**1610** |55.79gb, 94.3 gb|



**test 3 (fp8)**
same cmd as test 1, but with larger batches


| bs | with flash flag | branch | tps | memory |
| :---------------- | :------: | ----: |----: |----: |
| 32 |  yes | main | 1822.3 |  22.32 gb|
| 128 |  yes | main | 2259.48 |  66.6 gb|
| 192|  yes | main | 2341.06 3 |  94.62 gb|
| 128       |  no | main | 5855.92 |  79.96 gb|
|150        |  no | main | **5736.10** |  92.1 gb, 90.69 gb |
| 180, 192   |  no | main |OOM| - |
| 150 |  no | current branch |5729.6| 92.1gb |
| 192  |  no | current branch |OOM| -|
| 192 | yes | current branch | **8250.7**  | 91.84  |


**test 4** 
fp8 and no reuse_cache
first few rows of data are from test 3

| bs | with flash flag | branch | reusecache | tps | memory |
| :---------------- | :------: | ----: |----: |----: |----: |
|150        |  no | main | yes |  5736.10 |  92.1 gb, 90.69 gb |
| 192 | yes | current branch |  yes | 8250.7  | 91.84  |
| 180 | yes | current branch |  no | wip| wip |
| 192 | yes | current branch |  no | OOM| -|

TODO .. should bs=192 fp8, without reusecache have OOM'ed?

same cmd as test 1, but with reuse_cache removed, and larger batchsize
```
QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path /software/data/pytorch/huggingface/Qwen2-7B --use_kv_cache --max_new_tokens 4096 --max_input_tokens=2048 --batch_size 192 --use_hpu_graph --trim_logits --bucket_size 128 --bucket_internal --use_flash_attention --bf16 --flash_attention_recompute --flash_attention_causal_mask
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
