### PR TITLE
datasets downgrade version to 2.21.0

### DIFF
--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,2 +1,2 @@
-datasets
+datasets==2.21.0
 peft

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,2 +1,2 @@
-datasets==2.21.0
+datasets
 peft

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,1 +1,2 @@
 https://github.com/EleutherAI/lm-evaluation-harness/archive/0bf683b4e6a9df359b3156ba9ba8d62bdd47e0c0.zip
+datasets==2.21.0


### PR DESCRIPTION
downgrade datasets version to 2.21.0 for text-gen due to the following error

(/usr/local/lib/python3.10/dist-packages/datasets/__init__.py)
    import lm_eval.tasks
  File "/usr/local/lib/python3.10/dist-packages/lm_eval/tasks/__init__.py", line 65, in <module>
    from . import scrolls
  File "/usr/local/lib/python3.10/dist-packages/lm_eval/tasks/scrolls.py", line 33, in <module>
    from datasets import load_metric
ImportError: cannot import name 'load_metric' from 'datasets' (/usr/local/lib/python3.10/dist-packages/datasets/__init__.py)