### PR TITLE
Fix bridgetower example (#312)

### DIFF
--- a/optimum/habana/transformers/gradient_checkpointing.py
+++ b/optimum/habana/transformers/gradient_checkpointing.py
@@ -181,8 +181,10 @@ class CheckpointFunction(torch.autograd.Function):
                     set_device_states(ctx.fwd_devices, ctx.fwd_device_states)
             detached_inputs = detach_variable(tuple(inputs))
 
-            with torch.enable_grad(), torch.autocast(**ctx.hpu_autocast_kwargs), torch.amp.autocast(
-                "cpu", **ctx.cpu_autocast_kwargs
+            with (
+                torch.enable_grad(),
+                torch.autocast(**ctx.hpu_autocast_kwargs),
+                torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs),
             ):
                 outputs = ctx.run_function(*detached_inputs)
 

--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -453,9 +453,11 @@ class GaudiFalconAttention(FalconAttention):
                             )
                     else:
                         # TODO very similar to the fp8 case above, could be merged.
-                        with sdp_kernel(
-                            enable_recompute=flash_attention_recompute
-                        ) if SDPContext else contextlib.nullcontext():
+                        with (
+                            sdp_kernel(enable_recompute=flash_attention_recompute)
+                            if SDPContext
+                            else contextlib.nullcontext()
+                        ):
                             attn_output = FusedSDPA.apply(
                                 query_layer,
                                 key_layer,

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -362,9 +362,9 @@ class GaudiMixtralAttention(MixtralAttention):
                 )
                 htcore.mark_step()
             else:
-                with sdp_kernel(
-                    enable_recompute=flash_attention_recompute
-                ) if SDPContext else contextlib.nullcontext():
+                with (
+                    sdp_kernel(enable_recompute=flash_attention_recompute) if SDPContext else contextlib.nullcontext()
+                ):
                     attn_output = FusedSDPA.apply(
                         query_states, key_states, value_states, attention_mask, 0.0, False, None
                     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -87,9 +87,11 @@ class TestGaudiPipeline:
                 generate_kwargs = {"lazy_mode": True, "ignore_eos": False, "hpu_graphs": True}
 
             generator.model = wrap_in_hpu_graph(generator.model)
-            with torch.autocast(
-                "hpu", torch.bfloat16, enabled=(model_dtype == torch.bfloat16)
-            ), torch.no_grad(), torch.inference_mode():
+            with (
+                torch.autocast("hpu", torch.bfloat16, enabled=(model_dtype == torch.bfloat16)),
+                torch.no_grad(),
+                torch.inference_mode(),
+            ):
                 for i in range(3):
                     output = generator(text, forward_params=forward_params, generate_kwargs=generate_kwargs)
             assert isinstance(output["audio"], np.ndarray)

--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1639,9 +1639,10 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         self.assertEqual(transcription[0], "habitan aguas poco profundas y rocosas")
 
         # user-managed pool + num_processes should trigger a warning
-        with CaptureLogger(processing_wav2vec2_with_lm.logger) as cl, multiprocessing.get_context("fork").Pool(
-            2
-        ) as pool:
+        with (
+            CaptureLogger(processing_wav2vec2_with_lm.logger) as cl,
+            multiprocessing.get_context("fork").Pool(2) as pool,
+        ):
             transcription = processor.batch_decode(logits.cpu().numpy(), pool, num_processes=2).text
 
         self.assertIn("num_process", cl.out)


### PR DESCRIPTION
Description: Adding support for loading images stored directly in a JSON file (encoded using ISO-8859-1) into an image object.
 
It resolves an error: TypeError Unexpected type <class 'NoneType'> in BridgeTower model.
 
Command:
WANDB_DISABLED=true PT_HPU_MAX_COMPOUND_OP_SIZE=512 python3 run_bridgetower.py --model_name_or_path 'BridgeTower/bridgetower-large-itm-mlm-itc' --do_train --dataset_name 'jmhessel/newyorker_caption_contest' --dataset_config matching --image_column image --caption_column image_description --remove_unused_columns False --mediapipe_dataloader --output_dir /tmp/bridgetower-test --per_device_train_batch_size 40 --per_device_eval_batch_size 16 --learning_rate 1e-05 --overwrite_output_dir --use_habana --use_lazy_mode --use_hpu_graphs_for_inference --gaudi_config_name Habana/clip --save_strategy epoch --throughput_warmup_steps 3 --num_train_epochs 1 --logging_steps 10 --distribution_strategy fast_ddp