### PR TITLE
Fix the deepspeed init_inference reserves device memory as model size

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -410,6 +410,7 @@ def setup_distributed_model(args, model_dtype, model_kwargs, logger):
     ds_inference_kwargs["tensor_parallel"] = {"tp_size": args.world_size}
     ds_inference_kwargs["enable_cuda_graph"] = args.use_hpu_graphs
     ds_inference_kwargs["injection_policy"] = get_ds_injection_policy(config)
+    ds_inference_kwargs["keep_module_on_host"] = True
     if load_to_meta:
         ds_inference_kwargs["checkpoint"] = checkpoints_json.name
 


### PR DESCRIPTION
For text-generation, set 'keep_module_on_host' to True to save device memory.

For quantization run,  https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_FP8.html#enabling-and-running-inc-in-pytorch-models, says "If DeepSpeed is used, INC should be called after deepspeed.init_inference. "
But when deepspeed.init_inference() is called, it reserves the device memory as much as bf16 model size because it's initialized as bf16 model dtype first. This reserves extra device memory.

This change is fix for that.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
