### PR TITLE
Fix reshape error in mamba

### DIFF
--- a/optimum/habana/transformers/models/mamba/modeling_mamba.py
+++ b/optimum/habana/transformers/models/mamba/modeling_mamba.py
@@ -75,6 +75,8 @@ def gaudi_MambaForCausalLM_prepare_inputs_for_generation(
         else:
             idx = token_idx + kwargs.get("inputs_embeds_offset", 0) - 1
             input_ids = torch.index_select(input_ids, 1, idx)
+            if attention_mask is not None:
+                attention_mask = None
     else:
         if token_idx is not None:
             input_ids = torch.index_select(input_ids, 1, torch.arange(token_idx_cpu, device=input_ids.device))


### PR DESCRIPTION
# What does this PR do?

attention_mask not set to none in the default case ie use_cache and token_idx not none

<!-- Remove if not applicable -->

# Fixes # (issue)

Runtime error seen on Transformer 4.45 future branch. 
GAUDI2_CI=1  RUN_SLOW=1 python3.10 -m pytest tests/test_text_generation_example.py  -s -v -k "mamba"
 6626 RuntimeError: Reshape doesnt support change in number of elements: [1536, 1536, 110] Size of output: [2359296]

