### PR TITLE
Remove the default env variable to trust remote code by default

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -573,6 +573,8 @@ deepspeed --num_gpus 8 run_lm_eval.py \
 -o eval.json
 ```
 
+> If the dataset you want to use requires the execution of remote code, please set the following environment variable: `HF_DATASETS_TRUST_REMOTE_CODE=true`
+
 
 ## Text-Generation Pipeline
 

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -20,11 +20,8 @@
 import argparse
 import json
 import logging
-import os
-
-
-os.environ.setdefault("HF_DATASETS_TRUST_REMOTE_CODE", "true")
 import multiprocessing as mp
+import os
 import time
 
 import lm_eval.evaluator
@@ -32,6 +29,8 @@ import lm_eval.tasks
 import psutil
 import torch
 import torch.nn.functional as F
+
+# Local imports
 from run_generation import setup_parser
 from utils import finalize_quantization, initialize_model
 


### PR DESCRIPTION
# What does this PR do?

Remove the default env variable to trust remote code by default.

This is wrong to set the env variable by default in the code. 
```py
os.environ.setdefault("HF_DATASETS_TRUST_REMOTE_CODE", "true")
```

User should set this in their env if they trust remote dataset. User can do `export HF_DATASETS_TRUST_REMOTE_CODE=true` if they trust the remote dataset.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
