### PR TITLE
fix bug in initialize_model in text-generation-pipeline

### DIFF
--- a/examples/text-generation/text-generation-pipeline/pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/pipeline.py
@@ -5,7 +5,7 @@ from utils import initialize_model
 
 class GaudiTextGenerationPipeline(TextGenerationPipeline):
     def __init__(self, args, logger, use_with_langchain=False, warmup_on_init=True):
-        self.model, self.tokenizer, self.generation_config = initialize_model(args, logger)
+        self.model, _, self.tokenizer, self.generation_config = initialize_model(args, logger)
 
         self.task = "text-generation"
         self.device = args.device


### PR DESCRIPTION
# fix ValueError caused by setting wrong number of returned values in initialize_model 

example to reproduce the error:
python optimum-habana/examples/text-generation/text-generation-pipeline/run_pipeline.py --model_name_or_path meta-llama/Llama-2-7b-hf --use_hpu_graphs --use_kv_cache --max_new_tokens 100 --do_sample --prompt "Here is my prompt"

error:     
self.model, self.tokenizer, self.generation_config = initialize_model(args, logger)
ValueError: too many values to unpack (expected 3)

initialize_model returns 4 values (model, assistant_model, tokenizer, generation_config)
