### PR TITLE
fix(pr1284-ci): fixed the expected values after for img2img slice

### DIFF
--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -3330,7 +3330,7 @@ class GaudiStableDiffusionXLImg2ImgPipelineTests(TestCase):
 
         self.assertEqual(image.shape, (1, 32, 32, 3))
 
-        expected_slice = np.array([0.4664, 0.4886, 0.4403, 0.6902, 0.5592, 0.4534, 0.5931, 0.5951, 0.5224])
+        expected_slice = np.array([0.4925, 0.5007, 0.6594, 0.5544, 0.4423, 0.5585, 0.4643, 0.5444, 0.5376])
         self.assertLess(np.abs(image_slice.flatten() - expected_slice).max(), 1e-2)
 
 


### PR DESCRIPTION
# What does this PR do?
Opened this PR post #1284  since the `test_stable_diffusion_xl_img2img_euler` keeps crashing: https://github.com/huggingface/optimum-habana/actions/runs/10820064759/job/30019296923
> Note: the upstream code has a different expected values: https://github.com/huggingface/diffusers/blob/8336405e50e204fad3601e8350e04e6daa838eb4/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py#L219

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
