### PR TITLE
Fix BERT FSDP test

### DIFF
--- a/optimum/habana/accelerate/utils/__init__.py
+++ b/optimum/habana/accelerate/utils/__init__.py
@@ -5,6 +5,7 @@ from .dataclasses import (
     GaudiFullyShardedDataParallelPlugin,
     GaudiTorchDynamoPlugin,
 )
+from .other import extract_model_from_parallel
 from .transformer_engine import (
     FP8ContextWrapper,
     convert_model,

--- a/optimum/habana/accelerate/utils/other.py
+++ b/optimum/habana/accelerate/utils/other.py
@@ -9,6 +9,15 @@ from accelerate.utils.versions import is_torch_version
 
 
 def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive: bool = False):
+    """
+    Adapted from: https://github.com/huggingface/accelerate/blob/v0.33.0/src/accelerate/utils/other.py#L56
+
+    Changes:
+    - add a `distributed_model` variable to keep track of the distributed wrapper
+      and not lose it when setting it back at the end (for compiled models)
+
+    See https://github.com/huggingface/optimum-habana/pull/1281 for more information.
+    """
     options = (torch.nn.parallel.DistributedDataParallel, torch.nn.DataParallel)
 
     is_compiled = is_compiled_module(model)

--- a/optimum/habana/accelerate/utils/other.py
+++ b/optimum/habana/accelerate/utils/other.py
@@ -35,6 +35,8 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive
 
         options += (FSDP,)
 
+    # Keep track of the distributed wrapper
+    # TODO: to revisit as lines 44 to 71 are now useless
     distributed_model = model
     while isinstance(model, options):
         model = model.module

--- a/optimum/habana/accelerate/utils/other.py
+++ b/optimum/habana/accelerate/utils/other.py
@@ -1,0 +1,66 @@
+from types import MethodType
+
+import torch
+from accelerate.utils.constants import FSDP_PYTORCH_VERSION
+from accelerate.utils.imports import is_deepspeed_available, is_torch_distributed_available
+from accelerate.utils.other import is_compiled_module
+from accelerate.utils.transformer_engine import convert_model
+from accelerate.utils.versions import is_torch_version
+
+
+def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive: bool = False):
+    options = (torch.nn.parallel.DistributedDataParallel, torch.nn.DataParallel)
+
+    is_compiled = is_compiled_module(model)
+    if is_compiled:
+        compiled_model = model
+        model = model._orig_mod
+
+    if is_deepspeed_available():
+        from deepspeed import DeepSpeedEngine
+
+        options += (DeepSpeedEngine,)
+
+    if is_torch_version(">=", FSDP_PYTORCH_VERSION) and is_torch_distributed_available():
+        from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+
+        options += (FSDP,)
+
+    distributed_model = model
+    while isinstance(model, options):
+        model = model.module
+
+    if recursive:
+        # This is needed in cases such as using FSDPv2 on XLA
+        def _recursive_unwrap(module):
+            # Wrapped modules are standardly wrapped as `module`, similar to the cases earlier
+            # with DDP, DataParallel, DeepSpeed, and FSDP
+            if hasattr(module, "module"):
+                unwrapped_module = _recursive_unwrap(module.module)
+            else:
+                unwrapped_module = module
+            # Next unwrap child sublayers recursively
+            for name, child in unwrapped_module.named_children():
+                setattr(unwrapped_module, name, _recursive_unwrap(child))
+            return unwrapped_module
+
+        # Start with top-level
+        model = _recursive_unwrap(model)
+
+    if not keep_fp32_wrapper:
+        forward = model.forward
+        original_forward = model.__dict__.pop("_original_forward", None)
+        if original_forward is not None:
+            while hasattr(forward, "__wrapped__"):
+                forward = forward.__wrapped__
+                if forward == original_forward:
+                    break
+            model.forward = MethodType(forward, model)
+        if getattr(model, "_converted_to_transformer_engine", False):
+            convert_model(model, to_transformer_engine=False)
+
+    if is_compiled:
+        compiled_model._orig_mod = distributed_model
+        model = compiled_model
+
+    return model

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import accelerate
 import transformers
 import transformers.utils.fx
 
+from ..accelerate.utils import extract_model_from_parallel
 from .generation import (
     GaudiGenerationConfig,
     GaudiGenerationMixin,
@@ -201,6 +203,9 @@ def adapt_transformers_to_gaudi():
     Replaces some Transformers' methods for equivalent methods optimized
     for Gaudi.
     """
+    accelerate.utils.extract_model_from_parallel = extract_model_from_parallel
+    accelerate.utils.other.extract_model_from_parallel = extract_model_from_parallel
+    accelerate.accelerator.extract_model_from_parallel = extract_model_from_parallel
 
     # models that support symbolic tracing should be added to this list
     models_with_tracing_support = []


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes a bug where the FSDP wrapper of the model is lost at some point in Accelerate:
- Distributed wrappers (i.e. DDP, FSDP, DeepSpeed) are removed [here](https://github.com/huggingface/accelerate/blob/v0.33.0/src/accelerate/utils/other.py#L90),
- At some point after that operation is performed, the FSDP wrapper is lost, which makes the BERT FSDP test fail.

This PR fixes that issue by keeping a buffer variable to not lose track of the distributed model and making sure that it is set it back at the end.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
