### PR TITLE
Revert "Fix max_position_embedding init for tf4.43 upgrade (#1202)"

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -127,10 +127,6 @@ class GaudiLlamaRotaryEmbedding(torch.nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.original_inv_freq = self.inv_freq
 
-        # max_position_embeddings value is not passed as argument from Transformer 4.43.
-        # initialize the value here before update cos_sin cache
-        max_position_embeddings = config.max_position_embeddings
-
         # Build here to make `torch.jit.trace` work.
         self._set_cos_sin_cache(
             seq_len=self.max_seq_len_cached, device=self.inv_freq.device, dtype=torch.get_default_dtype()


### PR DESCRIPTION
This reverts commit 55f9b0ce39a4f01978077e601e031a6acc2d5609.

This commits fixes llama, but cause failure on Mixtral. 
New pull request(#1205) fix for both models. 