### PR TITLE
Fix starcoder2 accuracy issue and optimize performance with fused rope

### DIFF
--- a/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
@@ -54,7 +54,7 @@ def gaudi_starcoder2_attention_forward(
             "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
         )
     bsz, q_len, _ = hidden_states.size()
-    self.norm_factor = 1.0 / math.sqrt(self.head_dim)
+    norm_factor = 1.0 / math.sqrt(self.head_dim)
 
     query_states = self.q_proj(hidden_states)
     key_states = self.k_proj(hidden_states)
@@ -98,7 +98,7 @@ def gaudi_starcoder2_attention_forward(
     key_states = repeat_kv(key_states, self.num_key_value_groups)
     value_states = repeat_kv(value_states, self.num_key_value_groups)
 
-    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.norm_factor
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * norm_factor
 
     if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
         raise ValueError(


### PR DESCRIPTION
1. starcoder2 has accuracy issue when kv_cache is used and max_input_token is specified, such as with this command:

python run_generation.py --model_name_or_path bigcode/starcoder2-3b --batch_size 1 --use_hpu_graphs --use_kv_cache --max_new_tokens 100 --bf16 --prompt "def print_hello_world():" --max_input_tokens 1024

This PR is used to fix the accuracy issue.

2. Use fused RoPE to optimize the performance on Gaudi