### PR TITLE
Fix OOM error for code llama

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -119,7 +119,7 @@ class GaudiLlamaRotaryEmbedding(torch.nn.Module):
                 self.rope_type = "default"
             self.max_seq_len_cached = config.max_position_embeddings
             # Truncate the cached max sequence length to 8k to limit cached register buffer size
-            if config.max_position_embeddings >= 8192:
+            if config.max_position_embeddings > 8192 and self.rope_type == "llama3":
                 self.max_seq_len_cached = 8192
             self.original_max_seq_len = config.max_position_embeddings
 


### PR DESCRIPTION
# What does this PR do?

This was added for llama3 error, but it's breaking code llama long sequence run. 
We are adding check for the llama3 only. 
https://github.com/huggingface/optimum-habana/pull/1394


<!-- Remove if not applicable -->

Fixes # (issue)
`python run_generation.py --model_name_or_path codellama/CodeLlama-13b-Instruct-hf --use_hpu_graphs --trim_logits --use_kv_cache --limit_hpu_graphs --bucket_size=128 --bucket_internal --max_new_tokens 1384 --max_input_tokens 15000 --bf16 --batch_size 4 --use_flash_attention --flash_attention_recompute  
`
Out of memory error, only able to run batch 1. 