### PR TITLE
CI fix - Install stable-diffusion reqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ fast_tests:
 # Run unit and integration tests related to Diffusers
 fast_tests_diffusers:
 	python -m pip install .[tests]
+	python -m pip install -r examples/stable-diffusion/requirements.txt
 	python -m pytest tests/test_diffusers.py
 
 # Run single-card non-regression tests on image classification models
@@ -94,6 +95,7 @@ slow_tests_deepspeed: test_installs
 	python -m pytest tests/test_examples.py -v -s -k "deepspeed"
 
 slow_tests_diffusers: test_installs
+	python -m pip install -r examples/stable-diffusion/requirements.txt
 	python -m pytest tests/test_diffusers.py -v -s -k "test_no_"
 	python -m pytest tests/test_diffusers.py -v -s -k "test_textual_inversion"
 	python -m pip install peft==0.7.0

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -3415,7 +3415,6 @@ class GaudiDeterministicImageGenerationTester(TestCase):
         path_to_script = (
             Path(os.path.dirname(__file__)).parent / "examples" / "stable-diffusion" / "text_to_image_generation.py"
         )
-        install_requirements(path_to_script.parent / "requirements.txt")
 
         with tempfile.TemporaryDirectory():
             test_args = f"""


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

- Top level installation i.e examples/stable-diffusion/requirements.txt done for all diffuser tests from Makefile
- test_diffusers.py now only has specific sub level requirements.txt installation

### Regressions
```
export GAUDI2_CI=1
make fast_tests_diffusers
== 111 passed, 47 skipped, 367 warnings in 1433.14s (0:23:53) ==
```
Fixes # (issue)

Fixing CI so pre-requisites are installed 

| Test | Test name | Error |
|----|-----|----|
|tests.test_diffusers.GaudiStableDiffusionXLPipelineTester | test_stable_diffusion_xl_inference_script | 1977     from compel import Compel, ReturnedEmbeddingsType 1978 ModuleNotFoundError: No module named 'compel' |


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
