### PR TITLE
Add  bias to gptj 

### DIFF
--- a/optimum/habana/transformers/models/gptj/modeling_gptj.py
+++ b/optimum/habana/transformers/models/gptj/modeling_gptj.py
@@ -73,6 +73,14 @@ class GaudiGPTJAttention(GPTJAttention):
         super().__init__(config)
         self.config = config
 
+        max_positions = config.max_position_embeddings
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)).view(
+                1, 1, max_positions, max_positions
+            ),
+            persistent=False,
+        )
         self.matmul_qk = Matmul()
         self.matmul_av = Matmul()
         self.k_cache = KVCache()


### PR DESCRIPTION
# What does this PR do?
    Transformer4.45 has the Dynamic cache updates(https://github.com/huggingface/transformers/pull/31421) removing
self.bias causing the failure. Until we investigate further  and update the code based on the new transformer, we are putting bias back to GaudiGPTJAttention.init()


<!-- Remove if not applicable -->

Fixes # (issue)

`GAUDI2_CI=1  RUN_SLOW=1 python3.10 -m pytest tests/test_text_generation_example.py -k token0-EleutherAI/gpt-j-6b-1
`
```
File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/gptj/modeling_gptj.py", line 124, in _attn
causal_mask = self.bias[:, :, key_length - query_length : key_length, :key_length]
AttributeError: 'GaudiGPTJAttention' object has no attribute 'bias'
```

