### PR TITLE
fix bug when loading 4bit checkpoint quantized in INC

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -269,6 +269,9 @@ def setup_model(args, model_dtype, model_kwargs, logger):
             original_model=org_model,
             **model_kwargs,
         )
+        # TODO: This will be removed in v1.19 Synapse release
+        # the loaded model should have the same dtype as original_model
+        model = model.to(model_kwargs["torch_dtype"])
     else:
         if args.assistant_model is not None:
             assistant_model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
```
SRAM_SLICER_SHARED_MME_INPUT_EXPANSION_ENABLED=false ENABLE_EXPERIMENTAL_FLAGS=1 \
python run_generation.py \
--model_name_or_path meta-llama/Llama-2-7b-hf \
--use_hpu_graphs \
--use_kv_cache \
--trim_logits \
--batch_size 1 \
--bf16 \
--attn_softmax_bf16 \
--quantized_inc_model_path <local_model_path_from_inc> 
```
upper command gets error due to dtype mismatch. It will be fixed in Synapse 1.19.0
```
  File "/home/xinhe3/optimum-habana-fork/examples/text-generation/run_generation.py", line 656, in generate                                              
    output_tokens = model.generate(                                                                                                                      
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context                               
    return func(*args, **kwargs)                                                                                                                         
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/generation/utils.py", line 1292, in generate                                        
    result = self._sample(                                                                                                                               
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/generation/utils.py", line 2259, in _sample                                         
    outputs = self(                                                                                                                                      
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl                            
    return self._call_impl(*args, **kwargs)                                                                                                              
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1565, in _call_impl                                    
    return forward_call(*args, **kwargs)                                                                                                                 
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/habana_frameworks/torch/hpu/graphs.py", line 724, in forward                             
    return wrapped_hpugraph_forward(                                                                                                                     
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/habana_frameworks/torch/hpu/graphs.py", line 597, in wrapped_hpugraph_forward            
    outputs = orig_fwd(*args, **kwargs)                                                                                                                  
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 1345, in forward                              
    outputs = self.model(
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1606, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 1236, in forward
    layer_outputs = decoder_layer(
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/xinhe3/qnpu/venv-118/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1606, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 925, in forward
    hidden_states, self_attn_weights, present_key_value = self.pre_attn(
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 982, in pre_attn
    hidden_states, attn_weights, present_key_value = self.self_attn.pre_attn_forward(
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 647, in pre_attn_forward
    key_states = self.k_cache.update(past_key_value[0], key_states, 2, token_idx, self.inp_seq_len)
  File "/home/xinhe3/optimum-habana-fork/optimum/habana/transformers/models/llama/modeling_llama.py", line 424, in update
    prev.index_copy_(dim, idx - 1, cur)
RuntimeError: cpu fallback is not supported during hpu graph capturing
```

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
