### PR TITLE
Set input_embeds before it gets used

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -597,6 +597,9 @@ class GaudiMixtralModel(MixtralModel):
                 else:
                     past_key_values_length = past_key_values[0][0].shape[2]
 
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
         if cache_position is None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             cache_position = torch.arange(
@@ -605,9 +608,6 @@ class GaudiMixtralModel(MixtralModel):
 
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
-
-        if inputs_embeds is None:
-            inputs_embeds = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation == "flash_attention_2":
             # 2d mask is passed through the layers


### PR DESCRIPTION
# What does this PR do?
Currently `inputs_embeds` variable is used even if its none in below condition

```
        if cache_position is None:
            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
            cache_position = torch.arange(
                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
            )
```
This is leading to error as below in some cases.

```
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/mixtral/modeling_mixtral.py", line 603, in forward
    past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
AttributeError: 'NoneType' object has no attribute 'shape'
```
Moved code up that checks and sets for `inputs_embeds`.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
