### PR TITLE
Add trust_remote_code for t5 poly-tuning test

### DIFF
--- a/examples/language-modeling/peft_poly_seq2seq_with_generate.py
+++ b/examples/language-modeling/peft_poly_seq2seq_with_generate.py
@@ -233,7 +233,7 @@ def main():
 
     # boolq
     boolq_dataset = (
-        load_dataset("super_glue", "boolq")
+        load_dataset("super_glue", "boolq", trust_remote_code=model_args.trust_remote_code)
         .map(
             lambda x: {
                 "input": f"{x['passage']}\nQuestion: {x['question']}\nA. Yes\nB. No\nAnswer:",
@@ -248,7 +248,7 @@ def main():
 
     # multirc
     multirc_dataset = (
-        load_dataset("super_glue", "multirc")
+        load_dataset("super_glue", "multirc", trust_remote_code=model_args.trust_remote_code)
         .map(
             lambda x: {
                 "input": (
@@ -266,7 +266,7 @@ def main():
 
     # rte
     rte_dataset = (
-        load_dataset("super_glue", "rte")
+        load_dataset("super_glue", "rte", trust_remote_code=model_args.trust_remote_code)
         .map(
             lambda x: {
                 "input": (
@@ -284,7 +284,7 @@ def main():
 
     # wic
     wic_dataset = (
-        load_dataset("super_glue", "wic")
+        load_dataset("super_glue", "wic", trust_remote_code=model_args.trust_remote_code)
         .map(
             lambda x: {
                 "input": (

--- a/tests/baselines/t5_small.json
+++ b/tests/baselines/t5_small.json
@@ -135,7 +135,8 @@
                         "--max_target_length 2",
                         "--max_train_samples 1000",
                         "--max_eval_samples 100",
-                        "--bf16"
+                        "--bf16",
+                        "--trust_remote_code True"
                     ]
                 }
             }


### PR DESCRIPTION
# What does this PR do?

`super_glue` contains custom code, thus it requires manual permission. To automate testing we can provide passing the argument `--trust_remote_code=True` to allow this custom code to be run

<!-- Remove if not applicable -->

Fixes # (issue)

```sh
>>> python -m pytest tests/test_examples.py -v -s -k test_peft_poly_seq2seq_with_generate_t5-small_multi_card
[rank6]: ValueError: The repository for super_glue contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/super_glue.
[rank6]: Please pass the argument `trust_remote_code=True` to allow custom code to be run.
The repository for super_glue contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/super_glue.
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
