### PR TITLE
Fix tuple object error

### DIFF
--- a/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/optimum/habana/transformers/models/starcoder2/modeling_starcoder2.py
@@ -276,18 +276,18 @@ class GaudiStarcoder2Attention(Starcoder2Attention):
             if reuse_cache:
                 key_states = self.k_cache(key_states, 2, token_idx)
                 value_states = self.v_cache(value_states, 2, token_idx)
-                past_key_value = (self.k_cache.get_shape(), self.v_cache.get_shape())
+                past_key_value = list((self.k_cache.get_shape(), self.v_cache.get_shape()))
             else:
                 if past_key_value is None:
                     past_key = torch.zeros(key_states.shape, dtype=self.k_proj.weight.dtype, device=key_states.device)
                     past_value = torch.zeros(
                         key_states.shape, dtype=self.k_proj.weight.dtype, device=key_states.device
                     )
-                    past_key_value = (past_key, past_value)
+                    past_key_value = list((past_key, past_value))
                 key_states = self.k_cache.update(past_key_value[0], key_states, 2, token_idx, self.inp_seq_len)
                 value_states = self.v_cache.update(past_key_value[1], value_states, 2, token_idx, self.inp_seq_len)
                 if token_idx is None:
-                    past_key_value = (key_states, value_states)
+                    past_key_value = tuple((key_states, value_states))
 
             if cache_idx is not None and q_len == 1:
                 key_states = key_states[:, :, :cache_idx, :]


### PR DESCRIPTION
# What does this PR do?

Summary- (you can reproduce it from here)

Issue is not seen on 1 HPU.
Issue is seen with OptimumHabana v1.13 + with 8 HPU
Issue not seen with OptimumHabana v1.12 with 8 HPU

Replicate:

Reserve Gaudi2 with driver 1.17-495
docker pull [vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:1.17.0-495](http://vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:1.17.0-495)
git clone [GitHub - huggingface/optimum-habana: Easy and lightning fast training of 🤗 Transformers on Habana Gaudi processor (HPU)](https://github.com/huggingface/optimum-habana.git)
git checkout v1.13.2

docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --rm --cap-add=sys_nice --net=host --ipc=host -v $PWD:/root -v $PWD/data:/data --workdir=/root/ [vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:1.17.0-495](http://vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:1.17.0-495)

export HTTPS_PROXY=http://proxy-dmz.intel.com:912/

cd optimum-habana
python -m pip install .

cd examples/text-generation/
python -m pip install -r ./requirements.txt
python -m pip install -r ./requirements_lm_eval.txt
python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.17.0Connect your Github account
pip install datasets==2.19.2
huggingface-cli login --token $HF_TOKEN

QUANT_CONFIG=./quantization_config/maxabs_measure.json python ../gaudi_spawn.py
--use_deepspeed --world_size 8 run_generation.py
--model_name_or_path bigcode/starcoder2-15b
--attn_softmax_bf16
--use_hpu_graphs
--trust_remote_code
--trim_logits
--use_kv_cache
--bucket_size 128
--bucket_internal
--use_flash_attention
--flash_attention_recompute
--max_new_tokens 128
--batch_size 1
--bf16

Error: [rank0]: TypeError: 'tuple' object does not support item assignment
