### PR TITLE
Upgrade optimum-habana diffusers dependency from 0.26.3 to 0.29.2

### DIFF
--- a/examples/stable-diffusion/README.md
+++ b/examples/stable-diffusion/README.md
@@ -26,7 +26,7 @@ Stable Diffusion was proposed in [Stable Diffusion Announcement](https://stabili
 ### Single Prompt
 
 Here is how to generate images with one prompt:
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path runwayml/stable-diffusion-v1-5 \
     --prompts "An image of a squirrel in Picasso style" \
@@ -47,7 +47,7 @@ python text_to_image_generation.py \
 ### Multiple Prompts
 
 Here is how to generate images with several prompts:
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path runwayml/stable-diffusion-v1-5 \
     --prompts "An image of a squirrel in Picasso style" "A shiny flying horse taking off" \
@@ -85,7 +85,7 @@ python ../gaudi_spawn.py \
 
 [Stable Diffusion 2](https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion_2) can also be used to generate images with this script. Here is an example for a single prompt:
 
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path stabilityai/stable-diffusion-2-1 \
     --prompts "An image of a squirrel in Picasso style" \
@@ -111,7 +111,7 @@ python text_to_image_generation.py \
 [Original checkpoint](https://huggingface.co/Intel/ldm3d) and [latest checkpoint](https://huggingface.co/Intel/ldm3d-4c) are open source.
 A [demo](https://huggingface.co/spaces/Intel/ldm3d) is also available. Here is how to run this model:
 
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path "Intel/ldm3d-4c" \
     --prompts "An image of a squirrel in Picasso style" \
@@ -153,7 +153,7 @@ python ../gaudi_spawn.py \
 Stable Diffusion XL was proposed in [SDXL: Improving Latent Diffusion Models for High-Resolution Image Synthesis](https://arxiv.org/pdf/2307.01952.pdf) by the Stability AI team.
 
 Here is how to generate SDXL images with a single prompt:
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
     --prompts "Sailing ship painting by Van Gogh" \
@@ -172,7 +172,7 @@ python text_to_image_generation.py \
 > You can enable this mode with `--use_hpu_graphs`.
 
 Here is how to generate SDXL images with several prompts:
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
     --prompts "Sailing ship painting by Van Gogh" "A shiny flying horse taking off" \
@@ -189,7 +189,7 @@ python text_to_image_generation.py \
 SDXL combines a second text encoder (OpenCLIP ViT-bigG/14) with the original text encoder to significantly
 increase the number of parameters. Here is how to generate images with several prompts for both `prompt`
 and `prompt_2` (2nd text encoder), as well as their negative prompts:
-```python
+```bash
 python text_to_image_generation.py \
     --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
     --prompts "Sailing ship painting by Van Gogh" "A shiny flying horse taking off" \
@@ -237,7 +237,7 @@ Here is how to generate images with multiple prompts:
 python text_to_image_generation.py \
     --model_name_or_path stabilityai/sdxl-turbo \
     --prompts "Sailing ship painting by Van Gogh" "A shiny flying horse taking off" \
-    --num_images_per_prompt 20 \
+    --num_images_per_prompt 32 \
     --batch_size 8 \
     --image_save_dir /tmp/stable_diffusion_xl_turbo_images \
     --scheduler euler_ancestral_discrete \
@@ -256,8 +256,39 @@ python text_to_image_generation.py \
 
 > Please note: there is a regression with "--guidance_scale 0.0" for the latest release.
 
+### Stable Diffusion 3 (SD3)
 
-### ControlNet
+Stable Diffusion 3 was introduced by Stability AI [here](https://stability.ai/news/stable-diffusion-3).
+It uses Diffusion Transformer instead of UNet for denoising, which yields improved image quality.
+
+Before running SD3 pipeline, you need to:
+
+1. Agree to the Terms and Conditions for using SD3 model at [HuggingFace model page](https://huggingface.co/stabilityai/stable-diffusion-3-medium)
+2. Authenticate with HuggingFace using your HF Token. For authentication, run:
+```bash
+huggingface-cli login
+```
+
+Here is how to generate SD3 images with a single prompt:
+```bash
+PT_HPU_MAX_COMPOUND_OP_SIZE=1 \
+python text_to_image_generation.py \
+    --model_name_or_path stabilityai/stable-diffusion-3-medium-diffusers \
+    --prompts "Sailing ship painting by Van Gogh" \
+    --num_images_per_prompt 10 \
+    --batch_size 1 \
+    --num_inference_steps 28 \
+    --image_save_dir /tmp/stable_diffusion_3_images \
+    --use_habana \
+    --use_hpu_graphs \
+    --gaudi_config Habana/stable-diffusion \
+    --bf16
+```
+
+> For improved performance of the SD3 pipeline on Gaudi, it is recommended to configure the environment
+> by setting PT_HPU_MAX_COMPOUND_OP_SIZE to 1.
+ 
+## ControlNet
 
 ControlNet was introduced in [Adding Conditional Control to Text-to-Image Diffusion Models ](https://huggingface.co/papers/2302.05543) by Lvmin Zhang and Maneesh Agrawala.
 It is a type of model for controlling StableDiffusion by conditioning the model with an additional input image.
@@ -305,7 +336,7 @@ python ../gaudi_spawn.py \
     --controlnet_model_name_or_path lllyasviel/sd-controlnet-canny \
     --prompts "futuristic-looking woman" "a rusty robot" \
     --control_image https://hf.co/datasets/huggingface/documentation-images/resolve/main/diffusers/input_image_vermeer.png \
-    --num_images_per_prompt 10 \
+    --num_images_per_prompt 16 \
     --batch_size 4 \
     --image_save_dir /tmp/controlnet_images \
     --use_habana \
@@ -349,6 +380,44 @@ python text_to_image_generation.py \
     --use_habana \
     --use_hpu_graphs \
     --gaudi_config Habana/stable-diffusion-2
+```
+
+## Inpainting
+
+Inpainting replaces or edits specific areas of an image. For more details,
+please refer to [Hugging Face Diffusers doc](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint).
+
+### Stable Diffusion Inpainting
+```bash
+python text_to_image_generation.py \
+    --model_name_or_path  runwayml/stable-diffusion-inpainting \
+    --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png \
+    --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png \
+    --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k" \
+    --seed 0 \
+    --num_images_per_prompt 12 \
+    --batch_size 4 \
+    --image_save_dir /tmp/inpaiting_images \
+    --use_habana \
+    --use_hpu_graphs \
+    --gaudi_config Habana/stable-diffusion
+```
+
+### Stable Diffusion XL Inpainting
+```bash
+python text_to_image_generation.py \
+    --model_name_or_path  diffusers/stable-diffusion-xl-1.0-inpainting-0.1\
+    --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png \
+    --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png \
+    --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k" \
+    --seed 0 \
+    --scheduler euler_discrete \
+    --num_images_per_prompt 12 \
+    --batch_size 4 \
+    --image_save_dir /tmp/xl_inpaiting_images \
+    --use_habana \
+    --use_hpu_graphs \
+    --gaudi_config Habana/stable-diffusion
 ```
 
 ## Image-to-image Generation
@@ -445,6 +514,24 @@ python image_to_image_generation.py \
     --bf16
 ```
 
+## Unconditional Image Generation Example
+
+Here is how to perform unconditional-image-generation on Gaudi/HPU.
+
+Original unconditional image generation pipeline is shared in here: [Unconditional Image Generation](https://huggingface.co/docs/diffusers/using-diffusers/unconditional_image_generation)
+
+```bash
+python unconditional_image_generation.py \
+    --model_name_or_path "google/ddpm-ema-celebahq-256" \
+    --batch_size 16 \
+    --use_habana \
+    --use_gaudi_ddim_scheduler \
+    --use_hpu_graphs \
+    --bf16 \
+    --save_outputs \
+    --output_dir "/tmp/"
+```
+
 # Stable Video Diffusion Examples
 
 Stable Video Diffusion (SVD) was unveiled in [Stable Video Diffusion Announcement](https://stability.ai/news/stable-video-diffusion-open-ai-video-model)
@@ -458,6 +545,7 @@ Script `image_to_video_generation.py` showcases how to perform image-to-video ge
 
 Here is how to generate video with one image prompt:
 ```bash
+PT_HPU_MAX_COMPOUND_OP_SIZE=1 \
 python image_to_video_generation.py \
     --model_name_or_path "stabilityai/stable-video-diffusion-img2vid-xt" \
     --image_path "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png" \
@@ -470,10 +558,14 @@ python image_to_video_generation.py \
     --bf16
 ```
 
+> For improved performance of the image-to-video pipeline on Gaudi, it is recommended to configure the environment
+> by setting PT_HPU_MAX_COMPOUND_OP_SIZE to 1.
+
 ### Multiple Image Prompts
 
 Here is how to generate videos with several image prompts:
 ```bash
+PT_HPU_MAX_COMPOUND_OP_SIZE=1 \
 python image_to_video_generation.py \
     --model_name_or_path "stabilityai/stable-video-diffusion-img2vid-xt" \
     --image_path "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png" \
@@ -489,57 +581,5 @@ python image_to_video_generation.py \
     --bf16
 ```
 
-## Inpainting Example
-Inpainting replaces or edits specific areas of an image. For more details, please refer to [Huging Face Diffusers doc](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint).
-### Stable Diffusion Inpainting
-```bash
-python text_to_image_generation.py \
-    --model_name_or_path  runwayml/stable-diffusion-inpainting \
-    --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png \
-    --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png \
-    --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k" \
-    --seed 0 \
-    --num_images_per_prompt 12 \
-    --batch_size 4 \
-    --image_save_dir ./inpaiting_images \
-    --use_habana \
-    --use_hpu_graphs \
-    --gaudi_config Habana/stable-diffusion
-```
-
-### Stable Diffusion XL Inpainting
-
-```bash
-python text_to_image_generation.py \
-    --model_name_or_path  diffusers/stable-diffusion-xl-1.0-inpainting-0.1\
-    --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png \
-    --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png \
-    --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k" \
-    --seed 0 \
-    --scheduler euler_discrete \
-    --num_images_per_prompt 12 \
-    --batch_size 4 \
-    --image_save_dir ./xl_inpaiting_images \
-    --use_habana \
-    --use_hpu_graphs \
-    --gaudi_config Habana/stable-diffusion
-```
-
-
-### Unconditional Image Generation Example
-
-Here is how to perform unconditional-image-generation on Gaudi/HPU.
-
-Original unconditional image generation pipeline is shared in here: [Unconditional Image Generation](https://huggingface.co/docs/diffusers/using-diffusers/unconditional_image_generation)
-
-```bash
-python3 unconditional_image_generation.py \
-    --model_name_or_path "google/ddpm-ema-celebahq-256" \
-    --batch_size 16 \
-    --use_habana \
-    --use_gaudi_ddim_scheduler \
-    --use_hpu_graphs \
-    --bf16 \
-    --save_outputs \
-    --output_dir "/tmp/"
-```
+> For improved performance of the image-to-video pipeline on Gaudi, it is recommended to configure the environment
+> by setting PT_HPU_MAX_COMPOUND_OP_SIZE to 1.

--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -317,16 +317,16 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
         with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=self.gaudi_config.use_torch_autocast):
             # 1. Check inputs. Raise error if not correct
             self.check_inputs(
-                prompt,
-                image,
-                callback_steps,
-                negative_prompt,
-                prompt_embeds,
-                negative_prompt_embeds,
-                controlnet_conditioning_scale,
-                control_guidance_start,
-                control_guidance_end,
-                callback_on_step_end_tensor_inputs,
+                prompt=prompt,
+                image=image,
+                callback_steps=callback_steps,
+                negative_prompt=negative_prompt,
+                prompt_embeds=prompt_embeds,
+                negative_prompt_embeds=negative_prompt_embeds,
+                controlnet_conditioning_scale=controlnet_conditioning_scale,
+                control_guidance_start=control_guidance_start,
+                control_guidance_end=control_guidance_end,
+                callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
             )
 
             self._guidance_scale = guidance_scale

--- a/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import time
 from dataclasses import dataclass
 from math import ceil
@@ -25,12 +24,10 @@ from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalCon
 from diffusers.pipelines.stable_video_diffusion import StableVideoDiffusionPipeline
 from diffusers.pipelines.stable_video_diffusion.pipeline_stable_video_diffusion import (
     _append_dims,
-    _resize_with_antialiasing,
-    tensor2vid,
 )
 from diffusers.schedulers import EulerDiscreteScheduler
 from diffusers.utils import BaseOutput, logging
-from diffusers.utils.torch_utils import is_compiled_module, randn_tensor
+from diffusers.utils.torch_utils import randn_tensor
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
 
 from ....transformers.gaudi_configuration import GaudiConfig
@@ -112,194 +109,6 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
         )
 
         self.to(self._device)
-
-    def _encode_image(self, image, device, num_videos_per_prompt, do_classifier_free_guidance):
-        dtype = next(self.image_encoder.parameters()).dtype
-
-        if not isinstance(image, torch.Tensor):
-            image = self.image_processor.pil_to_numpy(image)
-            image = self.image_processor.numpy_to_pt(image)
-
-            # We normalize the image before resizing to match with the original implementation.
-            # Then we unnormalize it after resizing.
-            image = image * 2.0 - 1.0
-            image = _resize_with_antialiasing(image, (224, 224))
-            image = (image + 1.0) / 2.0
-
-            # Normalize the image with for CLIP input
-            image = self.feature_extractor(
-                images=image,
-                do_normalize=True,
-                do_center_crop=False,
-                do_resize=False,
-                do_rescale=False,
-                return_tensors="pt",
-            ).pixel_values
-
-        image = image.to(device=device, dtype=dtype)
-        image_embeddings = self.image_encoder(image).image_embeds
-        image_embeddings = image_embeddings.unsqueeze(1)
-
-        # duplicate image embeddings for each generation per prompt, using mps friendly method
-        bs_embed, seq_len, _ = image_embeddings.shape
-        image_embeddings = image_embeddings.repeat(1, num_videos_per_prompt, 1)
-        image_embeddings = image_embeddings.view(bs_embed * num_videos_per_prompt, seq_len, -1)
-
-        if do_classifier_free_guidance:
-            negative_image_embeddings = torch.zeros_like(image_embeddings)
-
-            # For classifier free guidance, we need to do two forward passes.
-            # Here we concatenate the unconditional and text embeddings into a single batch
-            # to avoid doing two forward passes
-            image_embeddings = torch.cat([negative_image_embeddings, image_embeddings])
-
-        return image_embeddings
-
-    def _encode_vae_image(
-        self,
-        image: torch.Tensor,
-        device,
-        num_videos_per_prompt,
-        do_classifier_free_guidance,
-    ):
-        image = image.to(device=device)
-        image_latents = self.vae.encode(image).latent_dist.mode()
-
-        if do_classifier_free_guidance:
-            negative_image_latents = torch.zeros_like(image_latents)
-
-            # For classifier free guidance, we need to do two forward passes.
-            # Here we concatenate the unconditional and text embeddings into a single batch
-            # to avoid doing two forward passes
-            image_latents = torch.cat([negative_image_latents, image_latents])
-
-        # duplicate image_latents for each generation per prompt, using mps friendly method
-        image_latents = image_latents.repeat(num_videos_per_prompt, 1, 1, 1)
-
-        return image_latents
-
-    def _get_add_time_ids(
-        self,
-        fps,
-        motion_bucket_id,
-        noise_aug_strength,
-        dtype,
-        batch_size,
-        num_videos_per_prompt,
-        do_classifier_free_guidance,
-        device,
-    ):
-        add_time_ids = [fps, motion_bucket_id, noise_aug_strength]
-
-        passed_add_embed_dim = self.unet.config.addition_time_embed_dim * len(add_time_ids)
-        expected_add_embed_dim = self.unet.add_embedding.linear_1.in_features
-
-        if expected_add_embed_dim != passed_add_embed_dim:
-            raise ValueError(
-                f"Model expects an added time embedding vector of length {expected_add_embed_dim}, but a vector of {passed_add_embed_dim} was created. The model has an incorrect config. Please check `unet.config.time_embedding_type` and `text_encoder_2.config.projection_dim`."
-            )
-
-        add_time_ids = torch.tensor([add_time_ids], dtype=dtype).to(device)
-        add_time_ids = add_time_ids.repeat(batch_size * num_videos_per_prompt, 1)
-
-        if do_classifier_free_guidance:
-            add_time_ids = torch.cat([add_time_ids, add_time_ids])
-
-        return add_time_ids
-
-    def decode_latents(self, latents, num_frames, decode_chunk_size=14):
-        # [batch, frames, channels, height, width] -> [batch*frames, channels, height, width]
-        latents = latents.flatten(0, 1)
-
-        latents = 1 / self.vae.config.scaling_factor * latents
-
-        forward_vae_fn = self.vae._orig_mod.forward if is_compiled_module(self.vae) else self.vae.forward
-        accepts_num_frames = "num_frames" in set(inspect.signature(forward_vae_fn).parameters.keys())
-
-        # decode decode_chunk_size frames at a time to avoid OOM
-        frames = []
-        for i in range(0, latents.shape[0], decode_chunk_size):
-            num_frames_in = latents[i : i + decode_chunk_size].shape[0]
-            decode_kwargs = {}
-            if accepts_num_frames:
-                # we only pass num_frames_in if it's expected
-                decode_kwargs["num_frames"] = num_frames_in
-
-            frame = self.vae.decode(latents[i : i + decode_chunk_size], **decode_kwargs).sample
-            frames.append(frame)
-        frames = torch.cat(frames, dim=0)
-
-        # [batch*frames, channels, height, width] -> [batch, channels, frames, height, width]
-        frames = frames.reshape(-1, num_frames, *frames.shape[1:]).permute(0, 2, 1, 3, 4)
-
-        # we always cast to float32 as this does not cause significant overhead and is compatible with bfloat16
-        frames = frames.float()
-        return frames
-
-    def check_inputs(self, image, height, width):
-        if (
-            not isinstance(image, torch.Tensor)
-            and not isinstance(image, PIL.Image.Image)
-            and not isinstance(image, list)
-        ):
-            raise ValueError(
-                "`image` has to be of type `torch.FloatTensor` or `PIL.Image.Image` or `List[PIL.Image.Image]` but is"
-                f" {type(image)}"
-            )
-
-        if height % 8 != 0 or width % 8 != 0:
-            raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
-
-    def prepare_latents(
-        self,
-        batch_size,
-        num_frames,
-        num_channels_latents,
-        height,
-        width,
-        dtype,
-        device,
-        generator,
-        latents=None,
-    ):
-        shape = (
-            batch_size,
-            num_frames,
-            num_channels_latents // 2,
-            height // self.vae_scale_factor,
-            width // self.vae_scale_factor,
-        )
-        if isinstance(generator, list) and len(generator) != batch_size:
-            raise ValueError(
-                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
-                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
-            )
-
-        if latents is None:
-            latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype).to(device)
-        else:
-            latents = latents.to(device)
-
-        # scale the initial noise by the standard deviation required by the scheduler
-        latents = latents * self.scheduler.init_noise_sigma
-        return latents
-
-    @property
-    def guidance_scale(self):
-        return self._guidance_scale
-
-    # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
-    # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
-    # corresponds to doing no classifier free guidance.
-    @property
-    def do_classifier_free_guidance(self):
-        if isinstance(self.guidance_scale, (int, float)):
-            return self.guidance_scale
-        return self.guidance_scale.max() > 1
-
-    @property
-    def num_timesteps(self):
-        return self._num_timesteps
 
     @classmethod
     def _pad_batches(cls, input_batches, num_dummy_samples):
@@ -499,16 +308,21 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
         Examples:
 
         ```py
-        from diffusers import StableVideoDiffusionPipeline
+        import os, torch
         from diffusers.utils import load_image, export_to_video
+        from optimum.habana.diffusers import GaudiStableVideoDiffusionPipeline
+        os.environ["PT_HPU_MAX_COMPOUND_OP_SIZE"] = "1"
 
-        pipe = StableVideoDiffusionPipeline.from_pretrained("stabilityai/stable-video-diffusion-img2vid-xt", torch_dtype=torch.float16, variant="fp16")
-        pipe.to("cuda")
-
-        image = load_image("https://lh3.googleusercontent.com/y-iFOHfLTwkuQSUegpwDdgKmOjRSTvPxat63dQLB25xkTs4lhIbRUFeNBWZzYf370g=s1200")
+        pipe = GaudiStableVideoDiffusionPipeline.from_pretrained(
+            "stabilityai/stable-video-diffusion-img2vid-xt",
+            torch_dtype=torch.bfloat16,
+            use_habana=True,
+            use_hpu_graphs=True,
+            gaudi_config="Habana/stable-diffusion",
+        )
+        image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png")
         image = image.resize((1024, 576))
-
-        frames = pipe(image, num_frames=25, decode_chunk_size=8).frames[0]
+        frames = pipe(image, num_frames=25).frames[0]
         export_to_video(frames, "generated.mp4", fps=7)
         ```
         """
@@ -556,7 +370,7 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
             fps = fps - 1
 
             # 4. Encode input image using VAE
-            image = self.image_processor.preprocess(image, height=height, width=width)
+            image = self.video_processor.preprocess(image, height=height, width=width)
             # torch.randn is broken on HPU so running it on CPU
             rand_device = "cpu" if device.type == "hpu" else device
             noise = randn_tensor(image.shape, generator=generator, device=rand_device, dtype=image.dtype).to(device)
@@ -600,14 +414,15 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                 num_images,
                 num_videos_per_prompt,
                 self.do_classifier_free_guidance,
-                device,
             )
             added_time_ids = added_time_ids.to(device)
 
             # 6 Prepare timesteps
             self.scheduler.set_timesteps(num_inference_steps, device=device)
             timesteps = self.scheduler.timesteps
-            self.scheduler.reset_timestep_dependent_params()
+            if hasattr(self.scheduler, "reset_timestep_dependent_params"):
+                # Reset timestep parameters for Gaudi-optimized scheduler
+                self.scheduler.reset_timestep_dependent_params()
 
             # 7 Prepare latent variables
             num_channels_latents = self.unet.config.in_channels
@@ -656,12 +471,17 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
 
             # 10. Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
+            use_warmup_inference_steps = (
+                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+            )
             self._num_timesteps = len(timesteps)
             for j in self.progress_bar(range(num_batches)):
                 # The throughput is calculated from the 3rd iteration
                 # because compilation occurs in the first two iterations
                 if j == throughput_warmup_steps:
                     t1 = time.time()
+                if use_warmup_inference_steps:
+                    t0_inf = time.time()
 
                 latents_batch = latents_batches[0]
                 latents_batches = torch.roll(latents_batches, shifts=-1, dims=0)
@@ -673,6 +493,9 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                 added_time_ids_batches = torch.roll(added_time_ids_batches, shifts=-1, dims=0)
 
                 for i in self.progress_bar(range(num_inference_steps)):
+                    if use_warmup_inference_steps and i == throughput_warmup_steps:
+                        t1 += time.time() - t0_inf
+
                     timestep = timesteps[0]
                     timesteps = torch.roll(timesteps, shifts=-1, dims=0)
 
@@ -716,7 +539,7 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                         self.vae.to(dtype=cast_dtype)
 
                     frames = self.decode_latents(latents_batch, num_frames, decode_chunk_size)
-                    frames = tensor2vid(frames, self.image_processor, output_type=output_type)
+                    frames = self.video_processor.postprocess_video(video=frames, output_type=output_type)
                 else:
                     frames = latents_batch
 
@@ -727,7 +550,7 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                 split=speed_metrics_prefix,
                 start_time=t0,
                 num_samples=num_batches * batch_size
-                if t1 == t0
+                if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
                 num_steps=num_batches,
                 start_time_after_warmup=t1,

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ INSTALL_REQUIRES = [
     "accelerate < 0.28.0",
     "diffusers >= 0.29.2",
     "huggingface_hub >= 0.23.2",
-    "datasets < 2.20.0",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,9 @@ INSTALL_REQUIRES = [
     "optimum",
     "torch",
     "accelerate < 0.28.0",
-    "diffusers >= 0.26.0, < 0.27.0",
-    "huggingface_hub < 0.23.0",
+    "diffusers >= 0.29.2",
+    "huggingface_hub >= 0.23.2",
+    "datasets < 2.20.0",
 ]
 
 TESTS_REQUIRE = [
@@ -47,6 +48,7 @@ TESTS_REQUIRE = [
     "timm",
     "safetensors",
     "pytest < 8.0.0",
+    "scipy",
     "torchsde",
     "timm",
 ]

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -3331,7 +3331,7 @@ class PipelineTesterMixin:
         model_dtypes = [component.dtype for component in components.values() if hasattr(component, "dtype")]
         self.assertTrue(all(dtype == torch.float32 for dtype in model_dtypes))
 
-        pipe.to(torch_dtype=torch.bfloat16)
+        pipe.to(dtype=torch.bfloat16)
         model_dtypes = [component.dtype for component in components.values() if hasattr(component, "dtype")]
         self.assertTrue(all(dtype == torch.bfloat16 for dtype in model_dtypes))
 


### PR DESCRIPTION
# Upgrade optimum-habana diffusers from 0.26.3 to 0.29.2

* Updated optimum-habana diffusers to 0.29.2 in `setup.py`
* Fixed SVD (GaudiStableVideoDiffusionPipeline) to handle updated API in 0.29.2 for `tensor2vid` and instead use `video_processor.postprocess_video`
* Fixed GaudiStableDiffusionControlNetPipeline to handle updated `check_inputs` API in 0.29.2
* Fixed `tests/test_diffusers.py` to use `to(dtype=...)` instead of `to(torch_dtype=...)` which is deprecated starting diffusers 0.27.0 (See [here](https://github.com/huggingface/diffusers/blob/v0.26.3/src/diffusers/pipelines/pipeline_utils.py#L781))
* Clean-up SVD to remove all inheritable functions
* Updated warmup logic in SVD
* Updated documentation example with command line for SVD that yields improved performance

## Tests
Ran tests on G2:

```bash
export RUN_SLOW=true
export GAUDI2_CI=1
make test_installs
python -m pytest tests/test_diffusers.py
```

Diffusers test results **before** diffusers upgrade:
```bash
17 failed, 106 passed, 13 skipped, 65 warnings in 2304.15s (0:38:24)
```

Diffusers test results **after** diffusers upgrade:
```bash
16 failed, 107 passed, 13 skipped, 316 warnings in 2157.94s (0:35:57)
```

**Note:**  Update is needed for supporting enabling newest pipelines such as **Stable Diffusion 3**, etc.