### PR TITLE
Fixes 'Tokenizer does not have padding token' introduced by  #1444 for Llama3.1

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -478,7 +478,6 @@ LOWER_LIST=ops_bf16.txt python ../gaudi_spawn.py \
 	--world_size 8 --use_mpi run_lora_clm.py \
 	--model_name_or_path meta-llama/Llama-2-7b-hf \
 	--dataset_name tatsu-lab/alpaca \
-	--bf16 True \
 	--output_dir ./model_lora_llama \
 	--num_train_epochs 3 \
 	--per_device_train_batch_size 16 \

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -478,7 +478,7 @@ LOWER_LIST=ops_bf16.txt python ../gaudi_spawn.py \
 	--world_size 8 --use_mpi run_lora_clm.py \
 	--model_name_or_path meta-llama/Llama-2-7b-hf \
 	--dataset_name tatsu-lab/alpaca \
-    --bf16 True \
+	--bf16 True \
 	--output_dir ./model_lora_llama \
 	--num_train_epochs 3 \
 	--per_device_train_batch_size 16 \

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -478,6 +478,7 @@ LOWER_LIST=ops_bf16.txt python ../gaudi_spawn.py \
 	--world_size 8 --use_mpi run_lora_clm.py \
 	--model_name_or_path meta-llama/Llama-2-7b-hf \
 	--dataset_name tatsu-lab/alpaca \
+    --bf16 True \
 	--output_dir ./model_lora_llama \
 	--num_train_epochs 3 \
 	--per_device_train_batch_size 16 \

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -700,6 +700,11 @@ def main():
         raise ValueError("Must provide model_name_or_path to load a pretrained CausalLM model.")
 
     if model.config.model_type == "llama":
+        if model.generation_config.pad_token_id is None:
+            if isinstance(model.generation_config.eos_token_id, int):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id
+            elif isinstance(model.generation_config.eos_token_id, list):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id[0]
         if model_args.attn_softmax_bf16:
             model.generation_config.attn_softmax_bf16 = True
         if model_args.use_flash_attention:
@@ -717,7 +722,10 @@ def main():
     if hasattr(model.generation_config, "pad_token_id") and model.generation_config.pad_token_id is not None:
         tokenizer.pad_token_id = model.generation_config.pad_token_id
     if hasattr(model.generation_config, "eos_token_id") and model.generation_config.eos_token_id is not None:
-        tokenizer.eos_token_id = model.generation_config.eos_token_id
+        if isinstance(model.generation_config.eos_token_id, int):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id
+        elif isinstance(model.generation_config.eos_token_id, list):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id[0]
     if hasattr(model.generation_config, "bos_token_id") and model.generation_config.bos_token_id is not None:
         tokenizer.bos_token_id = model.generation_config.bos_token_id
 


### PR DESCRIPTION
New error _'ValueError: Asking to pad but the tokenizer does not have a padding token. Please select a token to use as `pad_token` `(tokenizer.pad_token = tokenizer.eos_token e.g.)` or add a new pad token via `tokenizer.add_special_tokens({'pad_token': '[PAD]'})`'_ introduced by  #1444 for Llama3.1.

This patch fixes the above when running the run_lora_clm.py for **finetuning**  llama3.1 using command from **language-modeling** README:

```
PT_HPU_MAX_COMPOUND_OP_SIZE=10 \
python3 ../gaudi_spawn.py --use_deepspeed  --world_size 8  run_lora_clm.py \
  --model_name_or_path meta-llama/Llama-3.1-70B-Instruct \
  --deepspeed llama2_ds_zero3_config.json \
  --dataset_name tatsu-lab/alpaca \
  --bf16 True \
  --output_dir ./lora_out \
  --num_train_epochs 2 \
  --max_seq_len 2048 \
  --per_device_train_batch_size 10 \
  --per_device_eval_batch_size 1 \
  --gradient_checkpointing \
  --eval_strategy epoch \
  --eval_delay 2 \
  --save_strategy no \
  --learning_rate 0.0018 \
  --warmup_ratio 0.03 \
  --lr_scheduler_type "cosine" \
  --logging_steps 1 \
  --dataset_concatenation \
  --attn_softmax_bf16 True \
  --do_train \
  --do_eval \
  --use_habana \
  --use_lazy_mode \
  --pipelining_fwd_bwd \
  --throughput_warmup_steps 3 \
  --lora_rank 4 \
  --lora_target_modules "q_proj" "v_proj" "k_proj" "o_proj" \
  --validation_split_percentage 4 \
  --use_flash_attention True \
  --flash_attention_causal_mask True \
  --fp8 True
```
