### PR TITLE
Update language-modeling README.md, add trust_remote_code for flan-t5-xl

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -868,7 +868,8 @@ python3 ../gaudi_spawn.py --world_size 8 --use_mpi peft_poly_seq2seq_with_genera
     --per_device_eval_batch_size 4 \
     --bf16 \
     --use_hpu_graphs_for_inference \
-    --use_hpu_graphs_for_training
+    --use_hpu_graphs_for_training \
+    --trust_remote_code
 ```
 
 

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -618,7 +618,7 @@ pip install -r requirements_lm_eval.txt
 ```
 
 > [!NOTE]
-> Please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true with the installed lm_eval version and dependency datasets==2.21.0
+> Depending on the model being used, please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true instead of arg --trust_remote_code with the installed lm_eval version and dependency datasets==2.21.0
 
 ### Examples
 

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -618,7 +618,7 @@ pip install -r requirements_lm_eval.txt
 ```
 
 > [!NOTE]
-> Depending on the model being used, please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true instead of arg --trust_remote_code with the installed lm_eval version and dependency datasets==2.21.0
+> If custom models on hub is being used, please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true instead of arg --trust_remote_code with the installed lm_eval version and dependency datasets==2.21.0
 
 ### Examples
 

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -617,6 +617,8 @@ First, you should install the requirements:
 pip install -r requirements_lm_eval.txt
 ```
 
+> [!NOTE]
+> Please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true with the installed lm_eval version and dependency datasets==2.21.0
 
 ### Examples
 


### PR DESCRIPTION
add --trust_remote_code for google/flan-t5-xl as per runtime error comment


ValueError: Loading super_glue requires you to execute the dataset script in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
