### PR TITLE
Github action diffusers test case change

### DIFF
--- a/tests/ci/slow_tests_diffusers.sh
+++ b/tests/ci/slow_tests_diffusers.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+hl-smi
+hl-smi -q
+
 python -m pip install --upgrade pip
 export RUN_SLOW=true
 make test_installs
-CUSTOM_BF16_OPS=1 python -m pytest tests/test_diffusers.py -v -s -k "test_no_throughput_regression_autocast"
+CUSTOM_BF16_OPS=1 python -m pytest tests/test_diffusers.py -v -s -k "test_stable_diffusion_default"
 make slow_tests_diffusers


### PR DESCRIPTION
Currently "Test stable diffusion" github action test fails in (Gaudi2) Non-regression tests.
"test_no_throughput_regression_autocast" test case fails due to the order of importing "habana_frameworks.torch.core" and GaudiConfig setting for autocasting, which is not proper procedure to apply "autocast" config to habana torch core.
So,  change test_diffusers.py to run "test_stable_diffusion_default" instead "test_no_throughput_regression_autocast".