### PR TITLE
Only pass the use_kv_cache True to generator

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -211,13 +211,15 @@ def main():
     )
     generate_kwargs = {
         "lazy_mode": True,
-        "use_cache": args.use_kv_cache,
         "hpu_graphs": args.use_hpu_graphs,
         "max_new_tokens": args.max_new_tokens,
         "ignore_eos": args.ignore_eos,
         "use_flash_attention": args.use_flash_attention,
         "flash_attention_recompute": args.flash_attention_recompute,
     }
+    if args.use_kv_cache:
+        generate_kwargs["use_cache"] = args.use_kv_cache
+
     if args.use_hpu_graphs:
         from habana_frameworks.torch.hpu import wrap_in_hpu_graph
 

--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -146,6 +146,11 @@ def main():
         action="store_true",
         help="Whether to use the key/value cache for decoding. It should speed up generation.",
     )
+    parser.add_argument(
+        "--chat_template",
+        action="store_true",
+        help="Whether to use Llava/Llava Next processors and apply chat template. It might lower performance.",
+    )
 
     args = parser.parse_args()
 
@@ -161,21 +166,30 @@ def main():
         args.image_path = [
             "https://github.com/haotian-liu/LLaVA/blob/1a91fc274d7c35a9b50b3cb29c4247ae5837ce39/images/llava_v1_5_radar.jpg?raw=true"
         ]
-    if args.prompt is None and model_type in ("llava", "llava_next"):
-        if model_type == "llava":
-            processor = LlavaProcessor.from_pretrained(args.model_name_or_path)
-        elif model_type == "llava_next":
-            processor = LlavaNextProcessor.from_pretrained(args.model_name_or_path)
-        conversation = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "What is shown in this image?"},
-                    {"type": "image"},
-                ],
-            }
-        ]
-        args.prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+    # Made optional due to lower performance
+    if args.chat_template:
+        if args.prompt is None and model_type in ("llava", "llava_next"):
+            if model_type == "llava":
+                processor = LlavaProcessor.from_pretrained(args.model_name_or_path)
+            elif model_type == "llava_next":
+                processor = LlavaNextProcessor.from_pretrained(args.model_name_or_path)
+            conversation = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is shown in this image?"},
+                        {"type": "image"},
+                    ],
+                }
+            ]
+            args.prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+    else:
+        if args.prompt is None and model_type == "llava":
+            args.prompt = "<image>\nUSER: What's the content of the image?\nASSISTANT:"
+        elif args.prompt is None and model_type == "llava_next":
+            args.prompt = "[INST] <image>\nWhat is shown in this image? [/INST]"
+            if args.model_name_or_path in ["llava-hf/llava-v1.6-vicuna-13b-hf", "llava-hf/llava-v1.6-vicuna-7b-hf"]:
+                args.prompt = "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions. USER: <image>\nWhat is shown in this image? ASSISTANT:"
 
     image_paths = args.image_path
     image_paths_len = len(image_paths)

--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -146,11 +146,6 @@ def main():
         action="store_true",
         help="Whether to use the key/value cache for decoding. It should speed up generation.",
     )
-    parser.add_argument(
-        "--chat_template",
-        action="store_true",
-        help="Whether to use Llava/Llava Next processors and apply chat template. It might lower performance.",
-    )
 
     args = parser.parse_args()
 
@@ -166,30 +161,21 @@ def main():
         args.image_path = [
             "https://github.com/haotian-liu/LLaVA/blob/1a91fc274d7c35a9b50b3cb29c4247ae5837ce39/images/llava_v1_5_radar.jpg?raw=true"
         ]
-    # Made optional due to lower performance
-    if args.chat_template:
-        if args.prompt is None and model_type in ("llava", "llava_next"):
-            if model_type == "llava":
-                processor = LlavaProcessor.from_pretrained(args.model_name_or_path)
-            elif model_type == "llava_next":
-                processor = LlavaNextProcessor.from_pretrained(args.model_name_or_path)
-            conversation = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "What is shown in this image?"},
-                        {"type": "image"},
-                    ],
-                }
-            ]
-            args.prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
-    else:
-        if args.prompt is None and model_type == "llava":
-            args.prompt = "<image>\nUSER: What's the content of the image?\nASSISTANT:"
-        elif args.prompt is None and model_type == "llava_next":
-            args.prompt = "[INST] <image>\nWhat is shown in this image? [/INST]"
-            if args.model_name_or_path in ["llava-hf/llava-v1.6-vicuna-13b-hf", "llava-hf/llava-v1.6-vicuna-7b-hf"]:
-                args.prompt = "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions. USER: <image>\nWhat is shown in this image? ASSISTANT:"
+    if args.prompt is None and model_type in ("llava", "llava_next"):
+        if model_type == "llava":
+            processor = LlavaProcessor.from_pretrained(args.model_name_or_path)
+        elif model_type == "llava_next":
+            processor = LlavaNextProcessor.from_pretrained(args.model_name_or_path)
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is shown in this image?"},
+                    {"type": "image"},
+                ],
+            }
+        ]
+        args.prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
 
     image_paths = args.image_path
     image_paths_len = len(image_paths)

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -57,7 +57,6 @@ def _test_image_to_text(
         f"--model_name_or_path {model_name}",
         f"--batch_size {batch_size}",
         "--max_new_tokens 20",
-        "--use_kv_cache",
     ]
 
     command += [

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -14,15 +14,15 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "bf16": [
-            ("llava-hf/llava-1.5-7b-hf", 1, 77.9331887247788),
-            ("llava-hf/llava-1.5-13b-hf", 1, 47.98471187876668),
+            ("llava-hf/llava-1.5-7b-hf", 1, 77.98733740859008),
+            ("llava-hf/llava-1.5-13b-hf", 1, 48.54364937033955),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 33.17984878151546),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 35.00608681379742),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 23.527610042925),
         ],
         "fp8": [
-            ("llava-hf/llava-1.5-7b-hf", 1, 96.25635876671548),
-            ("llava-hf/llava-1.5-13b-hf", 1, 66.68347979470798),
+            ("llava-hf/llava-1.5-7b-hf", 1, 98.72578382705062),
+            ("llava-hf/llava-1.5-13b-hf", 1, 67.20488222876344),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 45.011551008367084),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 45.18544502949674),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 30.9535718774675),

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -56,7 +56,8 @@ def _test_image_to_text(
         f"{path_to_example_dir / 'image-to-text' / 'run_pipeline.py'}",
         f"--model_name_or_path {model_name}",
         f"--batch_size {batch_size}",
-        "--max_new_tokens 20",
+        "--max_new_tokens 20", 
+        "--use_kv_cache"
     ]
 
     command += [

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -14,15 +14,15 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "bf16": [
-            ("llava-hf/llava-1.5-7b-hf", 1, 87.2901500056982),
-            ("llava-hf/llava-1.5-13b-hf", 1, 51.04717105443364),
+            ("llava-hf/llava-1.5-7b-hf", 1, 77.9331887247788),
+            ("llava-hf/llava-1.5-13b-hf", 1, 47.98471187876668),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 33.17984878151546),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 35.00608681379742),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 23.527610042925),
         ],
         "fp8": [
-            ("llava-hf/llava-1.5-7b-hf", 1, 115.48515989461843),
-            ("llava-hf/llava-1.5-13b-hf", 1, 78.2635142547838),
+            ("llava-hf/llava-1.5-7b-hf", 1, 96.25635876671548),
+            ("llava-hf/llava-1.5-13b-hf", 1, 66.68347979470798),
             ("llava-hf/llava-v1.6-mistral-7b-hf", 1, 45.011551008367084),
             ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, 45.18544502949674),
             ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, 30.9535718774675),

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -56,8 +56,8 @@ def _test_image_to_text(
         f"{path_to_example_dir / 'image-to-text' / 'run_pipeline.py'}",
         f"--model_name_or_path {model_name}",
         f"--batch_size {batch_size}",
-        "--max_new_tokens 20", 
-        "--use_kv_cache"
+        "--max_new_tokens 20",
+        "--use_kv_cache",
     ]
 
     command += [


### PR DESCRIPTION
In case of not using use_kv_cache, the False value causes performance issue

# What does this PR do?

This PR addresses a performance issue caused by setting the `use_cache` argument to `False` by default for all model classes when not passing `--use_kv_cache`. 

The `use_cache` parameter should only be set to `True` when explicitly requested, as its default setting to `False` leads to performance degradation. This PR restores the original behavior, making PR #1343 unnecessary. 

Without the fix

```sh
>>> python3 run_pipeline.py  --model_name_or_path llava-hf/llava-1.5-7b-hf  --use_hpu_graphs --bf16

09/26/2024 20:56:05 - INFO - __main__ - time = 1933.194888199796ms, Throughput (including tokenization) = 20.691136855450857 tokens/second
```

With this fix

```sh
>>> python3 run_pipeline.py  --model_name_or_path llava-hf/llava-1.5-7b-hf  --use_hpu_graphs --bf16

09/26/2024 20:54:54 - INFO - __main__ - time = 942.6103481997416ms, Throughput (including tokenization) = 103.9666073973904 tokens/second
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
