### PR TITLE
Boost SDXL speed with initialized schedule step reset

### DIFF
--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -651,6 +651,8 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
             t1 = t0
 
             self._num_timesteps = len(timesteps)
+            if hasattr(self.scheduler, "set_begin_index"):
+                self.scheduler.set_begin_index()
 
             hb_profiler = HabanaProfile(
                 warmup=profiling_warmup_steps,
@@ -687,8 +689,6 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
                 timestep_cond = self.get_guidance_scale_embedding(
                     guidance_scale_tensor, embedding_dim=self.unet.config.time_cond_proj_dim
                 ).to(device=device, dtype=latents.dtype)
-
-            self._num_timesteps = len(timesteps)
 
             # 8.3 Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -536,6 +536,8 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 ).to(device=device, dtype=latents.dtype)
 
             self._num_timesteps = len(timesteps)
+            if hasattr(self.scheduler, "set_begin_index"):
+                self.scheduler.set_begin_index()
 
             # 8.3 Denoising loop
             throughput_warmup_steps = kwargs.get("throughput_warmup_steps", 3)

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -744,6 +744,8 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
                 ).to(device=device, dtype=latents.dtype)
 
             self._num_timesteps = len(timesteps)
+            if hasattr(self.scheduler, "set_begin_index"):
+                self.scheduler.set_begin_index()
 
             outputs = {
                 "images": [],


### PR DESCRIPTION
# Set SDXL scheduler starting timestep index

In current code, we are not setting the starting timestep for Euler type schedulers (e.g. `EulerDiscreteScheduler`, `GaudiEulerDiscreteScheduler`, etc).  Consequently, this value is `None` which causes slower timesteps reset process (e.g. in multiple batches scenarios for Euler schedulers).  When initial value is set to `0` then reset is performed as simple index switch (faster). (For example, this can be seen [here](https://github.com/huggingface/diffusers/blob/v0.30.0/src/diffusers/schedulers/scheduling_euler_discrete.py#L486-L491))

This PR fixes the aforementioned issue.  This gives notable speed boost in SDXL pipeline for both `default` and `euler_discrete` scheduler selections when processing multiple batches.

## Example

Ran the following command before and after the fix:
```bash
python text_to_image_generation.py \
    --model_name_or_path stabilityai/stable-diffusion-xl-base-1.0 \
    --prompts "Sailing ship painting by Van Gogh" \
    --num_images_per_prompt 16 \
    --batch_size 4 \
    --image_save_dir ./sdxl_images \
    --scheduler default \
    --use_habana \
    --gaudi_config Habana/stable-diffusion \
    --bf16
```

Output log **before** this PR's fix:
```bash
...
Speed metrics: {'generation_runtime': 269.7971, 'generation_samples_per_second': 0.233, 'generation_steps_per_second': 0.233}
```

Output log **after** this PR's fix:
```bash
Speed metrics: {'generation_runtime': 236.4827, 'generation_samples_per_second': 0.718, 'generation_steps_per_second': 0.718}
```

Performance is boosted from from **0.233 images/sec** to **0.718 images/sec** 

> Note: Rebased to latest main branch and ran `make style`
