### PR TITLE
fix bug when running image-to-text example

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -957,7 +957,7 @@ class GaudiGenerationMixin(GenerationMixin):
                             model_kwargs[other_inputs] = torch.nn.functional.pad(
                                 model_kwargs[other_inputs],
                                 (0, generation_config.max_new_tokens),
-                                value=generation_config.pad_token_id,
+                                value=0,
                             )
             else:
                 assert generation_config.bucket_size <= 0, "Untested path for bucket>0"


### PR DESCRIPTION
change back value to 0 when do the padding. Before the fix, when we run `python3 run_pipeline.py  --model_name_or_path llava-hf/llava-1.5-7b-hf --use_hpu_graphs  --bf16 --use_kv_cache`, it will return wrong output:
`result = [[{'generated_text': 'USER:  \nWhat is shown in this image? ASSISTANT: The\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\nЪ\n'}]
]`, this PR fix it.