### PR TITLE
add README.md for Sentence transformer examples with HPU device

### DIFF
--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -1,0 +1,23 @@
+# Examples for Sentence Transformer
+
+We provide 3 examples to show how to use the sentence transformer with HPU devices. 
+
+- **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a SentenceTransformer model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
+
+- **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example gives two sentences (premise and hypothesis) and the task of Natural Language Inference (NLI) is to decide if the premise entails the hypothesis, if they are contradiction, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
+
+- **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from the sentence transformers. We construct batches by sampling examples from the respective dataset. 
+
+### Tested Examples/Models and Configurations
+
+The following table contains examples supported and configurations we have validated on Gaudi2. 
+
+| Examples                    |  General  | Mistral 7B | BF16 | Single Card | Multi-Cards |
+|-----------------------------|-----------|------------|------|-------------|-------------|
+| training_nli.py             |     ✔     |      ✔    |   ✔  |     ✔       |     ✔      |
+| training_stsbenchmark.py    |     ✔     |      ✔    |   ✔  |     ✔       |     ✔      |
+| training_paraphrases.py     |     ✔     |           |       |     ✔       |            |
+
+Notice: 
+1. in the table the column 'General' means the general models like small models
+2. when Mistral 7b Model is enabled for the test single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -6,7 +6,7 @@ We provide 3 examples to show how to use the Sentence Transformers with HPU devi
 
 - **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example provides two sentences (a premise and a hypothesis), and the task of Natural Language Inference (NLI) is to determine whether the premise entails the hypothesis, contradicts it, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
 
-- **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from the sentence transformers. We construct batches by sampling examples from the respective dataset. 
+- **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from the Sentence Transformers. We construct batches by sampling examples from the respective dataset. 
 
 ### Tested Examples/Models and Configurations
 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -1,16 +1,16 @@
 # Examples for Sentence Transformers
 
-We provide 3 examples to show how to use the Sentence Transformers with HPU devices. 
+We provide 3 examples to show how to use Sentence Transformers with HPU devices.
 
 - **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a Sentence Transformers model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
 
 - **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example provides two sentences (a premise and a hypothesis), and the task of Natural Language Inference (NLI) is to determine whether the premise entails the hypothesis, contradicts it, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
 
-- **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from the Sentence Transformers. We construct batches by sampling examples from the respective dataset. 
+- **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from Sentence Transformers. We construct batches by sampling examples from the respective dataset.
 
 ### Tested Examples/Models and Configurations
 
-The following table contains examples supported and configurations we have validated on Gaudi2. 
+The following table contains examples supported and configurations we have validated on Gaudi2.
 
 | Examples                    |  General  | e5-mistral-7b-instruct | BF16 | Single Card | Multi-Cards |
 |-----------------------------|-----------|------------|------|-------------|-------------|
@@ -18,7 +18,7 @@ The following table contains examples supported and configurations we have valid
 | training_stsbenchmark.py    |     ✔     |      ✔    |   ✔  |     ✔       |     ✔      |
 | training_paraphrases.py     |     ✔     |           |       |     ✔       |            |
 
-Notice: 
+Notice:
 1. In the table, the column 'General' refers to general models like mpnet, MiniLM.
-2. When e5-mistral-7b-instruct model is enabled for the test, single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
-3. For the detailed instructions on how to run each example, you can refer to the README file located in each example folder. 
+2. When e5-mistral-7b-instruct model is enabled for the test, single card will use LoRA + gradient checkpointing and multi-card will use DeepSpeed ZeRO-2/ZeRO-3 to reduce the memory requirement.
+3. For the detailed instructions on how to run each example, you can refer to the README file located in each example folder.

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -21,4 +21,4 @@ The following table contains examples supported and configurations we have valid
 Notice: 
 1. in the table the column 'General' means the general models like small models
 2. When e5-mistral-7b-instruct model is enabled for the test, single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
-3. About the detailed command on how to run each example you can read each readme under each example folder. 
+3. For the detailed instructions on how to run each example, you can refer to the README file located in each example folder. 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -1,4 +1,4 @@
-# Examples for Sentence Transformer
+# Examples for Sentence Transformers
 
 We provide 3 examples to show how to use the Sentence Transformers with HPU devices. 
 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -20,5 +20,5 @@ The following table contains examples supported and configurations we have valid
 
 Notice: 
 1. in the table the column 'General' means the general models like small models
-2. when Mistral 7b Model is enabled for the test single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
+2. When e5-mistral-7b-instruct model is enabled for the test, single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
 3. About the detailed command on how to run each example you can read each readme under each example folder. 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -12,7 +12,7 @@ We provide 3 examples to show how to use the Sentence Transformers with HPU devi
 
 The following table contains examples supported and configurations we have validated on Gaudi2. 
 
-| Examples                    |  General  | Mistral 7B | BF16 | Single Card | Multi-Cards |
+| Examples                    |  General  | e5-mistral-7b-instruct | BF16 | Single Card | Multi-Cards |
 |-----------------------------|-----------|------------|------|-------------|-------------|
 | training_nli.py             |     ✔     |      ✔    |   ✔  |     ✔       |     ✔      |
 | training_stsbenchmark.py    |     ✔     |      ✔    |   ✔  |     ✔       |     ✔      |

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -19,6 +19,6 @@ The following table contains examples supported and configurations we have valid
 | training_paraphrases.py     |     ✔     |           |       |     ✔       |            |
 
 Notice: 
-1. in the table the column 'General' means the general models like small models
+1. In the table, the column 'General' refers to general models like mpnet, MiniLM.
 2. When e5-mistral-7b-instruct model is enabled for the test, single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
 3. For the detailed instructions on how to run each example, you can refer to the README file located in each example folder. 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -2,7 +2,7 @@
 
 We provide 3 examples to show how to use the Sentence Transformers with HPU devices. 
 
-- **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a SentenceTransformer model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
+- **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a Sentence Transformers model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
 
 - **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example provides two sentences (a premise and a hypothesis), and the task of Natural Language Inference (NLI) is to determine whether the premise entails the hypothesis, contradicts it, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -1,6 +1,6 @@
 # Examples for Sentence Transformer
 
-We provide 3 examples to show how to use the sentence transformer with HPU devices. 
+We provide 3 examples to show how to use the Sentence Transformers with HPU devices. 
 
 - **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a SentenceTransformer model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -21,3 +21,4 @@ The following table contains examples supported and configurations we have valid
 Notice: 
 1. in the table the column 'General' means the general models like small models
 2. when Mistral 7b Model is enabled for the test single card will use the LoRA + gradient_checkpoint and multi-card will use the deepspeed zero2/zero3 stage to reduce the memory requirement. 
+3. About the detailed command on how to run each example you can read each readme under each example folder. 

--- a/examples/sentence-transformers-training/README.md
+++ b/examples/sentence-transformers-training/README.md
@@ -4,7 +4,7 @@ We provide 3 examples to show how to use the sentence transformer with HPU devic
 
 - **[training_stsbenchmark.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/sts)** - This example shows how to create a SentenceTransformer model from scratch by using a pre-trained transformer model (e.g. [`distilbert-base-uncased`](https://huggingface.co/distilbert/distilbert-base-uncased)) together with a pooling layer.
 
-- **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example gives two sentences (premise and hypothesis) and the task of Natural Language Inference (NLI) is to decide if the premise entails the hypothesis, if they are contradiction, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
+- **[training_nli.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/nli)** - This example provides two sentences (a premise and a hypothesis), and the task of Natural Language Inference (NLI) is to determine whether the premise entails the hypothesis, contradicts it, or if they are neutral. Commonly the NLI dataset in [SNLI](https://huggingface.co/datasets/stanfordnlp/snli) and [MultiNLI](https://huggingface.co/datasets/nyu-mll/multi_nli) are used.
 
 - **[training_paraphrases.py](https://github.com/huggingface/optimum-habana/tree/main/examples/sentence-transformers-training/paraphrases)** - This example loads various datasets from the sentence transformers. We construct batches by sampling examples from the respective dataset. 
 


### PR DESCRIPTION
# What does this PR do?

This PR will add one README.md for all sentence transformer HPU examples although they have each readme on how to run for each example. This README will give the whole pictures on all examples for sentence transformer with HPU device and their supported features/test configurations as below like :

![image](https://github.com/user-attachments/assets/084d02f7-7660-4958-b338-54fdfc4009b6)

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
