### PR TITLE
Ig/synapse 1.17 ci fixes

### DIFF
--- a/tests/baselines/flan_t5_xxl.json
+++ b/tests/baselines/flan_t5_xxl.json
@@ -7,11 +7,11 @@
                 "deepspeed": {
                     "learning_rate": 1e-4,
                     "train_batch_size": 22,
-                    "eval_rougeLsum": 0.1429,
-                    "train_runtime": 89.486,
-                    "train_samples_per_second": 27.299,
+                    "eval_rougeLsum": 30.0552,
+                    "train_runtime": 162.566,
+                    "train_samples_per_second": 25.807,
                     "extra_arguments": [
-                        "--max_steps 10",
+                        "--max_steps 20",
                         "--max_eval_samples 880",
                         "--dataset_config 3.0.0",
                         "--source_prefix summarize: ",

--- a/tests/baselines/gpt2_xl.json
+++ b/tests/baselines/gpt2_xl.json
@@ -27,7 +27,7 @@
                 "deepspeed": {
                     "learning_rate": 4e-4,
                     "train_batch_size": 16,
-                    "perplexity": 13.0461,
+                    "perplexity": 13.23775,
                     "train_runtime": 190.696,
                     "train_samples_per_second": 89.877,
                     "extra_arguments": [

--- a/tests/baselines/gpt_neox_20b.json
+++ b/tests/baselines/gpt_neox_20b.json
@@ -7,7 +7,7 @@
                 "deepspeed": {
                     "learning_rate": 5e-5,
                     "train_batch_size": 2,
-                    "perplexity": 8.0545,
+                    "perplexity": 8.166753,
                     "train_runtime": 721.5428,
                     "train_samples_per_second": 7.571,
                     "extra_arguments": [

--- a/tests/baselines/roberta_base.json
+++ b/tests/baselines/roberta_base.json
@@ -56,8 +56,8 @@
                     "learning_rate": 7e-5,
                     "train_batch_size": 64,
                     "eval_f1": 91.5253,
-                    "train_runtime": 105.6042,
-                    "train_samples_per_second": 907.395,
+                    "train_runtime": 120.6563,
+                    "train_samples_per_second": 847.504,
                     "extra_arguments": [
                         "--max_seq_length 384",
                         "--use_hpu_graphs_for_inference"

--- a/tests/baselines/roberta_large.json
+++ b/tests/baselines/roberta_large.json
@@ -56,8 +56,8 @@
                     "learning_rate": 3e-5,
                     "train_batch_size": 32,
                     "eval_f1": 94.5886,
-                    "train_runtime": 342.1653,
-                    "train_samples_per_second": 284.873,
+                    "train_runtime": 361.4789,
+                    "train_samples_per_second": 266.47,
                     "extra_arguments": [
                         "--max_seq_length 384",
                         "--use_hpu_graphs_for_inference"

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -15,14 +15,14 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
     MODELS_TO_TEST = {
         "bf16": [
             ("llava-hf/llava-1.5-7b-hf", 1, 87.2901500056982),
-            ("llava-hf/llava-1.5-13b-hf", 1, 54.41252589197953),
+            ("llava-hf/llava-1.5-13b-hf", 1, 51.04717105443364),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 33.17984878151546),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 35.00608681379742),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 23.527610042925),
         ],
         "fp8": [
-            ("llava-hf/llava-1.5-7b-hf", 1, 123.00953973789325),
-            ("llava-hf/llava-1.5-13b-hf", 1, 82.81132373492122),
+            ("llava-hf/llava-1.5-7b-hf", 1, 115.48515989461843),
+            ("llava-hf/llava-1.5-13b-hf", 1, 78.2635142547838),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 45.011551008367084),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 45.18544502949674),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 30.9535718774675),


### PR DESCRIPTION
# What does this PR do?
- Fixes the failed tests on flan-t5, img2txt, gpt and reberta. 
  - For flan-t5, the increased steps adds about ~1min to total runtime. 
 - All tests have succeeded locally (below)
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Tests 
`gpt-neox`
```
[2024-08-07 19:24:21,431] [INFO] [launch.py:348:main] Process 588 exits successfully.
[2024-08-07 19:24:23,434] [INFO] [launch.py:348:main] Process 587 exits successfully.
[2024-08-07 19:24:24,435] [INFO] [launch.py:348:main] Process 589 exits successfully.
[2024-08-07 19:24:24,436] [INFO] [launch.py:348:main] Process 585 exits successfully.
[2024-08-07 19:24:25,437] [INFO] [launch.py:348:main] Process 586 exits successfully.
[2024-08-07 19:24:25,437] [INFO] [launch.py:348:main] Process 584 exits successfully.
[2024-08-07 19:24:26,439] [INFO] [launch.py:348:main] Process 591 exits successfully.
[2024-08-07 19:24:27,441] [INFO] [launch.py:348:main] Process 590 exits successfully.


Command to test: deepspeed --num_nodes 1 --num_gpus 8 --no_local_rank /devops/sgohari/tests/codes/ig/optimum-habana/examples/language-modeling/run_clm.py --model_name_or_path EleutherAI/gpt-neox-20b --gaudi_config_name Habana/gpt2 --dataset_name wikitext --do_train --output_dir /tmp/tmp1yox70ey --overwrite_output_dir --learning_rate 5e-05 --per_device_train_batch_size 2 --per_device_eval_batch_size 2 --num_train_epochs 2 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --dataset_config_name wikitext-2-raw-v1 --gradient_checkpointing --use_hpu_graphs_for_inference --deepspeed tests/configs/deepspeed_zero_2.json

PASSED

================ 1 passed, 55 deselected in 1204.11s (0:20:04) =================
```
`gpt2`
```
[2024-08-07 18:49:58,251] [INFO] [launch.py:348:main] Process 191084 exits successfully.
[2024-08-07 18:49:58,253] [INFO] [launch.py:348:main] Process 191080 exits successfully.
[2024-08-07 18:49:58,255] [INFO] [launch.py:348:main] Process 191085 exits successfully.
[2024-08-07 18:49:58,257] [INFO] [launch.py:348:main] Process 191087 exits successfully.
[2024-08-07 18:49:58,258] [INFO] [launch.py:348:main] Process 191081 exits successfully.
[2024-08-07 18:49:59,262] [INFO] [launch.py:348:main] Process 191082 exits successfully.
[2024-08-07 18:49:59,264] [INFO] [launch.py:348:main] Process 191086 exits successfully.
[2024-08-07 18:49:59,266] [INFO] [launch.py:348:main] Process 191083 exits successfully.


Command to test: deepspeed --num_nodes 1 --num_gpus 8 --no_local_rank /devops/sgohari/tests/codes/ig/optimum-habana/examples/language-modeling/run_clm.py --model_name_or_path gpt2-xl --gaudi_config_name Habana/gpt2 --dataset_name wikitext --do_train --output_dir /tmp/tmpzt9fxsoy --overwrite_output_dir --learning_rate 0.0004 --per_device_train_batch_size 16 --per_device_eval_batch_size 4 --num_train_epochs 2 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --dataset_config_name wikitext-2-raw-v1 --gradient_checkpointing --use_hpu_graphs_for_inference --deepspeed tests/configs/deepspeed_zero_2.json

PASSED

================= 1 passed, 55 deselected in 320.20s (0:05:20) =================
```
roberta-large
```

Command to test: python3 /devops/sgohari/tests/codes/ig/optimum-habana/examples/question-answering/run_qa.py --model_name_or_path roberta-large --gaudi_config_name Habana/roberta-large --dataset_name squad --do_train --output_dir /tmp/tmpan4wvlf4 --overwrite_output_dir --learning_rate 3e-05 --per_device_train_batch_size 32 --per_device_eval_batch_size 8 --num_train_epochs 1 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --max_seq_length 384 --torch_compile_backend hpu_backend --torch_compile

PASSED

================= 1 passed, 55 deselected in 471.53s (0:07:51) =================
```
roberta-base
```
Command to test: python3 /devops/sgohari/tests/codes/ig/optimum-habana/examples/question-answering/run_qa.py --model_name_or_path roberta-base --gaudi_config_name Habana/roberta-base --dataset_name squad --do_train --output_dir /tmp/tmp8qk5ytqi --overwrite_output_dir --learning_rate 7e-05 --per_device_train_batch_size 64 --per_device_eval_batch_size 8 --num_train_epochs 1 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --max_seq_length 384 --use_hpu_graphs_for_inference

PASSED

================= 1 passed, 55 deselected in 169.07s (0:02:49) =================
```
3 tests changed in img2text
```
------------------------------------------------------------------------------
The model 'GaudiLlavaForConditionalGeneration' is not supported for image-to-text. Supported models are ['BlipForConditionalGeneration', 'Blip2ForConditionalGeneration', 'ChameleonForConditionalGeneration', 'GitForCausalLM', 'Idefics2ForConditionalGeneration', 'InstructBlipForConditionalGeneration', 'InstructBlipVideoForConditionalGeneration', 'Kosmos2ForConditionalGeneration', 'LlavaForConditionalGeneration', 'LlavaNextVideoForConditionalGeneration', 'LlavaNextForConditionalGeneration', 'PaliGemmaForConditionalGeneration', 'Pix2StructForConditionalGeneration', 'VideoLlavaForConditionalGeneration', 'VipLlavaForConditionalGeneration', 'VisionEncoderDecoderModel'].
The attention layers in this model are transitioning from computing the RoPE embeddings internally through `position_ids` (2D tensor with the indexes of the tokens), to using externally computed `position_embeddings` (Tuple of tensors, containing cos and sin). In v4.45 `position_ids` will be removed and `position_embeddings` will be mandatory.
08/07/2024 18:01:45 - INFO - __main__ - result = [[{'generated_text': "\nUSER: What's the content of the image?\nASSISTANT: The image features a large, long, and very, very, and a very, very, and"}]], time = 244.5843950030394ms, Throughput (including tokenization) = 77.68279738273527 tokens/second


Command to test: python3 /devops/sgohari/tests/codes/ig/optimum-habana/examples/image-to-text/run_pipeline.py --model_name_or_path llava-hf/llava-1.5-13b-hf --batch_size 1 --max_new_tokens 20 --use_hpu_graphs --bf16 --output_dir /tmp/tmptu54b12d



Command to test: python3 /devops/sgohari/tests/codes/ig/optimum-habana/examples/image-to-text/run_pipeline.py --model_name_or_path llava-hf/llava-1.5-13b-hf --batch_size 1 --max_new_tokens 20 --use_hpu_graphs --bf16 --output_dir /tmp/tmptu54b12d --token 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

PASSED

======================== 3 passed in 327.86s (0:05:27) =========================
```