### PR TITLE
refine use cache for mpt model

### DIFF
--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -67,9 +67,12 @@ def gaudi_mpt_attention_forward(
             else:
                 key_states = torch.cat([past_key_value[0], key_states], dim=2)
                 value_states = torch.cat([past_key_value[1], value_states], dim=2)
-        past_key_value = [key_states, value_states]
+                past_key_value = [key_states, value_states]
     else:
-        past_key_value = [key_states, value_states]
+        past_key_value = [torch.empty(key_states.shape, dtype=key_states.dtype,device=key_states.device),
+                        torch.empty(key_states.shape, dtype=key_states.dtype,device=key_states.device)]
+        past_key_value[0][:] = key_states[:]
+        past_key_value[1][:] = value_states[:]
 
     attention_scores = torch.matmul(query_states, key_states.transpose(-1, -2)) * self.softmax_scale
 

--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -69,8 +69,10 @@ def gaudi_mpt_attention_forward(
                 value_states = torch.cat([past_key_value[1], value_states], dim=2)
                 past_key_value = [key_states, value_states]
     else:
-        past_key_value = [torch.empty(key_states.shape, dtype=key_states.dtype,device=key_states.device),
-                        torch.empty(key_states.shape, dtype=key_states.dtype,device=key_states.device)]
+        past_key_value = [
+            torch.empty(key_states.shape, dtype=key_states.dtype, device=key_states.device),
+            torch.empty(key_states.shape, dtype=key_states.dtype, device=key_states.device),
+        ]
         past_key_value[0][:] = key_states[:]
         past_key_value[1][:] = value_states[:]
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Modified the kv_cache initialization method and optimized performance.
Co-author:  @atakaha 
Test command:
```bash
python run_generation.py --model_name_or_path mosaicml/mpt-7b --use_hpu_graphs --use_kv_cache --limit_hpu_graph --batch_size 128  --max_input_tokens 128 --max_new_tokens 128 --trim_logits --attn_softmax_bf16 --warmup 3 --n_iterations 1 --bf16
```
Result:

|Version|batchsize|max input tokens|max new tokens|Throughput (including tokenization)(tokens/s)|Memory allocated(GB)|Max memory allocated(GB)|
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
|before|128|128|128|2900|37.28|64.39|
|after|128|128|128|4803|29.28|48.39|
|before|16|128|1024|624|26.55|41.79|
|after|16|128|1024|1215|23.04|33.77|
|before|2|1024|1024|197|16.27|19.66|
|after|2|1024|1024|255|15.27|17.66|
|before|16|1024|1024|384|40.78|67.86|
|after|16|1024|1024|846|32.78|51.86|
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
