### PR TITLE
Fix wrong setup of OS environment HLS_MODULE_ID cause device not found error in docker virtualization with 2/4 visible devices 

### DIFF
--- a/optimum/habana/accelerate/state.py
+++ b/optimum/habana/accelerate/state.py
@@ -61,7 +61,7 @@ class GaudiPartialState(PartialState):
                     import deepspeed
 
                     if world_size > 1:
-                        os.environ["HLS_MODULE_ID"] = str(local_rank)
+                        # os.environ["HLS_MODULE_ID"] = str(local_rank)
                         os.environ["ID"] = str(rank)
 
                     deepspeed.init_distributed(dist_backend=self.backend, **kwargs)


### PR DESCRIPTION
### **How to reproduce it ?**

1. use `hl-smi -Q index,module_id -f csv ` to find the mapping between module id and device id in the host.
  For example: 
```
index, module_id
0, 0
1, 4
2, 1
3, 5
4, 2
5, 6
6, 3
7, 7
```

2.  use below command to create a docker instance with two visible devices such as module id "2,3"
`docker run -it --name=test --rm --runtime=habana -e HABANA_VISIBLE_DEVICES=4,6 -e HABANA_VISIBLE_MODULES=2,3 -e OMPI_MCA_btl_vader_single_copy_mechanism=none  --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest`
3. Run fine tune workload (**You must run the finetune workload with deepspeed configuration**)
You need to setup the finetune workload env according to user guide. You can get DeepSpeed ZeRO-2 config: https://github.com/huggingface/optimum-habana/blob/main/tests/configs/deepspeed_zero_2.json
```shell
cd optimum-habana/examples/language-modeling
python ../gaudi_spawn.py \
--world_size 2 --use_deepspeed run_clm.py \
--model_name_or_path gpt2 \
--dataset_name wikitext \
--dataset_config_name wikitext-2-raw-v1 \
--per_device_train_batch_size 4 \
--per_device_eval_batch_size 4 \
--do_train \
--do_eval \
--output_dir /tmp/test-clm \
--gaudi_config_name Habana/gpt2 \
--use_habana \
--use_lazy_mode \
--use_hpu_graphs_for_inference \
--throughput_warmup_steps 3 \
--deepspeed deepspeed_zero_2.json
``` 
4. You will get below error trace.

```
Traceback (most recent call last):
  File "/hf/aicse.huggingface.model.references-main/optimum-habana/examples/language-modeling/run_clm.py", line 694, in <module>
    main()
  File "/hf/aicse.huggingface.model.references-main/optimum-habana/examples/language-modeling/run_clm.py", line 638, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 545, in train
    return inner_training_loop(
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 638, in _inner_training_loop
    self.optimizer, self.lr_scheduler = deepspeed_init(self, num_training_steps=max_steps)
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/integrations/deepspeed.py", line 119, in deepspeed_init
    model.to(dtype=hf_deepspeed_config.dtype(), device="hpu")
  File "/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py", line 2692, in to
    return super().to(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 173, in wrapped_to
    result = self.original_to(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1155, in to
    return self._apply(convert)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 802, in _apply
    module._apply(fn)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 802, in _apply
    module._apply(fn)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 825, in _apply
    param_applied = fn(param)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1153, in convert
    return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 53, in __torch_function__
    return super().__torch_function__(func, types, new_args, kwargs)
RuntimeError: synStatus=8 [Device not found] Device acquire failed.

``` 

### **Root cause analysis**

The OS environment HLS_MODULE_ID should match the host module id instead of using docker local rank id. For the virtualization situation, if you split the host (8 HPU cards) with four docker instances(2 HPU cards), the local rank will became "0,1" in each docker, so the  HLS_MODULE_ID also become "0,1" using the code logic in optimum/habana/accelerate/state.py. This will cause device not found error.
