### PR TITLE
Fix DeepSpeed CI on Gaudi2

### DIFF
--- a/.github/workflows/slow_tests_gaudi2.yml
+++ b/.github/workflows/slow_tests_gaudi2.yml
@@ -9,37 +9,9 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  stable-diffusion:
-    name: Test Stable Diffusion
-    runs-on: [self-hosted, linux, x64, gaudi2]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Pull image
-        run: |
-            docker pull vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest
-      - name: Run tests
-        run: |
-            docker run \
-            --rm \
-            -v $PWD:/root/workspace \
-            -v /scratch-1:/data \
-            --workdir=/root/workspace \
-            --runtime=habana \
-            -e HABANA_VISIBLE_DEVICES=all \
-            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
-            -e GAUDI2_CI=1 \
-            -e HF_HOME=/data \
-            --cap-add=sys_nice \
-            --net=host \
-            --ipc=host \
-            vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest \
-            /bin/bash tests/ci/slow_tests_diffusers.sh
   deepspeed:
     name: Test DeepSpeed models
     if: ${{ !cancelled() && (success() || failure()) }}
-    needs:
-      - stable-diffusion  # run the job when the previous test job is done
     runs-on: [self-hosted, linux, x64, gaudi2]
     steps:
       - name: Checkout

--- a/.github/workflows/slow_tests_gaudi2.yml
+++ b/.github/workflows/slow_tests_gaudi2.yml
@@ -3,7 +3,7 @@ name: (Gaudi2) Non-regression tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * 3,6'  # every Wednesday and Saturday at 1am CET (midnight winter time)
+    - cron: '0 23 * * *'  # every Wednesday and Saturday at 1am CET (midnight winter time)
 
 concurrency:
   group: ${{ github.workflow }}
@@ -63,7 +63,7 @@ jobs:
             --net=host \
             --ipc=host \
             vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest \
-            pip install huggingface_hub && huggingface-cli login --token ${{ secrets.TEXT_GENERATION_CI_HUB_TOKEN }} && /bin/bash tests/ci/slow_tests_deepspeed.sh
+            /bin/bash tests/ci/slow_tests_deepspeed.sh ${{ secrets.TEXT_GENERATION_CI_HUB_TOKEN }}
   fsdp:
     name: Test FSDP models
     if: ${{ !cancelled() && (success() || failure()) }}

--- a/.github/workflows/slow_tests_gaudi2.yml
+++ b/.github/workflows/slow_tests_gaudi2.yml
@@ -9,9 +9,37 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
+  stable-diffusion:
+    name: Test Stable Diffusion
+    runs-on: [self-hosted, linux, x64, gaudi2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Pull image
+        run: |
+            docker pull vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest
+      - name: Run tests
+        run: |
+            docker run \
+            --rm \
+            -v $PWD:/root/workspace \
+            -v /scratch-1:/data \
+            --workdir=/root/workspace \
+            --runtime=habana \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+            -e GAUDI2_CI=1 \
+            -e HF_HOME=/data \
+            --cap-add=sys_nice \
+            --net=host \
+            --ipc=host \
+            vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest \
+            /bin/bash tests/ci/slow_tests_diffusers.sh
   deepspeed:
     name: Test DeepSpeed models
     if: ${{ !cancelled() && (success() || failure()) }}
+    needs:
+      - stable-diffusion  # run the job when the previous test job is done
     runs-on: [self-hosted, linux, x64, gaudi2]
     steps:
       - name: Checkout

--- a/tests/baselines/CodeLlama_13b_Instruct_hf.json
+++ b/tests/baselines/CodeLlama_13b_Instruct_hf.json
@@ -7,8 +7,8 @@
                 "deepspeed": {
                     "learning_rate": 5e-5,
                     "train_batch_size": 48,
-                    "train_runtime": 438.536,
-                    "train_samples_per_second": 18.663,
+                    "train_runtime": 479.6139,
+                    "train_samples_per_second": 18.803,
                     "perplexity": 6.87936780659991,
                     "extra_arguments": [
                         "--dataset_config_name wikitext-2-raw-v1",

--- a/tests/baselines/LlamaGuard_7b.json
+++ b/tests/baselines/LlamaGuard_7b.json
@@ -8,7 +8,7 @@
                     "learning_rate": 3e-5,
                     "train_batch_size": 32,
                     "eval_f1": 0.8873483535528596,
-                    "train_runtime": 55.8644,
+                    "train_runtime": 62.4539,
                     "train_samples_per_second": 342.169,
                     "extra_arguments": [
                         "--max_seq_length 128",

--- a/tests/baselines/gpt_neox_20b.json
+++ b/tests/baselines/gpt_neox_20b.json
@@ -8,8 +8,8 @@
                     "learning_rate": 5e-5,
                     "train_batch_size": 2,
                     "perplexity": 8.166753,
-                    "train_runtime": 721.5428,
-                    "train_samples_per_second": 7.571,
+                    "train_runtime": 664.6985,
+                    "train_samples_per_second": 8.705,
                     "extra_arguments": [
                         "--dataset_config_name wikitext-2-raw-v1",
                         "--gradient_checkpointing",

--- a/tests/ci/slow_tests_deepspeed.sh
+++ b/tests/ci/slow_tests_deepspeed.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip huggingface_hub
 export RUN_SLOW=true
+huggingface-cli login --token $1
 make slow_tests_deepspeed


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

DeepSpeed CI slow tests are currently broken on Gaudi2 because some models are gated and a HF token is required.

The current solution
```bash
docker run ... pip install huggingface_hub && huggingface-cli login --token ${{ secrets.TEXT_GENERATION_CI_HUB_TOKEN }} && /bin/bash tests/ci/slow_tests_deepspeed.sh
```
doesn't work as only `pip install huggingface_hub` is executed inside the Docker container and `huggingface-cli login --token ${{ secrets.TEXT_GENERATION_CI_HUB_TOKEN }} && /bin/bash tests/ci/slow_tests_deepspeed.sh` are executed outside of the container.
This PR fixes that by moving all this logic to `tests/ci/slow_tests_deepspeed.sh`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
