### PR TITLE
Added missing condition check when using --run_partial_dataset

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -698,6 +698,8 @@ def main():
                 f"Output: {tokenizer.batch_decode(outputs, skip_special_tokens=True)[:args.batch_size*args.num_return_sequences]}"
             )
             print(separator)
+            if args.run_partial_dataset and args.n_iterations == i + 1:
+                break
         t_end = time.time()
 
         throughput = total_new_tokens_generated / duration


### PR DESCRIPTION
# What does this PR do?

@regisss --run_partial_dataset parameter is added by https://github.com/huggingface/optimum-habana/pull/1364 to ci_11102024 tag not main yet.
But when https://github.com/huggingface/optimum-habana/pull/1364 is ported, one condition check code is missing compare to optimum-habana-fork change.
We found that issue during our internal CI which using "--n_iterations 500 --dataset_name tatsu-lab/alpaca   --run_partial_dataset" in command line. It didn't finish after 500 iterations but kept running through whole dataloader size.


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
