### PR TITLE
[SW-191023][PyTorch][Optimum-Habana-fork]: Add flag to run inference with partial dataset

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -320,6 +320,11 @@ def setup_parser(parser):
         action="store_true",
         help="Whether to enable inputs_embeds or not.",
     )
+    parser.add_argument(
+        "--run_partial_dataset",
+        action="store_true",
+        help="Run the inference with dataset for specified --n_iterations(default:5)",
+    )
 
     args = parser.parse_args()
 
@@ -698,6 +703,8 @@ def main():
                 f"Output: {tokenizer.batch_decode(outputs, skip_special_tokens=True)[:args.batch_size*args.num_return_sequences]}"
             )
             print(separator)
+            if args.run_partial_dataset and args.n_iterations == i + 1:
+                break
         t_end = time.time()
 
         throughput = total_new_tokens_generated / duration


### PR DESCRIPTION
# What does this PR do?

While running the inference with a dataset (ex: Alpaca that has 52000 instructions), executing the full dataset takes longer time. For various experiment purposes running inference with the full dataset is not desirable. Add a command line argument to run the inference with the partial dataset.

Flag ' -- run_partial_dataset' that runs the inference with the dataset for specified --n_iterations(default:5)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
