### PR TITLE
fix(pr-1387/1386): reverting some of transformer pytest funcs/values

### DIFF
--- a/tests/transformers/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/transformers/tests/models/falcon/test_modeling_falcon.py
@@ -554,8 +554,9 @@ class FalconLanguageGenerationTest(unittest.TestCase):
         model.eval()
         model.to(torch_device)
         inputs = tokenizer("My favorite food is", return_tensors="pt").to(torch_device)
+
         EXPECTED_OUTPUT = (
-            "My favorite food is pizza. I love it so much that I have a pizza party every year for my birthday."
+            "My favorite food is pizza. I love it so much that I have a pizza party every week. I love it"
         )
         output_ids = model.generate(**inputs, do_sample=False, max_new_tokens=19)
         output_str = tokenizer.batch_decode(output_ids)[0]

--- a/tests/transformers/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/transformers/tests/models/gpt2/test_modeling_gpt2.py
@@ -750,9 +750,9 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         )
         output_seq_strs = tokenizer.batch_decode(output_seq, skip_special_tokens=True)
         output_seq_tt_strs = tokenizer.batch_decode(output_seq_tt, skip_special_tokens=True)
-        EXPECTED_OUTPUT_STR = (
-            "Today is a nice day and if you don't know anything about the state of play during your holiday"
-        )
+
+        EXPECTED_OUTPUT_STR = "Today is a nice day and I really want to take you here and show you how easy it's"
+
         self.assertEqual(output_str, EXPECTED_OUTPUT_STR)
         self.assertTrue(
             all(output_seq_strs[idx] != output_seq_tt_strs[idx] for idx in range(len(output_seq_tt_strs)))

--- a/tests/transformers/tests/models/llama/test_modeling_llama.py
+++ b/tests/transformers/tests/models/llama/test_modeling_llama.py
@@ -297,7 +297,7 @@ class LlamaModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
     )
     test_headmasking = False
     test_pruning = False
-    fx_compatible = True
+    # fx_compatible = True
 
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`
     # This is because we are hitting edge cases with the causal_mask buffer

--- a/tests/transformers/tests/models/llama/test_modeling_llama.py
+++ b/tests/transformers/tests/models/llama/test_modeling_llama.py
@@ -546,7 +546,7 @@ class LlamaModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
                 raise ValueError("The eager model should not have SDPA attention layers")
         has_sdpa = False
         for name, submodule in model_sdpa.named_modules():
-            if "SdpaAttention" in submodule.__class__.__name__:
+            if any(_i in submodule.__class__.__name__ for _i in ["ModuleFusedSDPA", "SdpaAttention"]):
                 has_sdpa = True
                 break
         if not has_sdpa:

--- a/tests/transformers/tests/models/vit/test_modeling_vit.py
+++ b/tests/transformers/tests/models/vit/test_modeling_vit.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Testing suite for the PyTorch ViT model."""
 
+import inspect
 import unittest
 
 from transformers import ViTConfig
@@ -225,6 +226,18 @@ class ViTModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
+
+    def test_forward_signature(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            signature = inspect.signature(model.forward)
+            # signature.parameters is an OrderedDict => so arg_names order is deterministic
+            arg_names = [*signature.parameters.keys()]
+
+            expected_arg_names = ["pixel_values"]
+            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1140,7 +1140,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_prob = 0.5
         mask_length = 1
         mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-        mask = torch.from_numpy(mask).to(torch_device)
+        # mask = torch.from_numpy(mask).to(torch_device)
         self.assertListEqual(mask.sum(axis=-1).tolist(), [mask_prob * sequence_length for _ in range(batch_size)])
 
     def test_compute_mask_indices_low_prob(self):
@@ -1156,7 +1156,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         count_dimensions_not_masked = 0
         for _ in range(n_trials):
             mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-            mask = torch.from_numpy(mask).to(torch_device)
+            # mask = torch.from_numpy(mask).to(torch_device)
             num_masks = torch.sum(mask).item()
             if num_masks > 0:
                 count_dimensions_masked += 1
@@ -1174,7 +1174,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_prob = 0.5
         mask_length = 4
         mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-        mask = torch.from_numpy(mask).to(torch_device)
+        # mask = torch.from_numpy(mask).to(torch_device)
         # because of overlap mask don't have to add up exactly to `mask_prob * sequence_length`, but have to be smaller or equal
         for batch_sum in mask.sum(axis=-1):
             self.assertTrue(int(batch_sum) <= mask_prob * sequence_length)
@@ -1189,7 +1189,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask = _compute_mask_indices(
             (batch_size, sequence_length), mask_prob, mask_length, attention_mask=attention_mask
         )
-        mask = torch.from_numpy(mask).to(torch_device)
+        # mask = torch.from_numpy(mask).to(torch_device)
         for batch_sum in mask.sum(axis=-1):
             self.assertTrue(int(batch_sum) <= mask_prob * sequence_length)
         self.assertTrue(mask[:2, sequence_length // 2 :].sum() == 0)


### PR DESCRIPTION
# What does this PR do?
Some of the changes introduced in #1387 and #1386 are leading to pytest failures. 
This PR reverts them back. 

Added failures:
```
FAILED tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx - AssertionError: Couldn't trace module: Model GaudiLlamaModel is not support...
FAILED tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx_output_loss - AssertionError: Couldn't trace module: Model GaudiLlamaModel is not support
FAILED tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx - AssertionError: Couldn't trace module: Model GaudiLlamaModel is not support...
FAILED tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx_output_loss - AssertionError: Couldn't trace module: Model GaudiLlamaModel is not support
FAILED tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices - TypeError: expected np.ndarray (got Tensor)
FAILED tests/transformers/tests/models/vit/test_modeling_vit.py::ViTModelTest::test_forward_signature - AssertionError: Lists differ: ['pixel_values'] != ['input_ids']
FAILED tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_attn_mask_overlap - TypeError: expected np.ndarray (got Tensor)
FAILED tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_low_prob - TypeError: expected np.ndarray (got Tensor)
FAILED tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_overlap - TypeError: expected np.ndarray (got Tensor)
```
Results with this PR
```
RUN_SLOW=true python -m pytest --disable-warnings tests/transformers/tests/models/falcon/                                                                                  -s -v  -k test_lm_generate_falcon
================================================================ test session starts =================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /devops/sgohari/tests/codes/ig/optimum-habana
configfile: setup.cfg
collected 89 items / 87 deselected / 2 selected

tests/transformers/tests/models/falcon/test_modeling_falcon.py::FalconLanguageGenerationTest::test_lm_generate_falcon Instantiating FalconAttention without passing a `layer_idx` is not recommended and will lead to errors during the forward call if caching is used. Please make sure to provide a `layer_idx` when creating this class.
============================= HABANA PT BRIDGE CONFIGURATION ===========================
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH =
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG =
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
---------------------------: System Configuration :---------------------------
Num CPU Cores : 16
CPU RAM       : 113419500 KB
------------------------------------------------------------------------------
Setting `pad_token_id` to `eos_token_id`:None for open-end generation.
PASSED
tests/transformers/tests/models/falcon/test_modeling_falcon.py::FalconLanguageGenerationTest::test_lm_generate_falcon_11b SKIPPED (test
requires bitsandbytes and torch)

====================================================================================== 1 passed, 1 skipped, 87 deselected, 5 warnings in 12.50s ============
```
```
 RUN_SLOW=true python -m pytest --disable-warnings tests/transformers/tests/models/llama/ -s -v -k test_torch
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /devops/sgohari/tests/codes/ig/optimum-habana
configfile: setup.cfg
collected 94 items / 89 deselected / 5 selected

tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx ============================= HABANA PT BRIDGE CONFIGURATION ===========================
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH =
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG =
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
---------------------------: System Configuration :---------------------------
Num CPU Cores : 16
CPU RAM       : 113419500 KB
------------------------------------------------------------------------------
PASSED
tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torch_fx_output_loss PASSED
tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torchscript_output_attentions SKIPPED (Segmentation fault is observed)
tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torchscript_output_hidden_state SKIPPED (Segmentation fault is observed)
tests/transformers/tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_torchscript_simple SKIPPED (Segmentation fault is observed)

======================================================================================= 2 passed, 3 skipped, 89 deselected, 6 warnings in 7.63s =================
```
```
RUN_SLOW=true python -m pytest --disable-warnings tests/transformers/tests/models/vit/ -s -v -k test_forward_signature
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /devops/sgohari/tests/codes/ig/optimum-habana
configfile: setup.cfg
collected 57 items / 56 deselected / 1 selected

tests/transformers/tests/models/vit/test_modeling_vit.py::ViTModelTest::test_forward_signature ============================= HABANA PT BRIDGE CONFIGURATION ===========================
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH =
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG =
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
---------------------------: System Configuration :---------------------------
Num CPU Cores : 16
CPU RAM       : 113419500 KB
------------------------------------------------------------------------------
PASSED

============================================================================================ 1 passed, 56 deselected, 5 warnings in 8.11s ====================================
```
```
# RUN_SLOW=true python -m pytest --disable-warnings tests/transformers/tests/models/wav2vec2/ -s -v -k test_compute_mask_indices
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /devops/sgohari/tests/codes/ig/optimum-habana
configfile: setup.cfg
collected 160 items / 155 deselected / 5 selected

tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices ============================= HABANA PT BRIDGE CONFIGURATION ===========================
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH =
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG =
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
---------------------------: System Configuration :---------------------------
Num CPU Cores : 16
CPU RAM       : 113419500 KB
------------------------------------------------------------------------------
PASSED
tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_attn_mask_overlap PASSED
tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_low_prob PASSED
tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_overlap PASSED
tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py::Wav2Vec2UtilsTest::test_compute_mask_indices_short_audio FAILED
```
```
RUN_SLOW=true python -m pytest --disable-warnings tests/transformers/tests/models/gpt2/test_modeling_gpt2.py::GPT2ModelLanguageGenerationTest::test_gpt2_sample
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0
rootdir: /devops/sgohari/tests/codes/ig/optimum-habana
configfile: setup.cfg
collected 1 item

tests/transformers/tests/models/gpt2/test_modeling_gpt2.py .                                                                                                                                                                    [100%]

=================================================================================================== 1 passed, 7 warnings in 17.29s ========
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
