### PR TITLE
change the order for test_diffusers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,12 @@ slow_tests_deepspeed: test_installs
 
 slow_tests_diffusers: test_installs
 	python -m pip install -r examples/stable-diffusion/requirements.txt
-	python -m pytest tests/test_diffusers.py -v -s -k "test_no_"
 	python -m pytest tests/test_diffusers.py -v -s -k "test_textual_inversion"
 	python -m pip install peft==0.7.0
 	python -m pytest tests/test_diffusers.py -v -s -k "test_train_text_to_image_"
 	python -m pytest tests/test_diffusers.py -v -s -k "test_train_controlnet"
 	python -m pytest tests/test_diffusers.py -v -s -k "test_deterministic_image_generation"
+	python -m pytest tests/test_diffusers.py -v -s -k "test_no_"
 
 # Run text-generation non-regression tests
 slow_tests_text_generation_example: test_installs


### PR DESCRIPTION
current order of execution of test_diffusers is running into a problem where 1x tests are done initially and doesnt seem to release the cards for subsequent 8x tests. hence changing the order