### PR TITLE
Quantize text generation example using INC or HQT

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -267,7 +267,7 @@ You will also need to add `--torch_compile` in your command.
 
 ### Running with FP8
 
-Llama2-70b, Llama2-7b, Llama3-70b, Llama3-8b, Mixtral-8x7B, Falcon-7B, Falcon-40B, Falcon-180B and phi-2 in FP8 are enabled using the Quantization Toolkit (HQT), which provides model measurement and quantization capabilities in PyTorch.
+Llama2-70b, Llama2-7b, Llama3-70b, Llama3-8b, Mixtral-8x7B, Falcon-7B, Falcon-40B, Falcon-180B and phi-2 in FP8 are enabled using the Intel Neural Compressor (INC), which provides model measurement and quantization capabilities in PyTorch.
 
 More information on enabling fp8 in SynapseAI is available here:
 https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_FP8.html
@@ -441,7 +441,7 @@ More information on usage of the unifier script can be found in fp8 Habana docs:
 ### CPU memory reduction on single card
 
 Some models can fit on HPU DRAM but can't fit on the CPU RAM.
-When we run a model on single card and don't use deepspeed, the `--disk_offload` flag allows to offload weights to disk during model quantization in HQT. When this flag is mentioned, during the quantization process, each weight first is loaded from disk to CPU RAM, when brought to HPU DRAM and quantized there. This way not all the model is on the CPU RAM but only one weight each time.
+When we run a model on single card and don't use deepspeed, the `--disk_offload` flag allows to offload weights to disk during model quantization in INC. When this flag is mentioned, during the quantization process, each weight first is loaded from disk to CPU RAM, when brought to HPU DRAM and quantized there. This way not all the model is on the CPU RAM but only one weight each time.
 To enable this weights offload mechanism, add `--disk_offload` flag to the topology command line.
 Here is an example of using disk_offload in quantize command.
 Please follow the "Running FP8 models on single device" section first before running the cmd below.

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -28,7 +28,7 @@ from itertools import cycle
 from pathlib import Path
 
 import torch
-from utils import adjust_batch, count_hpu_graphs, initialize_model, finalize_quantization
+from utils import adjust_batch, count_hpu_graphs, finalize_quantization, initialize_model
 
 from optimum.habana.utils import get_hpu_memory_stats
 

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -28,7 +28,7 @@ from itertools import cycle
 from pathlib import Path
 
 import torch
-from utils import adjust_batch, count_hpu_graphs, initialize_model
+from utils import adjust_batch, count_hpu_graphs, initialize_model, finalize_quantization
 
 from optimum.habana.utils import get_hpu_memory_stats
 
@@ -653,9 +653,7 @@ def main():
             print(f"Graph compilation duration          = {compilation_duration} seconds")
         print(separator)
     if args.quant_config:
-        import habana_quantization_toolkit
-
-        habana_quantization_toolkit.finish_measurements(model)
+        finalize_quantization(model)
     if args.const_serialization_path and os.path.isdir(args.const_serialization_path):
         import shutil
 

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -28,7 +28,7 @@ import lm_eval.tasks
 import torch
 import torch.nn.functional as F
 from run_generation import setup_parser
-from utils import initialize_model, finalize_quantization
+from utils import finalize_quantization, initialize_model
 
 from optimum.habana.utils import get_hpu_memory_stats
 

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -28,7 +28,7 @@ import lm_eval.tasks
 import torch
 import torch.nn.functional as F
 from run_generation import setup_parser
-from utils import initialize_model
+from utils import initialize_model, finalize_quantization
 
 from optimum.habana.utils import get_hpu_memory_stats
 
@@ -182,9 +182,8 @@ def main():
         json.dump(results, open(args.output_file, "w"), indent=2)
         print(json.dumps(results, indent=2))
     if args.quant_config:
-        import habana_quantization_toolkit
+        finalize_quantization(model)
 
-        habana_quantization_toolkit.finish_measurements(model)
     if args.const_serialization_path and os.path.isdir(args.const_serialization_path):
         import shutil
 

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -182,10 +182,11 @@ def get_torch_compiled_model(model):
 
 
 def setup_quantization(model, args):
-    if os.getenv("USE_INC", ""):
-        from neural_compressor.torch import FP8QuantConfig, convert, prepare
-        config = FP8QuantConfig.from_json_file(args.quant_config)
-        if config.calibrate:
+    if os.getenv("USE_INC", "1") != "0":
+        from neural_compressor.torch.quantization import FP8Config, convert, prepare
+
+        config = FP8Config.from_json_file(args.quant_config)
+        if config.measure:
             model = prepare(model, config)
         elif config.quantize:
             model = convert(model, config)
@@ -197,8 +198,9 @@ def setup_quantization(model, args):
 
 
 def finalize_quantization(model):
-    if os.getenv("USE_INC", ""):
-        from neural_compressor.torch import finalize_calibration
+    if os.getenv("USE_INC", "1") != "0":
+        from neural_compressor.torch.quantization import finalize_calibration
+
         finalize_calibration(model)
     else:
         import habana_quantization_toolkit

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -192,6 +192,7 @@ def setup_quantization(model, args):
             model = convert(model, config)
     else:
         import habana_quantization_toolkit
+
         habana_quantization_toolkit.prep_model(model)
 
     return model
@@ -204,6 +205,7 @@ def finalize_quantization(model):
         finalize_calibration(model)
     else:
         import habana_quantization_toolkit
+
         habana_quantization_toolkit.finish_measurements(model)
 
 

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -183,7 +183,12 @@ def get_torch_compiled_model(model):
 
 def setup_quantization(model, args):
     if os.getenv("USE_INC", "1") != "0":
-        from neural_compressor.torch.quantization import FP8Config, convert, prepare
+        try:
+            from neural_compressor.torch.quantization import FP8Config, convert, prepare
+        except ImportError:
+            raise ImportError(
+                "Module neural_compressor is missing. Please use a newer Synapse version to use quantization, or set the environment variable to USE_INC=0"
+            )
 
         config = FP8Config.from_json_file(args.quant_config)
         if config.measure:
@@ -200,7 +205,12 @@ def setup_quantization(model, args):
 
 def finalize_quantization(model):
     if os.getenv("USE_INC", "1") != "0":
-        from neural_compressor.torch.quantization import finalize_calibration
+        try:
+            from neural_compressor.torch.quantization import finalize_calibration
+        except ImportError:
+            raise ImportError(
+                "Module neural_compressor is missing. Please use a newer Synapse version to use quantization, or set the environment variable to USE_INC=0"
+            )
 
         finalize_calibration(model)
     else:


### PR DESCRIPTION
Setting INC as the primary running method.
HQT is deprecated in v1.17.0 and is planned to be removed.
Command line is not changed and is the same as in examples/text-generation/README.md