### PR TITLE
Text-generation, model set-up: torch.compile for attributes instead of models' types

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -179,20 +179,16 @@ def patch_scoped_linear_all_reduce(model):
 
 def get_torch_compiled_model(model, logger):
     # for gpt_bigcode, mpt, bloom, gpt2 model_type
-    if hasattr(model, 'transformer'):
+    if hasattr(model, "transformer"):
         model.transformer = torch.compile(
             model.transformer, backend="hpu_backend", options={"keep_input_mutations": True}
         )
     # for gpt_neox
-    elif hasattr(model, 'gpt_neox'):
-        model.gpt_neox = torch.compile(
-            model.gpt_neox, backend="hpu_backend", options={"keep_input_mutations": True}
-        )
+    elif hasattr(model, "gpt_neox"):
+        model.gpt_neox = torch.compile(model.gpt_neox, backend="hpu_backend", options={"keep_input_mutations": True})
     # for llama, mistral, mixtral, qwen2
-    elif hasattr(model, 'model'):
-        model.model = torch.compile(
-            model.model, backend="hpu_backend", options={"keep_input_mutations": True}
-        )
+    elif hasattr(model, "model"):
+        model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
     else:
         logger.warning(
             "In low performance case, please explicitly specify a module you want to wrap with `torch.compile`"


### PR DESCRIPTION
# What does this PR do?
It changes `get_torch_compiled_model(model)` function:
```python
def get_torch_compiled_model(model, logger):
    # for model_type in ["gpt_bigcode", "mpt", "bloom", "gpt2"]
    if hasattr(model, 'transformer'):
        model.transformer = torch.compile(
            model.transformer, backend="hpu_backend", options={"keep_input_mutations": True}
        )
        ...
        ...
```

It’s hard-coded now by models' types, but we can hard-code it from attributes' point of view. I think this way can cover more models already supported for each attribute.

Please advise, if you know better way to remove hard-codes.

I did some manual testing for models with types the function covers.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
        **Please, advise tests I need to run or a models list validated with `--torch_compile` option.**
