### PR TITLE
[SW-198030]: Prevent Graph break in Llama when using flash attention

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -617,7 +617,7 @@ class GaudiLlamaAttention(LlamaAttention):
         else:
             past_key_value = None
 
-        if use_flash_attention and FusedSDPA:
+        if use_flash_attention and FusedSDPA is not None:
             import habana_frameworks.torch.hpu as ht
 
             softmax_mode = "fast" if flash_attention_fast_softmax else "None"


### PR DESCRIPTION
# What does this PR do?
While using Flash Attention with Llama2 7B it was found that graph break is happening which causes poor perf.
The graph break happens due to 1) isinstance() and 2) applying a boolean condition with the class instance.

isinstance() is fixed by PR: #330.

This PR fixes applying the boolean condition.
Complete details can be found here: SW-192950

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
