### PR TITLE
Fix BERT FSDP test

### DIFF
--- a/tests/test_fsdp_examples.py
+++ b/tests/test_fsdp_examples.py
@@ -84,6 +84,7 @@ def _test_fsdp(
     ]
 
     if model_name == "bert-base-uncased":
+        # Setting --save_strategy "no" to disable saving checkpoint during train which fails with error, checkpoint is saved by save_model()
         command += [
             "--dataset_name squad",
             "--max_seq_length 384",
@@ -91,6 +92,7 @@ def _test_fsdp(
             "--num_train_epochs 2.0",
             "--logging_steps 20",
             "--save_steps 5000",
+            "--save_strategy 'no'"
             "--seed 42",
             "--doc_stride 128",
             "--overwrite_output_dir",


### PR DESCRIPTION
# What does this PR do?

Fixes Test failure from transformers_4.43 update. :  `tests/test_fsdp_examples.py::test_fsdp_bf16[token0-bert-base-uncased-Habana/bert-base-uncased-3516.322-85.5503-question-answering-24-8-run_qa.py-full_shard]` 
Error:
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/optimum-habana/examples/question-answering/run_qa.py", line 733, in <module>
[rank0]:     main()
[rank0]:   File "/root/optimum-habana/examples/question-answering/run_qa.py", line 679, in main
[rank0]:     train_result = trainer.train(resume_from_checkpoint=checkpoint)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 553, in train
[rank0]:     return inner_training_loop(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 1052, in _inner_training_loop
[rank0]:     self._maybe_log_save_evaluate(tr_loss, _grad_norm, model, trial, epoch, ignore_keys_for_eval)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 1269, in _maybe_log_save_evaluate
[rank0]:     self._save_checkpoint(model, trial, metrics=metrics)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 1331, in _save_checkpoint
[rank0]:     self._save_optimizer_and_scheduler(output_dir)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/trainer.py", line 1409, in _save_optimizer_and_scheduler
[rank0]:     save_fsdp_model(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/accelerate/utils/fsdp_utils.py", line 63, in save_fsdp_model
[rank0]:     with FSDP.state_dict_type(
[rank0]:   File "/usr/lib/python3.10/contextlib.py", line 142, in _exit_
[rank0]:     next(self.gen)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 828, in state_dict_type
[rank0]:     FullyShardedDataParallel.set_state_dict_type(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 704, in set_state_dict_type
[rank0]:     state_dict_config_type = _state_dict_type_to_config[state_dict_type]
[rank0]: KeyError: None
```

After adding `save_strategy 'no'`, checkpoint is still saved:
```
Saving model checkpoint to /tmp/tmp5iiwudxf
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
Related issue filed on transformers repo: https://github.com/huggingface/transformers/issues/32639

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
