### PR TITLE
fea(937): fixes related to OSError

### DIFF
--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1257,12 +1257,8 @@ class Wav2Vec2RobustModelTest(ModelTesterMixin, unittest.TestCase):
             pt_filepath = os.path.join(tempdir, WAV2VEC2_ADAPTER_PT_FILE.format("eng"))
             torch.save(adapter_weights, pt_filepath)
 
-            # model.load_adapter is broken in transformers
-            # since adapter_weights fails to load with weights_only=True
-            with self.assertRaises(OSError):
-                model.load_adapter("eng")
-            with self.assertRaises(OSError):
-                model.load_adapter("eng", use_safetensors=False)
+            model.load_adapter("eng")
+            model.load_adapter("eng", use_safetensors=False)
             # we will load adapter_weights directly while model.load_adapter fails
             state_dict = torch.load(pt_filepath)
             state_dict = {k: v.to(adapter_weights[k]) for k, v in state_dict.items()}


### PR DESCRIPTION
# What does this PR do?
Part of the previous PR: https://github.com/huggingface/optimum-habana/pull/937/files 
```
GAUDI2_CI=1 RUN_SLOW=1 python -m pytest tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py -s -v -k test_load_attn_adapter
```
```
=========================================================================================== 1 passed, 156 deselected, 5 warnings in 16.37s ============================================================================================
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
