### PR TITLE
Remove torch req from LM example

### DIFF
--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -1,4 +1,3 @@
-torch >= 1.3
 datasets >= 2.14.0
 sentencepiece != 0.1.92
 protobuf


### PR DESCRIPTION
Hi
Specifying torch requirement causes some bug in our QA infra, can we just skip the obvious pytorch requirement? I am not sure this version is still supported.