### PR TITLE
Add _reorder_cache back to Llama for HPU

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1381,6 +1381,17 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
         )
         return model_inputs
 
+    # Transformer4.43 use new Cache mechanism while Gaudi is not.
+    # Adding _reorder_cache back to support HPU.
+    @staticmethod
+    def _reorder_cache(past_key_values, beam_idx):
+        reordered_past = ()
+        for layer_past in past_key_values:
+            reordered_past += (
+                tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past),
+            )
+        return reordered_past
+
 
 def apply_customized_rope(q, k, cos, sin, position_ids):
     if q.device.type == "hpu" and has_fused_rope:


### PR DESCRIPTION
Transformer 4.43 has moved to use new Cache mechanism(https://github.com/huggingface/transformers/pull/31898) , and removed _reorder_cache from llama code while HPU is still using the previous mechanism.  Adding back _reorder_cache to the HPU llama code. 

Without this PR, below test case is failing. 

 RUN_SLOW=true  GAUDI2_CI=1 python -m pytest tests/transformers/tests/models/llama/test_modeling_llama.py -v -s -k test_beam_search_generate 