### PR TITLE
Fix FSDP graph error due to Tranformer 4.43 update

### DIFF
--- a/examples/language-modeling/fsdp_config.json
+++ b/examples/language-modeling/fsdp_config.json
@@ -9,5 +9,5 @@
     "fsdp_use_orig_params": true,
     "transformer_layer_cls_to_wrap": "GaudiLlamaDecoderLayer",
     "fsdp_activation_checkpointing": false,
-    "cpu_ram_efficient_loading": true
+    "fsdp_cpu_ram_efficient_loading": true
 }

--- a/examples/language-modeling/fsdp_config.json
+++ b/examples/language-modeling/fsdp_config.json
@@ -8,5 +8,6 @@
     "fsdp_sync_module_states": true,
     "fsdp_use_orig_params": true,
     "transformer_layer_cls_to_wrap": "GaudiLlamaDecoderLayer",
-    "fsdp_activation_checkpointing": false
+    "fsdp_activation_checkpointing": false,
+    "cpu_ram_efficient_loading": true
 }

--- a/examples/question-answering/fsdp_config.json
+++ b/examples/question-answering/fsdp_config.json
@@ -8,5 +8,6 @@
     "fsdp_sync_module_states": true,
     "fsdp_use_orig_params": true,
     "transformer_layer_cls_to_wrap": "BertLayer",
-    "fsdp_activation_checkpointing": false
+    "fsdp_activation_checkpointing": false,
+    "cpu_ram_efficient_loading": true
 }

--- a/examples/question-answering/fsdp_config.json
+++ b/examples/question-answering/fsdp_config.json
@@ -9,5 +9,5 @@
     "fsdp_use_orig_params": true,
     "transformer_layer_cls_to_wrap": "BertLayer",
     "fsdp_activation_checkpointing": false,
-    "cpu_ram_efficient_loading": true
+    "fsdp_cpu_ram_efficient_loading": true
 }

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -485,6 +485,12 @@ class GaudiAccelerator(Accelerator):
                             ),
                             auto_wrap_policy=fsdp_plugin.auto_wrap_policy,
                         )
+
+                """
+                TODO: Temporarily disable this upcast due to FSDP graph compile issue.
+                Investigate why the parameters are loaded as bf16(autocast?) and why
+                graph compile failure is seen due to upcast.
+
                 # In the event the model had been loaded in low precision, but
                 # mixed precision had also been activated, then we follow DeepSpeed's
                 # strategy to hold the parameters in full precision.
@@ -550,6 +556,8 @@ class GaudiAccelerator(Accelerator):
                             warnings.warn(
                                 "FSDP upcast of low precision parameters may affect the precision of model checkpoints."
                             )
+
+                """
 
                 # if the previous and current models are same, delete the previous one
                 if len(self._models) > 1 and (self._models[-2] is self._models[-1]):

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -490,6 +490,7 @@ class GaudiAccelerator(Accelerator):
                 TODO: Temporarily disable this upcast due to FSDP graph compile issue.
                 Investigate why the parameters are loaded as bf16(autocast?) and why
                 graph compile failure is seen due to upcast.
+                Original accelerate PR: https://github.com/huggingface/accelerate/pull/2674
 
                 # In the event the model had been loaded in low precision, but
                 # mixed precision had also been activated, then we follow DeepSpeed's

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -656,7 +656,6 @@ class GaudiTrainingArguments(TrainingArguments):
         # accelerate integration for FSDP
         if len(self.fsdp) > 0 and not self.fsdp_config["xla"]:
             os.environ["ACCELERATE_USE_FSDP"] = "true"
-            os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"] = "true"
             from accelerate.utils.constants import (
                 FSDP_AUTO_WRAP_POLICY,
                 FSDP_SHARDING_STRATEGY,


### PR DESCRIPTION
- Update CPU_RAM_EFFICIENT_LOADING to take it from config
- Disable FSDP flat_param upcast

# What does this PR do?
With transformer 4.43 update(Accelerator 0.33.0), FSDP functionality is broken. 
- Flag was not set correctly due to the argument update. This cause FSDP not fully enabled causing Llama70b test fail with Host OOM. 
- Upcast logic(https://github.com/huggingface/accelerate/pull/2674) has been added on the update, but this is causing FSDP graph compiler failure. 
