### PR TITLE
fix error - LlamaConfig object has no attribute flash_attention_fp8

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -445,7 +445,7 @@ class GaudiLlamaAttention(LlamaAttention):
                 scale=self.norm_factor,
                 attention_dropout=self.attention_dropout,
                 enable_recompute=False,
-                flash_attention_fp8=config.flash_attention_fp8,
+                flash_attention_fp8=config.flash_attention_fp8 if hasattr(config, "flash_attention_fp8") else False
             )
             if FusedSDPA
             else None


### PR DESCRIPTION
fix error 

[rank1]: Traceback (most recent call last):
[rank1]:   File "/root/optimum-habana/examples/language-modeling/run_clm.py", line 695, in <module>
[rank1]:     main()
[rank1]:   File "/root/optimum-habana/examples/language-modeling/run_clm.py", line 457, in main
[rank1]:     model = AutoModelForCausalLM.from_pretrained(
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/auto_factory.py", line 564, in from_pretrained
[rank1]:     return model_class.from_pretrained(
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py", line 3886, in from_pretrained
[rank1]:     model = cls(config, *model_args, **model_kwargs)
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/llama/modeling_llama.py", line 1279, in __init__
[rank1]:     super().__init__(config)
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/transformers/models/llama/modeling_llama.py", line 1110, in __init__
[rank1]:     self.model = LlamaModel(config)
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/llama/modeling_llama.py", line 1029, in __init__
[rank1]:     layer = GaudiLlamaDecoderLayer(config, layer_idx)
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/llama/modeling_llama.py", line 856, in __init__
[rank1]:     self.self_attn = GaudiLlamaAttention(config=config, layer_idx=layer_idx)
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/llama/modeling_llama.py", line 448, in __init__
[rank1]:     flash_attention_fp8=config.flash_attention_fp8,
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 202, in __getattribute__
[rank1]:     return super().__getattribute__(key)
[rank1]: AttributeError: 'LlamaConfig' object has no attribute 'flash_attention_fp8'