### PR TITLE
Fix overflow of steps in SDXL for default diffusers scheduler

### DIFF
--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -713,6 +713,10 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
                 add_time_ids_batch = add_time_ids_batches[0]
                 add_time_ids_batches = torch.roll(add_time_ids_batches, shifts=-1, dims=0)
 
+                if hasattr(self.scheduler, "_init_step_index"):
+                    # Reset scheduler step index for next batch
+                    self.scheduler._init_step_index(timesteps[0])
+
                 for i in range(num_inference_steps):
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -559,6 +559,10 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 add_time_ids_batch = add_time_ids_batches[0]
                 add_time_ids_batches = torch.roll(add_time_ids_batches, shifts=-1, dims=0)
 
+                if hasattr(self.scheduler, "_init_step_index"):
+                    # Reset scheduler step index for next batch
+                    self.scheduler._init_step_index(timesteps[0])
+
                 for i in range(len(timesteps)):
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -782,8 +782,8 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
                     image_latents_batch = image_latents_batches[0]
                     image_latents_batches = torch.roll(image_latents_batches, shifts=-1, dims=0)
 
-                # If use the diffuser's scheduler of non-Gaudi version, the timesteps need to reset every batch in order to avoid index overflow of timesteps.
-                if j > 0 and "Gaudi" not in self.scheduler.__class__.__name__:
+                if hasattr(self.scheduler, "_init_step_index"):
+                    # Reset scheduler step index for next batch
                     self.scheduler._init_step_index(timesteps[0])
 
                 for i, _ in enumerate(timesteps):


### PR DESCRIPTION
# SDXL scheduler fix

This PR fixes overflow of steps in SDXL for default diffusers scheduler for all SDXL pipelines.

In SDXL scheduler tracks steps index of timesteps.  Issue happens when we have multiple batches.  Then default scheduler from diffusers would cause error.  This fix calls init function at beginning of each batch processing thus fixing the issue.
