### PR TITLE
Fix LlamaConfig attr errors during test

### DIFF
--- a/tests/transformers/tests/models/llama/test_modeling_llama.py
+++ b/tests/transformers/tests/models/llama/test_modeling_llama.py
@@ -17,7 +17,8 @@
 import unittest
 
 from parameterized import parameterized
-from transformers import LlamaConfig, is_torch_available
+from transformers import is_torch_available, set_seed
+from optimum.habana.transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.testing_utils import require_torch, slow
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi


### PR DESCRIPTION
To resolve "AttributeError: 'LlamaConfig' object has no attribute 'parallel_strategy'" from test "GAUDI2_CI=1 RUN_SLOW=1 python -m pytest tests/transformers/tests/models/llama/test_modeling_llama.py -v -s".

* changes from : https://github.com/HabanaAI/optimum-habana-fork/pull/272