### PR TITLE
Add flash attention support for FP8 Mistral

### DIFF
--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -135,9 +135,12 @@ class Matmul(torch.nn.Module):
 
 
 # Copy from GaudiMixtralAttentionLongSequence
-class GaudiMistralAttentionLongSequence:
-    @staticmethod
-    def forward(q, k, v, mask, causal, q_block_size):
+class GaudiMistralAttentionLongSequence(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fsdpa_module = ModuleFusedSDPA(FusedSDPA)
+
+    def forward(self, q, k, v, mask, causal, q_block_size):
         """
         Support long sequence at prompt phase
         """
@@ -153,8 +156,7 @@ class GaudiMistralAttentionLongSequence:
             s, e = i * q_block_size, (i + 1) * q_block_size
             row_q = q[:, :, s:e, :]
             row_mask = mask[:, :, s:e, :]
-            row_o = attn_output[:, :, s:e, :]
-            row_o.fill_(FusedSDPA.apply(row_q, k, v, row_mask, 0.0, causal, None))
+            attn_output[:, :, s:e, :] = self.fsdpa_module(row_q, k, v, row_mask, 0.0, causal, None)
 
         if q_padding != 0:
             attn_output = attn_output[:, :, :-q_padding, :]
@@ -229,10 +231,11 @@ class GaudiMistralAttention(MistralAttention):
         self.matmul_qk = Matmul()
         self.matmul_av = Matmul()
         self.fused_scaled_dot_product_attention = ModuleFusedSDPA(FusedSDPA) if FusedSDPA else None
+        self.fused_sdpa_long = GaudiMistralAttentionLongSequence() if FusedSDPA else None
         self.inp_seq_len = -1
         self._init_rope()
         self.norm_factor = 1.0 / math.sqrt(self.head_dim)
-        self.block_size = 1024
+        self.block_size = 8192 if os.getenv("QUANT_CONFIG", "") else 1024
 
     def _init_rope(self):
         """
@@ -386,28 +389,29 @@ class GaudiMistralAttention(MistralAttention):
                     )
             else:
                 # first token
-                if flash_attention_causal_mask:
-                    # causal masking on first token requires inputs to be of the same length
-                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                        attn_output = self.fused_scaled_dot_product_attention(
-                            query_states, key_states, value_states, None, 0.0, True, None
-                        )
+                if not self.training and q_len == key_states.size(-2) and q_len > 8192 and os.getenv("QUANT_CONFIG", ""):
+                    htcore.mark_step()
+                    attn_output = self.fused_sdpa_long(
+                        query_states,
+                        key_states,
+                        value_states,
+                        attention_mask,
+                        False,
+                        self.block_size,
+                    )
+                    htcore.mark_step()
                 else:
-                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                        attn_output = self.fused_scaled_dot_product_attention(
-                            query_states, key_states, value_states, attention_mask, 0.0, False, None
-                        )
-        elif FusedSDPA and not self.training and q_len == key_states.size(-2) and q_len > 8192:
-            htcore.mark_step()
-            attn_output = GaudiMistralAttentionLongSequence.forward(
-                query_states,
-                key_states,
-                value_states,
-                attention_mask,
-                False,
-                self.block_size,
-            )
-            htcore.mark_step()
+                    if flash_attention_causal_mask:
+                        # causal masking on first token requires inputs to be of the same length
+                        with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
+                            attn_output = self.fused_scaled_dot_product_attention(
+                                query_states, key_states, value_states, None, 0.0, True, None
+                            )
+                    else:
+                        with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
+                            attn_output = self.fused_scaled_dot_product_attention(
+                                query_states, key_states, value_states, attention_mask, 0.0, False, None
+                            )
         else:
             # repeat k/v heads if n_kv_heads < n_heads
             query_states, key_states, value_states, attention_mask = gaudi_mistral_repeat_kv(

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -25,7 +25,6 @@ from typing import List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
 import torch
-import torch.nn.functional as F
 from torch import nn
 from torch.nn import CrossEntropyLoss
 from transformers.cache_utils import Cache, DynamicCache
@@ -134,36 +133,6 @@ class Matmul(torch.nn.Module):
         return torch.matmul(x, y)
 
 
-# Copy from GaudiMixtralAttentionLongSequence
-class GaudiMistralAttentionLongSequence(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.fsdpa_module = ModuleFusedSDPA(FusedSDPA)
-
-    def forward(self, q, k, v, mask, causal, q_block_size):
-        """
-        Support long sequence at prompt phase
-        """
-        q_len = q.size(-2)
-        q_tiles = (q_len // q_block_size) if (q_len % q_block_size == 0) else math.ceil(q_len / q_block_size)
-        q_padding = q_tiles * q_block_size - q_len
-        q = F.pad(q, (0, 0, 0, q_padding), "constant", 0)
-        if mask is not None:
-            mask = F.pad(mask, (0, 0, 0, q_padding), "constant", -10000.0)
-        attn_output = torch.zeros_like(q)
-
-        for i in range(q_tiles):
-            s, e = i * q_block_size, (i + 1) * q_block_size
-            row_q = q[:, :, s:e, :]
-            row_mask = mask[:, :, s:e, :]
-            attn_output[:, :, s:e, :] = self.fsdpa_module(row_q, k, v, row_mask, 0.0, causal, None)
-
-        if q_padding != 0:
-            attn_output = attn_output[:, :, :-q_padding, :]
-
-        return attn_output
-
-
 def gaudi_mistral_repeat_kv(
     query_states: torch.Tensor,
     key_states: torch.Tensor,
@@ -231,11 +200,9 @@ class GaudiMistralAttention(MistralAttention):
         self.matmul_qk = Matmul()
         self.matmul_av = Matmul()
         self.fused_scaled_dot_product_attention = ModuleFusedSDPA(FusedSDPA) if FusedSDPA else None
-        self.fused_sdpa_long = GaudiMistralAttentionLongSequence() if FusedSDPA else None
         self.inp_seq_len = -1
         self._init_rope()
         self.norm_factor = 1.0 / math.sqrt(self.head_dim)
-        self.block_size = 8192 if os.getenv("QUANT_CONFIG", "") else 1024
 
     def _init_rope(self):
         """
@@ -389,34 +356,18 @@ class GaudiMistralAttention(MistralAttention):
                     )
             else:
                 # first token
-                if (
-                    not self.training
-                    and q_len == key_states.size(-2)
-                    and q_len > 8192
-                    and os.getenv("QUANT_CONFIG", "")
-                ):
-                    htcore.mark_step()
-                    attn_output = self.fused_sdpa_long(
-                        query_states,
-                        key_states,
-                        value_states,
-                        attention_mask,
-                        False,
-                        self.block_size,
-                    )
-                    htcore.mark_step()
+                if flash_attention_causal_mask:
+                    # causal masking on first token requires inputs to be of the same length
+                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
+                        attn_output = self.fused_scaled_dot_product_attention(
+                            query_states, key_states, value_states, None, 0.0, True, None
+                        )
                 else:
-                    if flash_attention_causal_mask:
-                        # causal masking on first token requires inputs to be of the same length
-                        with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                            attn_output = self.fused_scaled_dot_product_attention(
-                                query_states, key_states, value_states, None, 0.0, True, None
-                            )
-                    else:
-                        with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                            attn_output = self.fused_scaled_dot_product_attention(
-                                query_states, key_states, value_states, attention_mask, 0.0, False, None
-                            )
+                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
+                        attn_output = self.fused_scaled_dot_product_attention(
+                            query_states, key_states, value_states, attention_mask, 0.0, False, None
+                        )
+
         else:
             # repeat k/v heads if n_kv_heads < n_heads
             query_states, key_states, value_states, attention_mask = gaudi_mistral_repeat_kv(

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -389,7 +389,12 @@ class GaudiMistralAttention(MistralAttention):
                     )
             else:
                 # first token
-                if not self.training and q_len == key_states.size(-2) and q_len > 8192 and os.getenv("QUANT_CONFIG", ""):
+                if (
+                    not self.training
+                    and q_len == key_states.size(-2)
+                    and q_len > 8192
+                    and os.getenv("QUANT_CONFIG", "")
+                ):
                     htcore.mark_step()
                     attn_output = self.fused_sdpa_long(
                         query_states,

--- a/tests/test_text_generation_example.py
+++ b/tests/test_text_generation_example.py
@@ -52,10 +52,10 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
             ("meta-llama/Llama-2-70b-hf", 4, 750, False, 128, 2048, 7422.4),
             ("meta-llama/Llama-2-70b-hf", 4, 207, False, 2048, 128, 568.5),
             ("meta-llama/Llama-2-70b-hf", 8, 172, False, 2048, 2048, 4656.2),
-            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 896, True, 128, 128, 12397.11410288204),
-            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 120, True, 128, 2048, 5394.675714459493),
-            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 120, True, 2048, 128, 919.8470890081497),
-            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 44, True, 2048, 2048, 2471.950758729518),
+            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 896, True, 128, 128, 17068.965283763682),
+            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 120, True, 128, 2048, 6979.225194247115),
+            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 120, True, 2048, 128, 1681.4401450088983),
+            ("mistralai/Mistral-7B-Instruct-v0.2", 1, 44, True, 2048, 2048, 3393.149396451692),
             ("mistralai/Mixtral-8x7B-v0.1", 1, 1, True, 128, 128, 39.26845661768185),
             ("microsoft/phi-2", 1, 1, True, 128, 128, 254.08932787178165),
         ],
@@ -165,6 +165,11 @@ def _test_text_generation(
             command.insert(-2, "--flash_attention_recompute")
             command.insert(-2, "--bucket_size 128")
             command.insert(-2, "--bucket_internal")
+        if "Mistral" in model_name:
+            command.insert(-2, "--use_flash_attention")
+            command.insert(-2, "--flash_attention_recompute")
+            command.insert(-2, "--attn_softmax_bf16")
+            command.insert(-2, "--trim_logits")
         elif "falcon-180b" in model_name.lower():
             command.insert(-2, "--flash_attention_recompute")
 


### PR DESCRIPTION
--use_flash_attention was not used for FP8 Mistral due to the accuracy issue (https://github.com/huggingface/optimum-habana/pull/985). Since the accuracy issue is now gone in 1.17.0, this PR refactor the mistral modeling script to enable flash attention for FP8 flow. Also the GaudiMistralAttentionLongSequence class is removed because the model can serve seq_len==max_position_embedding and performs better without it.

For the case with --batch_size 7 --max_new_tokens 512 --max_input_tokens 32000

Original code without flash attention:
Throughput (including tokenization) = 42.07969811168232 tokens/second
Number of HPU graphs = 121
Memory allocated = 37.51 GB
Max memory allocated = 94.31 GB
Total memory available = 94.62 GB
Graph compilation duration = 285.1875329967588 seconds
Time to first token = 77804.80473767966ms

This PR with flash attention:
Throughput (including tokenization) = 63.06745994995644 tokens/second
Number of HPU graphs = 85
Memory allocated = 37.52 GB
Max memory allocated = 94.0 GB
Total memory available = 94.62 GB
Graph compilation duration = 277.9795082975179 seconds
Time to first token = 49177.13945917785ms

command: QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path /root/tf/test/mistral/ --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 7 --max_new_tokens 512 --max_input_tokens 32000 --limit_hpu_graphs --use_flash_attention --flash_attention_recompute

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
