### PR TITLE
fix llama model text generation error

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1168,8 +1168,10 @@ class GaudiGenerationMixin(GenerationMixin):
         # If the model supports `num_logits_to_keep` in forward(), set it to 1 to avoid computing the whole
         # logit matrix. This can save a lot of memory during the first forward pass. Note that assisted decoding
         # dynamically overrides this value as it can need more than the last token logits
-        if self._supports_num_logits_to_keep() and "num_logits_to_keep" not in model_kwargs:
-            model_kwargs["num_logits_to_keep"] = 1
+        #
+        # Use trim_logits in HPU to save memory (in replacement of the num_logits_to_keep)
+        # if self._supports_num_logits_to_keep() and "num_logits_to_keep" not in model_kwargs:
+        #    model_kwargs["num_logits_to_keep"] = 1
 
         self._validate_generated_length(
             generation_config,


### PR DESCRIPTION
# What does this PR do?
PR #1359 introduced error in some models text generation:
’meta-llama/Llama-2-7b-hf‘
‘mistralai/Mistral-7B-Instruct-v0.2'
’Qwen/Qwen2-7B‘
’bigcode/starcoder2-15b‘

Reproduce command:
`
python examples/text-generation/run_generation.py --use_hpu_graphs --model_name_or_path meta-llama/Llama-2-7b-hf
`

Input/outputs:
input 1: ('DeepSpeed is a machine learning framework',)
output 1: ('DeepSpeed is a machine learning frameworkЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉ\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n.............................\n\n............\n......',)
 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

Only use slicing operation on hidden_states for logits computing in case of kv_cache and reuse_cache is enabled.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
