### PR TITLE
Update ci sentence_transformer.sh

### DIFF
--- a/tests/ci/sentence_transformers.sh
+++ b/tests/ci/sentence_transformers.sh
@@ -7,6 +7,6 @@ python -m pip install --upgrade pip
 python -m pip install $OPTIMUM_HABANA_PATH[tests]
 cd $SENTENCE_TRANSFORMER_PATH/tests
 python -m pip install ..
-pytest test_cmnrl.py test_evaluator.py test_multi_process.py test_train_stsb.py test_compute_embeddings.py test_model_card_data.py test_trainer.py test_util.py test_pretrained_stsb.py
+pytest test_cmnrl.py test_multi_process.py test_compute_embeddings.py test_model_card_data.py test_util.py 
 cd $OPTIMUM_HABANA_PATH/tests
 python -m pytest test_sentence_transformers.py


### PR DESCRIPTION
# What does this PR do?

We suggest to modify the file tests/ci/sentence_transformers.sh to remove CI block issue -
 
    1.  test_evaluator.py not existing in latest ST repo and no need to add here
    2.  remove the testcases of file “ test_train_stsb.py test_trainer.py test_pretrained_stsb.py “ because all ST with hpu related training cases already put into tests/sentence_transformers. There are three training ST test cases there.
    3.  So the final test cases just need to cover ST inference like - " test_cmnrl.py test_multi_process.py test_compute_embeddings.py test_model_card_data.py test_util.py " to be included in tests/ci/sentence_transformers.sh
 
The above suggestion can remove CI block issue due to the original ST training part not enabled with hpu device from ST repo.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
