### PR TITLE
Enable t.compile for Granite20B

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -177,7 +177,10 @@ def patch_scoped_linear_all_reduce(model):
 
 
 def get_torch_compiled_model(model):
-    model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
+    if  model.config.model_type in ['gpt_bigcode']:
+      model.transformer = torch.compile(model.transformer, backend="hpu_backend", options={"keep_input_mutations": True})
+    else:
+      model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
     return model
 
 


### PR DESCRIPTION
**Enable t.compile for Granite20B**

Granite20B model uses the GPTBigCode model type. In this model, model object uses model.transformer instead of model.model for the actual model. This is a pointed fix for this model, in future other models may need similar change.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
