### PR TITLE
torch.compile keep input mutation in graph this avoids unnecessary memcpy

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -177,7 +177,7 @@ def patch_scoped_linear_all_reduce(model):
 
 
 def get_torch_compiled_model(model):
-    model.model = torch.compile(model.model, backend="hpu_backend")
+    model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
     return model
 
 


### PR DESCRIPTION
torch.compile keep input mutation in graph this avoids unnecessary memcpy coming from inplace index_copy from kv cache