### PR TITLE
replace flash attention flag

### DIFF
--- a/optimum/habana/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/optimum/habana/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -204,7 +204,7 @@ def gaudi_gpt_neo_model_forward(
     hidden_states = inputs_embeds + position_embeds
 
     # Attention mask.
-    if self._use_flash_attention_2:
+    if self.config._attn_implementation == "flash_attention_2":
         # 2d mask is passed through the layers
         attention_mask = attention_mask if (attention_mask is not None and 0 in attention_mask) else None
     else:


### PR DESCRIPTION
replace flash attention flag in gpt neo since variable no longer defined in the latest transformers. Fixes the following CI test

test_text_generation_bf16_1x[token0-EleutherAI/gpt-neo-2.7B-1-False-257.2476416844122]


