### PR TITLE
Fix test CausalLanguageModelingLORAExampleTester KeyError

### DIFF
--- a/tests/baselines/llama_7b.json
+++ b/tests/baselines/llama_7b.json
@@ -1,6 +1,42 @@
 {
     "gaudi": {
-        "tatsu-lab/alpaca": {
+         "databricks/databricks-dolly-15k": {
+            "num_train_epochs": 1,
+            "eval_batch_size": 2,
+            "distribution": {
+                "single_card": {
+                    "learning_rate": 2e-4,
+                    "train_batch_size": 2,
+                    "perplexity": 3.9168,
+                    "train_runtime": 132.665,
+                    "train_samples_per_second": 2.295,
+                    "extra_arguments": [
+                        "--bf16",
+                        "--gradient_accumulation_steps 1",
+                        "--evaluation_strategy no",
+                        "--save_strategy no",
+                        "--warmup_ratio 0.03",
+                        "--lr_scheduler_type constant",
+                        "--max_grad_norm 0.3",
+                        "--logging_steps 1",
+                        "--use_hpu_graphs_for_inference",
+                        "--lora_rank 8",
+                        "--lora_alpha 16",
+                        "--lora_dropout 0.1",
+                        "--lora_target_modules q_proj v_proj",
+                        "--dataset_concatenation",
+                        "--low_cpu_mem_usage True",
+                        "--adam_epsilon 1e-08",
+                        "--validation_split_percentage 20",
+                        "--attn_softmax_bf16",
+                        "--max_steps 100",
+                        "--input_column_name context",
+                        "--output_column_name response"
+                    ]
+                }
+            }
+        },
+       "tatsu-lab/alpaca": {
             "num_train_epochs": 1,
             "eval_batch_size": 2,
             "distribution": {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -237,8 +237,6 @@ class ExampleTestMeta(type):
             return False
         elif "falcon" in model_name and task_name in ("llama-adapter", "databricks/databricks-dolly-15k"):
             return False
-        elif "llama" in model_name and task_name == "databricks/databricks-dolly-15k" and not IS_GAUDI2:
-            return False
         elif model_name not in models_with_specific_rules and not deepspeed:
             return True
         elif model_name == "gpt2-xl" and deepspeed:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -235,7 +235,9 @@ class ExampleTestMeta(type):
             return False
         elif ("qwen2" in model_name or "Qwen2" in model_name) and task_name == "trl-sft":
             return False
-        elif "falcon" in model_name and task_name == "llama-adapter":
+        elif "falcon" in model_name and task_name in ("llama-adapter", "databricks/databricks-dolly-15k"):
+            return False
+        elif "llama" in model_name and task_name == "databricks/databricks-dolly-15k" and not IS_GAUDI2:
             return False
         elif model_name not in models_with_specific_rules and not deepspeed:
             return True


### PR DESCRIPTION
# What does this PR do?

The CausalLanguageModelingLORAExampleTester using "databricks/databricks-dolly-15k" only has a baseline defined for llama-7b with Gaudi2. The test was incorrectly trying to run in other use cases causing a key error:

1. The test was trying to run with falcon-40b and with llama-7b with Gaudi 1. 
```
RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card
...
FAILED tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card - KeyError: 'databricks/databricks-dolly-15k'
```

2. The test was trying to run with llama-7b with Gaudi 1
```
GAUDI2_CI=0 RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_llama-7b_single_card
...
FAILED tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_llama-7b_single_card - KeyError: 'databricks/databricks-dolly-15k'
```

To fix the issues, I updated the `to_test()` conditionals to exclude testing "falcon" models with dolly-15k and "llama" models when not using Gaudi 2.

I verified running test with different situations...

Running Gaudi 2 with llama 7b (the test should run/pass):
```
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_llama-7b_single_card  
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /workspace/optimum-habana
configfile: setup.cfg
collected 1 item                                                                                                                                                                                                             

tests/test_examples.py .                                                                                                                                                                                               [100%]

=============================================================================================== 1 passed in 231.97s (0:03:51) ================================================================================================
```

And then the rest of the cases where the test should not run are:

Gaudi 1 with llama 7b:
```
GAUDI2_CI=0 RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_llama-7b_single_card
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /workspace/optimum-habana
configfile: setup.cfg
collected 0 items                                                                                                                                                                                                            

=================================================================================================== no tests ran in 2.86s ====================================================================================================
ERROR: not found: /workspace/optimum-habana/tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_llama-7b_single_card
(no match in any of [<UnitTestCase CausalLanguageModelingLORAExampleTester>])
```

Gaudi 1 with falcon:
```
GAUDI2_CI=0 RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /workspace/optimum-habana
configfile: setup.cfg
collected 0 items                                                                                                                                                                                                            

=================================================================================================== no tests ran in 2.85s ====================================================================================================
ERROR: not found: /workspace/optimum-habana/tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card
(no match in any of [<UnitTestCase CausalLanguageModelingLORAExampleTester>])
```

Gaudi 2 with falcon:
```
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /workspace/optimum-habana
configfile: setup.cfg
collected 0 items                                                                                                                                                                                                            

=================================================================================================== no tests ran in 2.84s ====================================================================================================
ERROR: not found: /workspace/optimum-habana/tests/test_examples.py::CausalLanguageModelingLORAExampleTester::test_run_lora_clm_falcon-40b_single_card
(no match in any of [<UnitTestCase CausalLanguageModelingLORAExampleTester>])
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes? - N/A
- [ ] Did you write any new necessary tests? - N/A this is test fix
