### PR TITLE
Change the image path for transformers tests back to the corrrect loc…

### DIFF
--- a/tests/transformers/tests/models/swin/test_modeling_swin.py
+++ b/tests/transformers/tests/models/swin/test_modeling_swin.py
@@ -512,7 +512,7 @@ class SwinModelIntegrationTest(unittest.TestCase):
         model = SwinModel.from_pretrained("microsoft/swin-tiny-patch4-window7-224").to(torch_device)
 
         image_processor = self.default_image_processor
-        image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
+        image = Image.open("./tests/resource/img/000000039769.png")
         inputs = image_processor(images=image, size={"height": 481, "width": 481}, return_tensors="pt")
         pixel_values = inputs.pixel_values.to(torch_device)
 

--- a/tests/transformers/tests/models/vit/test_modeling_vit.py
+++ b/tests/transformers/tests/models/vit/test_modeling_vit.py
@@ -247,7 +247,7 @@ class ViTModelTest(ModelTesterMixin, unittest.TestCase):
 
 # We will verify our results on an image of cute cats
 def prepare_img():
-    image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
+    image = Image.open("./tests/resource/img/000000039769.png")
     return image
 
 


### PR DESCRIPTION
…ation.


Additional transformers pytests were added for SWIN and VIT models by the following PRs.

https://github.com/huggingface/optimum-habana/pull/1381/files
https://github.com/huggingface/optimum-habana/pull/1387/files

They reference the old image path for ./tests/fixtures/tests_samples/COCO/000000039769.png, which is the correct location in upstream transformers, but has been moved to ./tests/resource/img/000000039769.png in optimum-habana.