### PR TITLE
Fix PyTorch version in the Kubernetes docker-compose to match image

### DIFF
--- a/examples/kubernetes/docker-compose.yaml
+++ b/examples/kubernetes/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
         GAUDI_SW_VER: ${GAUDI_SW_VER:-1.17.0}
         OS: ${OS:-ubuntu22.04}
         OPTIMUM_HABANA_VER:  ${OPTIMUM_HABANA_VER:-1.12.1}
-        TORCH_VER: ${TORCH_VER:-2.2.2}
+        TORCH_VER: ${TORCH_VER:-2.3.1}
         REGISTRY: ${REGISTRY}
         REPO: ${REPO}
       context: .


### PR DESCRIPTION
# What does this PR do?

This is a small PR fixing the default PyTorch version to match the 1.17 image: 
```
docker pull vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest
```

Without this fix, trying to build the container with the default build args will give the following error:
```
 => ERROR [optimum-habana-examples internal] load metadata for vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest    
```

The documentation already has the correct `TORCH_VER`: https://github.com/huggingface/optimum-habana/blob/main/examples/kubernetes/README.md?plain=1#L48

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
