### PR TITLE
T5 multi card

### DIFF
--- a/examples/language-modeling/peft_poly_seq2seq_with_generate.py
+++ b/examples/language-modeling/peft_poly_seq2seq_with_generate.py
@@ -390,6 +390,8 @@ def main():
         token=model_args.token,
     )
     peft_model = get_peft_model(model, peft_config)
+    if training_args.bf16:
+        peft_model = peft_model.to(torch.bfloat16)
     peft_model.print_trainable_parameters()
 
     # training and evaluation

--- a/examples/language-modeling/run_multitask_prompt_tuning.py
+++ b/examples/language-modeling/run_multitask_prompt_tuning.py
@@ -18,6 +18,7 @@ Adapted from the following sources:
 https://github.com/huggingface/peft/blob/main/examples/conditional_generation/multitask_prompt_tuning.ipynb
 """
 
+import copy
 import logging
 import sys
 from dataclasses import dataclass, field
@@ -346,6 +347,8 @@ def main():
         low_cpu_mem_usage=model_args.low_cpu_mem_usage,
         token=model_args.token,
     )
+    model_target = copy.deepcopy(model)
+
     peft_model = get_peft_model(model, peft_config)
     peft_model.print_trainable_parameters()
 
@@ -386,7 +389,7 @@ def main():
         trainer.save_metrics("eval", metrics)
 
     # target train
-    peft_model = get_peft_model(model, peft_config_target)
+    peft_model = get_peft_model(model_target, peft_config_target)
     peft_model.print_trainable_parameters()
     trainer = GaudiSeq2SeqTrainer(
         model=peft_model,


### PR DESCRIPTION
# What does this PR do?

This PR addresses issues after upgrading the peft from `0.10.0` -> `0.12.0`

The second issue is resolved by yi.a.wang@intel.com

To test,

```sh
export RUN_SLOW=true
export GAUDI2_CI=1
python -m pytest tests/test_examples.py -v -s -k test_run_multitask_prompt_tuning_t5-small_multi_card
python -m pytest tests/test_examples.py -v -s -k test_peft_poly_seq2seq_with_generate_t5-small_multi_card
```

Fixes # (issue)

- In the recent version peft > 0.10.0, https://github.com/huggingface/peft/blob/e6cd24c907565040ee1766a5735afe3d13a71164/src/peft/mapping.py#L133, getting a Peft model object from a model and a config, cast adapter weights using float16 or bfloat16 to float32. This causes an issue. This PR is workaround for this issue.
- The second issue is copying the original model to avoid reusing modified model for the target

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
