### PR TITLE
Support `bucket_internal` for MPT

### DIFF
--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -67,9 +67,9 @@ def gaudi_mpt_attention_forward(
             else:
                 key_states = torch.cat([past_key_value[0], key_states], dim=2)
                 value_states = torch.cat([past_key_value[1], value_states], dim=2)
-        past_key_value = (key_states, value_states)
+        past_key_value = [key_states, value_states]
     else:
-        past_key_value = (key_states, value_states)
+        past_key_value = [key_states, value_states]
 
     attention_scores = torch.matmul(query_states, key_states.transpose(-1, -2)) * self.softmax_scale
 
@@ -289,7 +289,9 @@ class GaudiMptForCausalLM(MptForCausalLM):
         - add new args token_idx
         - add token_idx into model_inputs
         - from step2 when enable KV cache, slice next_input_ids from input_ids base on the token_idx
+        - support for internal bucketing
         """
+        bucket_internal = kwargs.get("bucket_internal")
         # only last tokens for input_ids if past is not None
         if past_key_values is not None:
             if token_idx is None:
@@ -305,6 +307,13 @@ class GaudiMptForCausalLM(MptForCausalLM):
                 input_ids = input_ids[:, remove_prefix_length:]
             else:
                 input_ids = torch.index_select(input_ids, 1, token_idx - 1)
+            # Converting back to tuples as it should be, so there's no type mismatch when calling graph
+            past_key_values = tuple([tuple(kv) for kv in past_key_values])
+        elif bucket_internal and token_idx is not None:
+            # KV cache is pre allocated with reuse cache or will be padded with bucket internal
+            # hence for the 1st token we can slice the inputs till token idx for the fwd pass.
+            input_ids = input_ids[:, :token_idx]
+            attention_mask = attention_mask[:, :token_idx]
 
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:


### PR DESCRIPTION
# What does this PR do?

Adds support for `--bucket_internal` for MPT model.

Measurements:
| Param                                  | In/Out tokens | Bath size | Throughput t/s |  Memory allocated |
|-------------------------------|----------------|------------|----------------|-------------------|
| `--bucket_internal`               | 128/128         | 128           | 6019.4            | 37.04 GB           |
| **NO** `--bucket_internal`   | 128/128         | 128           | 2919.8           | 37.28 GB           |
| `--bucket_internal`               | 128/256         | 64             | 4268.5           | 31.28 GB           |
| **NO** `--bucket_internal`   | 128/256         | 64            | 3265.1           | 37.03 GB          |
| `--bucket_internal`               | 128/512         | 32             | 2529.7           | 28.03 GB           |
| **NO** `--bucket_internal`   | 128/512         | 32            | 2543.2          | 43.16 GB          |


Command line used: `python run_generation.py --model_name_or_path mosaicml/mpt-7b --use_hpu_graphs --use_kv_cache --max_input_tokens 128 --max_new_tokens <num> --trim_logits --bf16 --warmup 2 --n_iterations 2 --limit_hpu_graphs --batch_size=<num> --bucket_size 128 --bucket_internal`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
