### PR TITLE
Fixes the no attribute error with the falcon multicard test

### DIFF
--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -701,8 +701,16 @@ def main():
         tokenizer.pad_token_id = tokenizer.eos_token_id
 
     def tokenize(prompt, add_eos_token=True, add_bos_token=True):
-        add_eos_token_o = tokenizer.add_eos_token
-        add_bos_token_o = tokenizer.add_bos_token
+        if hasattr(tokenizer, "add_eos_token"):
+            add_eos_token_o = tokenizer.add_eos_token
+        else:
+            add_eos_token_o = None
+
+        if hasattr(tokenizer, "add_bos_token"):
+            add_bos_token_o = tokenizer.add_bos_token
+        else:
+            add_bos_token_o = None
+
         if not data_args.dataset_concatenation:
             tokenizer.add_eos_token = add_eos_token
             padding = "max_length"
@@ -717,8 +725,12 @@ def main():
             return_tensors=None,
         )
         # restore original value
-        tokenizer.add_eos_token = add_eos_token_o
-        tokenizer.add_bos_token = add_bos_token_o
+        if add_eos_token_o is not None:
+            tokenizer.add_eos_token = add_eos_token_o
+
+        if add_bos_token_o is not None:
+            tokenizer.add_bos_token = add_bos_token_o
+
         for i in range(len(results["input_ids"])):
             if (
                 results["input_ids"][i][-1] != tokenizer.eos_token_id


### PR DESCRIPTION
# What does this PR do?

Fixes the failing test : 
**tests.test_examples.MultiCardCausalLanguageModelingLORAExampleTester2 | test_run_lora_clm_falcon-40b_multi_card**


[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/optimum-habana/examples/language-modeling/run_lora_clm.py", line 930, in <module>
[rank0]:     main()
[rank0]:   File "/root/optimum-habana/examples/language-modeling/run_lora_clm.py", line 756, in main
[rank0]:     tokenized_datasets = raw_datasets.map(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/dataset_dict.py", line 866, in map
[rank0]:     {
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/dataset_dict.py", line 867, in <dictcomp>
[rank0]:     k: dataset.map(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/arrow_dataset.py", line 560, in wrapper
[rank0]:     out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/arrow_dataset.py", line 3035, in map
[rank0]:     for rank, done, content in Dataset._map_single(**dataset_kwargs):
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/arrow_dataset.py", line 3438, in _map_single
[rank0]:     batch = apply_function_on_filtered_inputs(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/datasets/arrow_dataset.py", line 3300, in apply_function_on_filtered_inputs
[rank0]:     processed_inputs = function(*fn_args, *additional_args, **fn_kwargs)
[rank0]:   File "/root/optimum-habana/examples/language-modeling/run_lora_clm.py", line 742, in preprocess_function
[rank0]:     examples_tokenized = tokenize(st, add_bos_token=add_bos_token)
[rank0]:   File "/root/optimum-habana/examples/language-modeling/run_lora_clm.py", line 704, in tokenize
[rank0]:     add_eos_token_o = tokenizer.add_eos_token
[rank0]: AttributeError: 'PreTrainedTokenizerFast' object has no attribute 'add_eos_token'. Did you mean: '_eos_token'?


**PASSING TEST RESULT** :  GAUDI2_CI=1  RUN_SLOW=1  python -m pytest tests/test_examples.py::MultiCardCausalLanguageModelingLORAExampleTester2::test_run_lora_clm_falcon-40b_multi_card -s -v

***** train metrics *****
  epoch                       =       2.9952
  max_memory_allocated (GB)   =        94.54
  memory_allocated (GB)       =        81.15
  total_flos                  = 1765923822GF
  total_memory_available (GB) =        94.62
  train_loss                  =       0.4221
  train_runtime               =   0:19:14.21
  train_samples_per_second    =       28.456
  train_steps_per_second      =        0.222
[INFO|trainer.py:811] 2024-09-19 16:20:42,967 >> The following columns in the evaluation set don't have a corresponding argument in `PeftModelForCausalLM.forward` and have been ignored: prompt_targets, prompt_sources. If prompt_targets, prompt_sources are not expected by `PeftModelForCausalLM.forward`,  you can safely ignore this message.
09/19/2024 16:20:42 - INFO - __main__ -   *** Evaluate ***
[INFO|trainer.py:1812] 2024-09-19 16:20:42,981 >> Using HPU graphs for inference.
[INFO|trainer.py:1830] 2024-09-19 16:20:42,981 >>
***** Running Evaluation *****
[INFO|trainer.py:1832] 2024-09-19 16:20:42,981 >>   Num examples = 3000
[INFO|trainer.py:1835] 2024-09-19 16:20:42,981 >>   Batch size = 1
100%|██████████| 375/375 [00:28<00:00, 13.07it/s]
***** eval metrics *****
  epoch                       =     2.9952
  eval_accuracy               =     0.9361
  eval_loss                   =     0.2844
  eval_runtime                = 0:00:33.55
  eval_samples                =       3000
  eval_samples_per_second     =    103.842
  eval_steps_per_second       =      12.98
  max_memory_allocated (GB)   =      94.54
  memory_allocated (GB)       =      81.24
  perplexity                  =      1.329
  total_memory_available (GB) =      94.62
PASSED



