### PR TITLE
Remove huggingface_hub install that is no longer needed in the kubernetes example

### DIFF
--- a/examples/kubernetes/requirements.txt
+++ b/examples/kubernetes/requirements.txt
@@ -1,3 +1,2 @@
-huggingface_hub==0.23.0
 -r optimum-habana/examples/language-modeling/requirements.txt
 -r optimum-habana/examples/text-classification/requirements.txt


### PR DESCRIPTION
# What does this PR do?

huggingface_hub was being specified in the requirements.txt because optimum habana v1.12.0 was using huggingface_hub < 0.23.0, and the Kubernetes workflow required huggingface_hub 0.23.0+ in order to use `HF_TOKEN_PATH`, as explained [here](https://github.com/huggingface/optimum-habana/pull/1099#discussion_r1678440748). Since 1.13.0 is using huggingface_hub >= 0.23.2, we can remove huggingface_hub from the requirements.txt.

I tested this change by rebuilding the container, and running the kubernetes example using a gated model to verify that the `HF_TOKEN_PATH` is working.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
