### PR TITLE
Fix error caused by uninitialized attn_weights (#1391)

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -391,7 +391,7 @@ class GaudiMixtralAttention(MixtralAttention):
 
         attn_output = self.o_proj(attn_output)
 
-        if not output_attentions:
+        if not output_attentions or FusedSDPA:
             attn_weights = None
 
         return attn_output, attn_weights, past_key_value


### PR DESCRIPTION
fix following error from CI run

tests.transformers.tests.models.mixtral.test_modeling_mixtral.MixtralModelTest

UnboundLocalError: local variable 'attn_weights' referenced before assignment