### PR TITLE
Ig/Diffusers timing

### DIFF
--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -516,7 +516,6 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
                 num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
 
                 for i in range(num_inference_steps):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()
                         t1 += t1_inf - t0_inf
@@ -608,8 +607,6 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
                             callback(step_idx, t, latents_batch)
 
                     hb_profiler.step()
-
-                    logger.info(f"i {i}elapsed {time.time()-ts}")
 
                 if use_warmup_inference_steps:
                     t1 = warmup_inference_steps_time_adjustment(

--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -31,7 +31,7 @@ from transformers import CLIPImageProcessor, CLIPTextModel, CLIPTokenizer, CLIPV
 from optimum.utils import logging
 
 from ....transformers.gaudi_configuration import GaudiConfig
-from ....utils import HabanaProfile, speed_metrics
+from ....utils import HabanaProfile, speed_metrics, warmup_inference_steps_time_adjustment
 from ..pipeline_utils import GaudiDiffusionPipeline
 from ..stable_diffusion.pipeline_stable_diffusion import (
     GaudiStableDiffusionPipeline,
@@ -497,11 +497,17 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
 
             # 8. Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
+            use_warmup_inference_steps = (
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+            )
+
             for j in self.progress_bar(range(num_batches)):
                 # The throughput is calculated from the 3rd iteration
                 # because compilation occurs in the first two iterations
                 if j == throughput_warmup_steps:
                     t1 = time.time()
+                if use_warmup_inference_steps:
+                    t0_inf = time.time()
 
                 latents_batch = latents_batches[0]
                 latents_batches = torch.roll(latents_batches, shifts=-1, dims=0)
@@ -510,6 +516,11 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
                 num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
 
                 for i in range(num_inference_steps):
+                    ts=time.time()
+                    if use_warmup_inference_steps and i == throughput_warmup_steps:
+                        t1_inf = time.time()
+                        t1 += t1_inf - t0_inf
+
                     t = timesteps[0]
                     timesteps = torch.roll(timesteps, shifts=-1, dims=0)
 
@@ -598,6 +609,13 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
 
                     hb_profiler.step()
 
+                    logger.info(f"i {i}elapsed {time.time()-ts}")
+
+                if use_warmup_inference_steps:
+                    t1 = warmup_inference_steps_time_adjustment(
+                        t1, t1_inf, num_inference_steps, throughput_warmup_steps
+                    )
+
                 if not output_type == "latent":
                     # 8. Post-processing
                     output_image = self.vae.decode(
@@ -617,9 +635,9 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
                 split=speed_metrics_prefix,
                 start_time=t0,
                 num_samples=num_batches * batch_size
-                if t1 == t0
+                if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -513,7 +513,6 @@ class GaudiStableDiffusionPipeline(GaudiDiffusionPipeline, StableDiffusionPipeli
                 text_embeddings_batches = torch.roll(text_embeddings_batches, shifts=-1, dims=0)
 
                 for i in range(len(timesteps)):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()
                         t1 += t1_inf - t0_inf
@@ -574,7 +573,6 @@ class GaudiStableDiffusionPipeline(GaudiDiffusionPipeline, StableDiffusionPipeli
                         callback(step_idx, timestep, latents_batch)
 
                     hb_profiler.step()
-                    logger.info(f"i {i}elapsed {time.time()-ts}")
 
                 if use_warmup_inference_steps:
                     t1 = warmup_inference_steps_time_adjustment(

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
@@ -313,7 +313,7 @@ class GaudiStableDiffusionImageVariationPipeline(GaudiDiffusionPipeline, StableD
             t1 = t0
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
             use_warmup_inference_steps = (
-                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
             )
             for j in self.progress_bar(range(num_batches)):
                 # The throughput is calculated from the 3rd iteration
@@ -376,7 +376,7 @@ class GaudiStableDiffusionImageVariationPipeline(GaudiDiffusionPipeline, StableD
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -553,7 +553,7 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
             num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
             use_warmup_inference_steps = (
-                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
             )
 
             self._num_timesteps = len(timesteps)
@@ -715,7 +715,7 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
@@ -414,7 +414,6 @@ class GaudiStableDiffusionInstructPix2PixPipeline(GaudiDiffusionPipeline, Stable
                 prompt_embeds_batches = torch.roll(prompt_embeds_batches, shifts=-1, dims=0)
 
                 for i in range(len(timesteps)):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()
                         t1 += t1_inf - t0_inf
@@ -474,8 +473,7 @@ class GaudiStableDiffusionInstructPix2PixPipeline(GaudiDiffusionPipeline, Stable
                         step_idx = i // getattr(self.scheduler, "order", 1)
                         callback(step_idx, t, latents_batch)
                     hb_profiler.step()
-                    logger.info(f"i {i} elapsed {time.time()-ts}")
-                
+
                 if use_warmup_inference_steps:
                     t1 = warmup_inference_steps_time_adjustment(
                         t1, t1_inf, num_inference_steps, throughput_warmup_steps
@@ -490,7 +488,6 @@ class GaudiStableDiffusionInstructPix2PixPipeline(GaudiDiffusionPipeline, Stable
                     self.htcore.mark_step()
 
             hb_profiler.stop()
-            logger.info(f"t1-t0 {t1-t0} num_samples {num_batches * batch_size if t1 == t0 or use_warmup_inference_steps else (num_batches - throughput_warmup_steps) * batch_size} ")
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_ldm3d.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_ldm3d.py
@@ -358,7 +358,6 @@ class GaudiStableDiffusionLDM3DPipeline(GaudiDiffusionPipeline, StableDiffusionL
                 text_embeddings_batches = torch.roll(text_embeddings_batches, shifts=-1, dims=0)
 
                 for i in range(len(timesteps)):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()
                         t1 += t1_inf - t0_inf
@@ -398,8 +397,6 @@ class GaudiStableDiffusionLDM3DPipeline(GaudiDiffusionPipeline, StableDiffusionL
                     if callback is not None and i % callback_steps == 0:
                         step_idx = i // getattr(self.scheduler, "order", 1)
                         callback(step_idx, timestep, latents_batch)
-
-                    logger.info(f"i {i}elapsed {time.time()-ts}")
 
                 if use_warmup_inference_steps:
                     t1 = warmup_inference_steps_time_adjustment(

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
@@ -438,7 +438,7 @@ class GaudiStableDiffusionUpscalePipeline(GaudiDiffusionPipeline, StableDiffusio
             # 10. Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
             use_warmup_inference_steps = (
-                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
             )
 
             for j in self.progress_bar(range(num_batches)):
@@ -541,7 +541,7 @@ class GaudiStableDiffusionUpscalePipeline(GaudiDiffusionPipeline, StableDiffusio
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -718,7 +718,6 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
                     self.scheduler._init_step_index(timesteps[0])
 
                 for i in range(num_inference_steps):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1_inf = time.time()
                         t1 += t1_inf - t0_inf
@@ -793,7 +792,6 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
                             callback(step_idx, timestep, latents)
 
                     hb_profiler.step()
-                    logger.info(f"i {i}elapsed {time.time()-ts}")
 
                 if use_warmup_inference_steps:
                     t1 = warmup_inference_steps_time_adjustment(

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -559,7 +559,6 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 add_time_ids_batch = add_time_ids_batches[0]
                 add_time_ids_batches = torch.roll(add_time_ids_batches, shifts=-1, dims=0)
 
-
                 if hasattr(self.scheduler, "_init_step_index"):
                     # Reset scheduler step index for next batch
                     self.scheduler._init_step_index(timesteps[0])

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -540,7 +540,7 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
             # 8.3 Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
             use_warmup_inference_steps = (
-                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
             )
             for j in self.progress_bar(range(num_batches)):
                 # The throughput is calculated from the 3rd iteration
@@ -558,6 +558,7 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 add_text_embeddings_batches = torch.roll(add_text_embeddings_batches, shifts=-1, dims=0)
                 add_time_ids_batch = add_time_ids_batches[0]
                 add_time_ids_batches = torch.roll(add_time_ids_batches, shifts=-1, dims=0)
+
 
                 if hasattr(self.scheduler, "_init_step_index"):
                     # Reset scheduler step index for next batch
@@ -672,7 +673,7 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -752,7 +752,7 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
             t1 = t0
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)
             use_warmup_inference_steps = (
-                num_batches < throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
+                num_batches <= throughput_warmup_steps and num_inference_steps > throughput_warmup_steps
             )
 
             for j in self.progress_bar(range(num_batches)):
@@ -920,7 +920,7 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,
-                num_steps=num_batches,
+                num_steps=num_batches * batch_size * num_inference_steps,
                 start_time_after_warmup=t1,
             )
             logger.info(f"Speed metrics: {speed_measures}")

--- a/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -493,7 +493,6 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                 added_time_ids_batches = torch.roll(added_time_ids_batches, shifts=-1, dims=0)
 
                 for i in self.progress_bar(range(num_inference_steps)):
-                    ts=time.time()
                     if use_warmup_inference_steps and i == throughput_warmup_steps:
                         t1 += time.time() - t0_inf
 
@@ -533,8 +532,6 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                         callback_outputs = callback_on_step_end(self, i, timestep, callback_kwargs)
 
                         latents_batch = callback_outputs.pop("latents", latents_batch)
-
-                    logger.info(f"i {i}elapsed {time.time()-ts}")
 
                 if not output_type == "latent":
                     # cast back to fp16/bf16 if needed

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -30,7 +30,9 @@ from typing import Callable, Union
 from unittest import TestCase, skipIf, skipUnless
 
 import diffusers
+import habana_frameworks.torch.hpu as hthpu
 import numpy as np
+import pytest
 import requests
 import safetensors
 import torch
@@ -798,6 +800,7 @@ class GaudiStableDiffusionPipelineTester(TestCase):
         self.assertLess(np.abs(expected_slice - upscaled_image[-3:, -3:, -1].flatten()).max(), 5e-3)
 
     @slow
+    @pytest.mark.skipif(hthpu.is_available() and hthpu.device_count() != 8, reason="system does not have 8 cards")
     def test_textual_inversion(self):
         path_to_script = (
             Path(os.path.dirname(__file__)).parent
@@ -2093,6 +2096,7 @@ class TrainControlNet(TestCase):
         self.assertEqual(return_code, 0)
 
     @slow
+    @pytest.mark.skipif(hthpu.is_available() and hthpu.device_count() != 8, reason="system does not have 8 cards")
     def test_train_controlnet(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path_to_script = (


### PR DESCRIPTION
# What does this PR do?
This PR addresses the followings:
- Fixes the controlnet pipeline to include `use_warmup_inference_steps`  adjustments 
- Fixed the `use_warmup_inference_steps` logic to include the warmup in all diffuser pipelines. 
  - issue: when `num_batches = throughput_warmup_steps` the `generation_samples_per_second` is almost 0.   
- Following the work @dsocek  and I did for SD3 ([here](https://github.com/huggingface/optimum-habana/blob/main/optimum/habana/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py#L468)), updated the `steps_per_second` for all pipelines to represent average time for 1 `inference step`
   - 1 average inference step is a good measure because it is independent of numbers of steps per sample which can vary (i.e. 20, 50, etc). 
   - @regisss  @ssarkar2 WDYT on this? Any thoughts what was the original thoughts/ideas behind using only `num_batches`, and not include batch size and number of images per prompt and number of prompts?
      - I have not found an equivalent of this metric on HF upstream code.  
- Added a skip in 8x MPI tests in `tests/test_diffusers.py` when 8 cards are not avail 
   - Added value here is ability to run this tests on KVM systems with only 1card available. 

## Example of issue with SDXL

```
python text_to_image_generation.py     --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0     --prompts "Sailing ship painting by Van Gogh"     --num_images_per_prompt 3     --batch_size 1     --image_save_dir /tmp/stable_diffusion_xl_images     --scheduler euler_discrete     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16
.
.
.
/usr/local/lib/python3.10/dist-packages/diffusers/models/unets/unet_2d_blocks.py:2628: FutureWarning: `scale` is deprecated and will be removed in version 1.0.0. The `scale` argument is deprecated and will be ignored. Please remove it, as passing it will raise an error in the future. `scale` should directly be passed while calling the underlying pipeline component i.e., via `cross_attention_kwargs`.
  deprecate("scale", "1.0.0", deprecation_message)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [02:33<00:00, 51.23s/it]
[INFO|pipeline_stable_diffusion_xl.py:829] 2024-08-27 16:57:50,077 >> Speed metrics: {'generation_runtime': 153.6776, 'generation_samples_per_second': 0.02, 'generation_steps_per_second': 0.02}
```

## Tests 
All the changed pipelines are tested for #prompts = #throughput_steps and the measured `samples_per_second` are compared with expected values. 

### stable diff 
```bash
python examples/stable-diffusion/text_to_image_generation.py     --model_name_or_path runwayml/stable-diffusion-v1-5     --prompts "An image of a squirrel in Picasso style"     --num_images_per_prompt 3     --batch_size 1     --image_save_dir /tmp/stable_diffusion_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16
```
```
[INFO|pipeline_stable_diffusion.py:608] 2024-08-16 20:45:32,560 >> Speed metrics: {'generation_runtime': 55.8091, 'generation_samples_per_second': 0.821, 'generation_steps_per_second': 41.071}
```
Expected=0.9. Matches measured. ✅ 


### sd-inpainting
```
python text_to_image_generation.py     --model_name_or_path  runwayml/stable-diffusion-inpainting     --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png     --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png     --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k"     --seed 0     --num_images_per_prompt 3     --batch_size 1     --image_save_dir /tmp/inpaiting_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16
```
```
[INFO|pipeline_stable_diffusion_inpaint.py:721] 2024-08-16 20:51:29,610 >> Speed metrics: {'inpainting_runtime': 49.0233, 'inpainting_samples_per_second': 0.827, 'inpainting_steps_per_second': 41.342}
```
Expected=0.9. Matches measured. ✅ 

### sdv2 
```
python text_to_image_generation.py     --model_name_or_path stabilityai/stable-diffusion-2-1     --prompts "An image of a squirrel in Picasso style"     --num_images_per_prompt 3     --batch_size 1     --height 768     --width 768     --image_save_dir /tmp/stable_diffusion_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion-2     --bf16
```
```
[INFO|pipeline_stable_diffusion.py:608] 2024-08-16 21:14:22,343 >> Speed metrics: {'generation_runtime': 88.7877, 'generation_samples_per_second': 0.352, 'generation_steps_per_second': 17.612}
```
Expected=0.36. Matches measured. ✅ 


### sdxl 
```
python text_to_image_generation.py     --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0     --prompts "Sailing ship painting by Van Gogh"     --num_images_per_prompt 3     --batch_size 1     --image_save_dir /tmp/stable_diffusion_xl_images     --scheduler euler_discrete     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16
```
```
[INFO|pipeline_stable_diffusion_xl.py:827] 2024-08-16 21:12:07,058 >> Speed metrics: {'generation_runtime': 163.4171, 'generation_samples_per_second': 0.199, 'generation_steps_per_second': 9.938}
```
Expected=0.2. Matches measured. ✅ 

### sdxl-inpaint 
```
python text_to_image_generation.py     --model_name_or_path  diffusers/stable-diffusion-xl-1.0-inpainting-0.1    --base_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png     --mask_image https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png     --prompts "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k"     --seed 0     --scheduler euler_discrete     --num_images_per_prompt 3     --batch_size 1     --image_save_dir /tmp/xl_inpaiting_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16
```
```
[INFO|pipeline_stable_diffusion_xl_inpaint.py:926] 2024-08-16 21:25:01,668 >> Speed metrics: {'inpainting_runtime': 108.7956, 'inpainting_samples_per_second': 0.203, 'inpainting_steps_per_second': 9.942}
```
Expected=0.2. Matches measured. ✅ 

### ldm3d 
```
python text_to_image_generation.py     --model_name_or_path "Intel/ldm3d-4c"     --prompts "An image of a squirrel in Picasso style"     --num_images_per_prompt 3     --batch_size 1     --height 768     --width 768     --image_save_dir /tmp/stable_diffusion_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion-2     --ldm3d     --bf16
```
```
[INFO|pipeline_stable_diffusion_ldm3d.py:426] 2024-08-16 22:23:58,857 >> Speed metrics: {'generation_runtime': 92.824, 'generation_samples_per_second': 0.269, 'generation_steps_per_second': 13.472}
```
Expected=0.2754. Matches measured. ✅ 

### svd 
```
PT_HPU_MAX_COMPOUND_OP_SIZE=1 python image_to_video_generation.py     --model_name_or_path "stabilityai/stable-video-diffusion-img2vid-xt"     --image_path "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png"     --num_videos_per_prompt 3     --video_save_dir /tmp/stable_video_diffusion_xt     --save_frames_as_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion     --bf16 
```
```
[INFO|pipeline_stable_video_diffusion.py:561] 2024-08-16 22:57:53,107 >> Speed metrics: {'generation_runtime': 491.712, 'generation_samples_per_second': 0.007, 'generation_steps_per_second': 0.174}
```
Expected=0.008. Matches measured. ✅ 

### controlnet 
```
python text_to_image_generation.py     --model_name_or_path stabilityai/stable-diffusion-2-1     --controlnet_model_name_or_path thibaud/controlnet-sd21-canny-diffusers     --control_image https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/sd_controlnet/bird_canny.png     --control_preprocessing_type "none"     --prompts "bird"     --seed 0     --num_images_per_prompt $numimg     --batch_size 1     --image_save_dir /tmp/controlnet-2-1_images     --use_habana     --use_hpu_graphs     --gaudi_config Habana/stable-diffusion-2     --bf16
````
Expected=0.04379.

`--num_images_per_prompt 2`
```
[INFO|pipeline_controlnet.py:643] 2024-08-16 22:45:04,991 >> Speed metrics: {'generation_runtime': 72.2782, 'generation_samples_per_second': 0.44, 'generation_steps_per_second': 21.982}
```
`--num_images_per_prompt 3`
```
[INFO|pipeline_controlnet.py:643] 2024-08-16 22:41:10,373 >> Speed metrics: {'generation_runtime': 85.7749, 'generation_samples_per_second': 0.439, 'generation_steps_per_second': 21.955}
```
`--num_images_per_prompt 4`
```
[INFO|pipeline_controlnet.py:643] 2024-08-16 22:43:18,312 >> Speed metrics: {'generation_runtime': 88.1551, 'generation_samples_per_second': 0.447, 'generation_steps_per_second': 89.366}
```
all measured checks ✅.

## CI tests 
The `GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/test_diffusers.py -s -v` produces the same results before/after this changes. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
