### PR TITLE
run_generation example: fixed graph compilation statistics reporting

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -227,6 +227,11 @@ def setup_parser(parser):
         help="Skip HPU Graph usage for first token to save memory",
     )
     parser.add_argument(
+        "--show_graphs_count",
+        action="store_true",
+        help="Show statistics of HPU graph compilation.",
+    )
+    parser.add_argument(
         "--reuse_cache",
         action="store_true",
         help="Whether to reuse key/value cache for decoding. It should save memory.",
@@ -520,7 +525,8 @@ def main():
                 json.dump(results, f, ensure_ascii=False, indent=4)
 
         stats = f"Throughput (including tokenization) = {throughput} tokens/second"
-        stats = stats + f"\nNumber of HPU graphs                = {count_hpu_graphs()}"
+        if args.show_graphs_count:
+            stats = stats + f"\nNumber of HPU graphs                = {count_hpu_graphs()}"
         separator = "-" * len(stats)
         print()
         print("Stats:")

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -135,6 +135,10 @@ def setup_env(args):
     # TODO: SW-167588 - WA for memory issue in hqt prep_model
     os.environ.setdefault("EXPERIMENTAL_WEIGHT_SHARING", "FALSE")
 
+    if args.global_rank == 0 and not args.torch_compile and args.show_graphs_count:
+        os.environ.setdefault("GRAPH_VISUALIZATION", "true")
+        shutil.rmtree(".graph_dumps", ignore_errors=True)
+
     if args.world_size > 0:
         os.environ.setdefault("PT_HPU_LAZY_ACC_PAR_MODE", "0")
         os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")


### PR DESCRIPTION
After PR https://github.com/huggingface/optimum-habana/pull/1231 merge graph recompilation statistics reporting is broken. Added cmd option to turn this statistics back on (off by default)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
