### PR TITLE
Update bloom attention forward reshape follwing the transformer change

### DIFF
--- a/optimum/habana/transformers/models/bloom/modeling_bloom.py
+++ b/optimum/habana/transformers/models/bloom/modeling_bloom.py
@@ -137,11 +137,9 @@ def gaudi_bloom_attention_forward(
     # 3 x [batch_size, num_heads, seq_length, head_dim]
     query_layer, key_layer, value_layer = self._reshape(fused_qkv)
 
-    batch_size, q_length, _, _ = query_layer.shape
-
-    query_layer = query_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim)
-    key_layer = key_layer.permute(0, 2, 3, 1).reshape(batch_size * self.num_heads, self.head_dim, q_length)
-    value_layer = value_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim)
+    query_layer = query_layer.reshape(batch_size * self.num_heads, -1, self.head_dim)
+    key_layer = key_layer.reshape(batch_size * self.num_heads, -1, self.head_dim).transpose(1, 2)
+    value_layer = value_layer.reshape(batch_size * self.num_heads, -1, self.head_dim)
 
     # Collapse views to improve performance on HPU
     query_layer = query_layer.contiguous()


### PR DESCRIPTION
# What does this PR do?
https://github.com/huggingface/transformers/blob/main/src/transformers/models/bloom/modeling_bloom.py#L262 _reshape() function covers OH transpose change. No need to transpose in OH.

The current code is failed at text-getneration CI.

CI run command: python3 /root/optimum-habana/examples/text-generation/run_generation.py --model_name_or_path bigscience/bloomz-7b1 --batch_size 1 --use_kv_cache --max_new_tokens 100 --use_hpu_graphs --bf16

Error message:
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/bloom/modeling_bloom.py", line 142, in gaudi_bloom_attention_forward
    query_layer = query_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim)
RuntimeError: shape '[32, 32, 128]' is invalid for input of size 438272

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
