### PR TITLE
Fix max_position_embedding init for tf4.43 upgrade

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -127,6 +127,10 @@ class GaudiLlamaRotaryEmbedding(torch.nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.original_inv_freq = self.inv_freq
 
+        # max_position_embeddings value is not passed as argument from Transformer 4.43.
+        # initialize the value here before update cos_sin cache
+        max_position_embeddings = config.max_position_embeddings
+
         # Build here to make `torch.jit.trace` work.
         self._set_cos_sin_cache(
             seq_len=max_position_embeddings, device=self.inv_freq.device, dtype=torch.get_default_dtype()


### PR DESCRIPTION
max_position_embedding value was passed through as an argument on the 4.40.2, and initialized correctly but this is no longer happening since tf4.43 code is changed. We still use old architecture for this RotaryEmbedding, so the valuehas to be initialized before cos/sin cache updated. I am setting this up in RotaryEmbedding itself by reading it from config. 

https://github.com/huggingface/transformers/blob/v4.43.2/src/transformers/models/llama/modeling_llama.py#L306  vs 
https://github.com/huggingface/transformers/blob/v4.40.2/src/transformers/models/llama/modeling_llama.py#L295
 
 
 Without above change, crash was seen on transformer 4.43 branch for llama when the max_new_token is bigger than 2048. 
 
