### PR TITLE
Fix error on 4bit checkpoint load with run_lm_eval on TF4.45.2

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -691,7 +691,7 @@ def local_load_remaining_pretrained_weight(self,model):
             "model": model,
             "state_dict": state_dict,
             "start_prefix": "",
-            "expected_keys": list(state_dict.keys()),
+            "expected_keys": self.loaded_state_dict_keys,
             "device_map": {"": self.device},
             "offload_folder": offload_folder,
             "state_dict_folder": tempfile.mkdtemp() if offload_state_dict else None,


### PR DESCRIPTION
# What does this PR do?
We are seeing error on INT4 weight loading on Transformer 4.45.2 release when we use run_lm_eval.py 
The fix is backward compatible, so we don't need to differentiate between different transformer version. 

<!-- Remove if not applicable -->

```
Fixes # (issue)
SRAM_SLICER_SHARED_MME_INPUT_EXPANSION_ENABLED=false ENABLE_EXPERIMENTAL_FLAGS=1 python run_lm_eval.py -o acc_load_uint4_model.txt --model_name_or_path TheBloke/Llama-2-7B-GPTQ --use_hpu_graphs --use_kv_cache --trim_logits --batch_size 1 --bf16 --attn_softmax_bf16 --bucket_size=128 --bucket_internal --load_quantized_model_with_inc
 
```
```
   File "/usr/local/lib/python3.10/dist-packages/neural_compressor/torch/algorithms/weight_only/save_load.py", line 228, in load_hf_format_woq_model
    model = self._load_remaining_pretrained_weight(model)
  File "/root/tf/optimum-habana/examples/text-generation/utils.py", line 703, in local_load_remaining_pretrained_weight
    _load_state_dict_into_meta_model(**params_dict)
  File "/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py", line 973, in _load_state_dict_into_meta_model
    set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/accelerate/utils/modeling.py", line 341, in set_module_tensor_to_device
    raise ValueError(f"{module} does not have a parameter or a buffer named {tensor_name}.")
ValueError: HPUWeightOnlyLinear(in_features=11008, out_features=4096, bits=4, group_size=128, bias=True) does not have a parameter or a buffer named bias.

```
