### PR TITLE
fix merge error and update text-to-speech readme

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -576,7 +576,7 @@ python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
 --attn_softmax_bf16 \
 --bucket_size=128 \
 --bucket_internal \
---batch_size 10 \
+--batch_size 8 \
 --max_input_tokens 40960 \
 --max_new_tokens 5120 \
 --use_flash_attention \

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -316,12 +316,6 @@ def setup_parser(parser):
         help="Run the inference with dataset for specified --n_iterations(default:5)",
     )
 
-    parser.add_argument(
-        "--run_partial_dataset",
-        action="store_true",
-        help="Run the inference with dataset for specified --n_iterations(default:5)",
-    )
-
     quant_parser_group = parser.add_mutually_exclusive_group()
     quant_parser_group.add_argument(
         "--load_quantized_model_with_autogptq",

--- a/examples/text-to-speech/README.md
+++ b/examples/text-to-speech/README.md
@@ -36,5 +36,4 @@ python3 run_pipeline.py \
 ```
 Models that have been validated:
   - [microsoft/speecht5_tts](https://huggingface.co/microsoft/speecht5_tts)
-  - [facebook/hf-seamless-m4t-medium](https://huggingface.co/facebook/hf-seamless-m4t-medium)
   - [facebook/mms-tts-eng](https://huggingface.co/facebook/mms-tts-eng)


### PR DESCRIPTION
this PR address 3 issues
1. a merge error in run_generation
2. remove support for facebook/hf-seamless-m4t-medium from text-to-speech due to issues
3. reduce the batch size for text-generation command using Using Habana Flash Attention due to memory issues