### PR TITLE
sasarkar/Fix recompiles if limit_hpu_graph is False

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1880,7 +1880,7 @@ class GaudiGenerationMixin(GenerationMixin):
             ):
                 # Pad the returned past key values tensors from prefill phase forward run to maximum length
                 # before starting the decode phase.
-                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
+                if outputs.past_key_values[0][0].shape[2] == model_inputs["input_ids"].shape[1]:
                     self._pad_past_key_values(model_kwargs)
                 model_kwargs["pad_done"] = True
 
@@ -2300,7 +2300,7 @@ class GaudiGenerationMixin(GenerationMixin):
             ):
                 # Pad the returned past key values tensors from prefill phase forward run to maximum length
                 # before starting the decode phase.
-                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
+                if outputs.past_key_values[0][0].shape[2] == model_inputs["input_ids"].shape[1]:
                     self._pad_past_key_values(model_kwargs)
                 model_kwargs["pad_done"] = True
 

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -2301,7 +2301,7 @@ class GaudiGenerationMixin(GenerationMixin):
             ):
                 # Pad the returned pask key values tensors from prefill phase forward run to maximum length
                 # before starting the decode phase.
-                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids']:
+                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
                     self._pad_past_key_values(model_kwargs)
                 model_kwargs["pad_done"] = True
 

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1873,15 +1873,17 @@ class GaudiGenerationMixin(GenerationMixin):
                     torch_hpu.synchronize()
                 hb_gen_time.step()
 
-            if (
-                not model_kwargs.get("pad_done", False)
-                and not model_kwargs.get("reuse_cache", False)
-                and bucket_internal
-            ):
-                # Pad the returned pask key values tensors from prefill phase forward run to maximum length
-                # before starting the decode phase.
-                self._pad_past_key_values(model_kwargs)
-                model_kwargs["pad_done"] = True
+
+                if (
+                    not model_kwargs.get("pad_done", False)
+                    and not model_kwargs.get("reuse_cache", False)
+                    and bucket_internal
+                ):
+                    # Pad the returned pask key values tensors from prefill phase forward run to maximum length
+                    # before starting the decode phase.
+                    if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
+                        self._pad_past_key_values(model_kwargs)
+                    model_kwargs["pad_done"] = True
 
         if (
             model_kwargs.get("use_hpu_graphs", False)
@@ -2299,7 +2301,8 @@ class GaudiGenerationMixin(GenerationMixin):
             ):
                 # Pad the returned pask key values tensors from prefill phase forward run to maximum length
                 # before starting the decode phase.
-                self._pad_past_key_values(model_kwargs)
+                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids']:
+                    self._pad_past_key_values(model_kwargs)
                 model_kwargs["pad_done"] = True
 
         if (

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1873,17 +1873,16 @@ class GaudiGenerationMixin(GenerationMixin):
                     torch_hpu.synchronize()
                 hb_gen_time.step()
 
-
-                if (
-                    not model_kwargs.get("pad_done", False)
-                    and not model_kwargs.get("reuse_cache", False)
-                    and bucket_internal
-                ):
-                    # Pad the returned pask key values tensors from prefill phase forward run to maximum length
-                    # before starting the decode phase.
-                    if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
-                        self._pad_past_key_values(model_kwargs)
-                    model_kwargs["pad_done"] = True
+            if (
+                not model_kwargs.get("pad_done", False)
+                and not model_kwargs.get("reuse_cache", False)
+                and bucket_internal
+            ):
+                # Pad the returned past key values tensors from prefill phase forward run to maximum length
+                # before starting the decode phase.
+                if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
+                    self._pad_past_key_values(model_kwargs)
+                model_kwargs["pad_done"] = True
 
         if (
             model_kwargs.get("use_hpu_graphs", False)
@@ -2299,7 +2298,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 and not model_kwargs.get("reuse_cache", False)
                 and bucket_internal
             ):
-                # Pad the returned pask key values tensors from prefill phase forward run to maximum length
+                # Pad the returned past key values tensors from prefill phase forward run to maximum length
                 # before starting the decode phase.
                 if outputs.past_key_values[0][0].shape[2] ==  model_inputs['input_ids'].shape[1]:
                     self._pad_past_key_values(model_kwargs)


### PR DESCRIPTION
# What does this PR do?
**TL;DR**
Fix recompiles if limit_hpu_graph is False


**Details**
If `--limit_hpu_graphs` is set to False, there are multiple recompilations, causing low thruput.

The reason for recompilations is:
for 1st prefill, input = prompt of len “p” goes in, and kv cache of size “p” comes out, and that is padded by “m” to give size = p+m
for second prefill (during second warmup), inp = p goes in, but output is p+m (should have been just p).. which is padded by m again, and then becomes p+m+m etc
 This is probably because this clearing code isnt invoked when limit_hpu_graph=False: [optimum-habana/optimum/habana/transformers/generation/utils.py at main · huggingface/optimum-habana](https://github.com/huggingface/optimum-habana/blob/main/optimum/habana/transformers/generation/utils.py#L1888)


A possible fix is to check if inputsize==output_kv_size, and pad only in that case, which is what this PR does. Note that if input sizes are different in each step, this might not work correctly (but that is not the case in normal mode of operations of text gen using run_generation)


**Tests/Experiments**
basic cmd line. This is a toy case with small inp/outs
```
QUANT_CONFIG=./quantization_config/maxabs_quant.json TQDM_DISABLE=1 python run_generation.py --model_name_or_path meta-llama/Llama-2-7b-hf --attn_softmax_bf16 --use_hpu_graphs --trim_logits --warmup 2 --use_kv_cache --bucket_size=4 --bucket_internal --max_input_tokens 8 --max_new_tokens 16 --bf16 --batch_size 1 --use_flash_attention --flash_attention_recompute --n_iter 3
```
Note that when we say limit_hpu_graph=True, we might have to comment out these lines, which set it to false:
https://github.com/huggingface/optimum-habana/blob/main/examples/text-generation/utils.py#L484


| Branch | model | limit_hpu_graph | generation mode | dtype | thruput | 1st tkn latency | 
| -------- | ------- | ------- | ------- | ------- | ------- |------- |
| main | llama7 | False        | greedy | fp8 |  **1.131** | 6.7 - 7.3 |
|  this branch |  llama7 | False    |  greedy | fp8 | **221.78** | 6.6 |
|  main  | llama7 |  True      |  greedy | fp8 | 120.89 | 62-64 |
|  this branch |  llama7 |  True |  greedy | fp8 | 131.36  | 52-54 |
| main |  llama7 | False        | --do_sample | fp8 | **1.12** | 8.8 |
|  this branch | llama7 |  False    |  --do_sample | fp8 | **187.30** | 7.5-8.7 |
|  main  |  llama7 | True      |  --do_sample | fp8 | 117.48 | 54-57 |
|  this branch | llama7 |   True |   --do_sample |fp8 |  114.89  | 57-59 |
| main |  llama7 | False        | greedy | bf16 |  **19.454** | 9.2 |
|  this branch |  llama7 | False    |  greedy | bf16 |**140.02** | 9.1 |
|  main  |  llama7 | True      |  greedy | bf16 | 113.37 | 33 |
|  this branch |   llama7 | True |  greedy | bf16 | 113.5  | 33 |
| main |  falcon7 | False        | greedy | bf16 |  **2.94** | 10-11 |
|  this branch |  falcon7 | False    |  greedy | bf16 | **129.78** | 9.8 |
|  main  |  falcon7 | True      |  greedy | bf16 | 101.67 | 39-43 |
|  this branch |   falcon7 | True |  greedy | bf16 | 102.9 | 39 |

Some other tests:
1. Without `--bucket_size 4 --bucket_internal`, limit_hpu_graph=False
222.52 tps, 6.5 ms FTL ... same as main
2. Without `--bucket_size 4 --bucket_internal`, limit_hpu_graph=True
131.73, 55 ms FTL ... same as main
3. Without `--bucket_internal`, with `--bucket_size 4`, limit_hpu_graph=False
213 tps, 6.2 ms FTL ..same as main
4. Without `--bucket_internal`, with `--bucket_size 4`, limit_hpu_graph=True
131.07 tps, 55 ms FTL ... same as main

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->


<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
