### PR TITLE
Fixed '--no-ignore_eos' not working correctly

### DIFF
--- a/optimum/habana/transformers/generation/stopping_criteria.py
+++ b/optimum/habana/transformers/generation/stopping_criteria.py
@@ -75,7 +75,7 @@ def gaudi_EosTokenCriteria_call(
     if kwargs["needs_tensor_output"]:
         return is_done.byte()
     else:
-        return torch.all(is_done).item()
+        return is_done # torch.all(is_done).item()
 
 
 def needs_tensor_output(token_idx, ignore_eos, eos_token_id) -> bool:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
Command used for testing:
```bash
python3 run_generation.py  -model_name_or_path /workspace/ckpt/huggingface/hub/models--mistralai--Mixtral-8x7B-Instruct-v0.1/snapshots/41bd4c9e7e4fb318ca40e721131d4933966c2cc1 --use_kv_cache --reuse_cache --trim_logits  --attn_softmax_bf16 --max_input_tokens 60 --max_new_tokens 500 --bf16 --batch_size 2 --warmup 0 --n_iterations 1  --no-ignore_eos --prompt "Hello world" "How are you?"
```
Added the following code after the L480 of 'run_generation.py' file to observe the output of the model.
```
import numpy as np
for idx, output in enumerate(outputs[:2], start=1):
    arr = np.array(output)
    with open(f"samp;e-{idx}.txt", "w") as file:
        file.writelines(f" {it} \n" for it in arr)
```

**Expected behavior:** with '--no-ignore_eos', if a sample generates an eos token, the subsequently generated tokens will be overwritten by the pad token until all samples in the current batch have generated eos or meet other termination conditions.

**Actual behavior:** Taking batch_size=2 as an example, sample0 and sample1 have generated eos tokens respectively (note that not at the same time), the model will not stop generating, and subsequent tokens will not be overwritten by pad tokens. Instead, it will not stop until all samples generate eos tokens at the same time or trigger other stop criteria. This will cause some unreasonable sentences to appear at the end of the output.

**Code Details**
As shown [here](https://github.com/huggingface/optimum-habana/blob/a8b9400c5be7acfbc791e1295fe19caba299f174/optimum/habana/transformers/generation/utils.py#L2450),  `unfinished_sequences `maintains information about whether each sample has finished generating. If the sample with `idx==x` has not finished generating, then `unfinished_sequences[x]` will be True.  If it has finished, the subsequently generated token will be overwritten by the pad token. This is fine.

However, since eos-related stop criteria only return a single bool value[see [here](https://github.com/huggingface/optimum-habana/blob/a8b9400c5be7acfbc791e1295fe19caba299f174/optimum/habana/transformers/generation/stopping_criteria.py#L78)] , the `unfinished_sequence `cannot be updated correctly[[update code](https://github.com/huggingface/optimum-habana/blob/a8b9400c5be7acfbc791e1295fe19caba299f174/optimum/habana/transformers/generation/utils.py#L2492-L2499)]. 

I changed the return value to tensor and the final output was as expected.

**Question**
There are comments in code([comment1](https://github.com/huggingface/optimum-habana/blob/10dabfa80875743d61858b28598217a5f3c9c9f4/optimum/habana/transformers/generation/stopping_criteria.py#L27-L29), [comment2](https://github.com/huggingface/optimum-habana/blob/10dabfa80875743d61858b28598217a5f3c9c9f4/optimum/habana/transformers/generation/stopping_criteria.py#L97)) indicate that a boolean value is returned in the case of static shape. But why is it necessary to return a single value under static shape?

In addition, can we change the default value of ignore_eos to false? Set it to true only when we need to test performance? In actual use, it is more intuitive to stop after generating eos, and it can also avoid unnecessary calculations.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
