### PR TITLE
fix OOM when inference with llama-3.1-70b

### DIFF
--- a/optimum/habana/transformers/modeling_attn_mask_utils.py
+++ b/optimum/habana/transformers/modeling_attn_mask_utils.py
@@ -92,6 +92,8 @@ class GaudiAttentionMaskConverter(AttentionMaskConverter):
                 sliding_window=self.sliding_window,
             )
 
+            # just create a bool tensor with shape [bsz, 1, tgt_seq_len, src_seq_len]
+            # OOM problem can be prevent by using bool tensor
             bsz, src_len = attention_mask_2d.size()
             tgt_len = input_shape[-1] if input_shape[-1] is not None else src_len
             bool_mask = (attention_mask_2d != 1.0)

--- a/optimum/habana/transformers/modeling_attn_mask_utils.py
+++ b/optimum/habana/transformers/modeling_attn_mask_utils.py
@@ -96,7 +96,7 @@ class GaudiAttentionMaskConverter(AttentionMaskConverter):
             # OOM problem can be prevent by using bool tensor
             bsz, src_len = attention_mask_2d.size()
             tgt_len = input_shape[-1] if input_shape[-1] is not None else src_len
-            bool_mask = (attention_mask_2d != 1.0)
+            bool_mask = attention_mask_2d != 1.0
             expanded_attn_mask = bool_mask[:, None, None, :].expand(bsz, 1, tgt_len, src_len).to(device=device)
 
             return causal_4d_mask.masked_fill(expanded_attn_mask, torch.finfo(dtype).min)

--- a/optimum/habana/transformers/modeling_attn_mask_utils.py
+++ b/optimum/habana/transformers/modeling_attn_mask_utils.py
@@ -99,7 +99,7 @@ class GaudiAttentionMaskConverter(AttentionMaskConverter):
             bool_mask = (attention_mask_2d != 1.0)
             expanded_attn_mask = bool_mask[:, None, None, :].expand(bsz, 1, tgt_len, src_len).to(device=device)
 
-            return result.masked_fill(expanded_attn_mask, torch.finfo(dtype).min)
+            return causal_4d_mask.masked_fill(expanded_attn_mask, torch.finfo(dtype).min)
         elif self.sliding_window is not None:
             raise NotImplementedError("Sliding window is currently only implemented for causal masking")
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

## background

when I running inference with command:
``` bash
INPUT=32768
OUTPUT=32768
BATCH_SIZE=12

python gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
    --model_name_or_path Meta-Llama-3.1-70B-Instruct/ \
    --max_input_tokens ${INPUT} \
    --max_new_tokens ${OUTPUT} \
    --bf16 \
    --use_hpu_graphs \
    --use_kv_cache \
    --batch_size ${BATCH_SIZE} \
    --attn_softmax_bf16 \
    --limit_hpu_graphs \
    --trim_logits \
    --flash_attention_causal_mask \
    --flash_attention_recompute \
    --warmup 1 \
    --n_iteration 1 \
    --bucket_internal \
    --bucket_size=512 \
    --use_flash_attention
```
it will OOM, while not OOM if `BATCH_SIZE=11`

after I debugged by using memory analysis tool, I found that the first time of creating causal attention mask tensor need too much device memory, that lead to device memory exhaustion.

## details of creating causal mask tensor
Converts 2D attention mask to 4D attention mask by expanding mask to (bsz, head_dim=1, query_length, key_value_length) shape and by adding a large negative bias to not-attended positions.

If attention_mask is causal, a causal mask will be added.

For the first time of creating this tensor, the shape is very big (for my case, it is [12, 1, 32768, 32768]).
During the creation of this tensor, it need a mask tensor. The mask tensor's dtype can be `torch.bool`, but actual it is `torch.int`, which caused four times the memory usage. (for shape [12, 1, 32768, 32768], it need 48G device memory, it will cause peak memory usage.)


## Fixes

This PR's change is aim to **explicitly** make the computation of causal attention mask tensor use less device memory by using the `torch.bool` type mask tensor.

For code changes, just overwrite the base class's `to_4d` function.

## Others
But why `BATCH_SIZE=11` did not cause device memory exhaustion?
I think its a bug of **LAZY GRAPH**.
In lazy graph, it should optimize the computation of the big tensor with using less device memory.
So the best solution of fixing this bug is doing more optimization in **LAZY GRAPH**.


<!-- Remove if not applicable -->




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
