### PR TITLE
Makes the with_stack of the profiler changeable

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -882,6 +882,7 @@ class GaudiTrainer(Trainer):
             warmup=self.args.profiling_warmup_steps,
             active=self.args.profiling_steps,
             record_shapes=self.args.profiling_record_shapes,
+            with_stack=self.args.profiling_with_stack,
         )
         hb_profiler.start()
 

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -242,6 +242,11 @@ class GaudiTrainingArguments(TrainingArguments):
         default=True,
         metadata={"help": ("Record shapes when enabling profiling.")},
     )
+    
+    profiling_with_stack: Optional[bool] = field(
+        default=False,
+        metadata={"help": ("record source information (file and line number) for the ops when enabling profiling.")},
+    )
     # Overriding the default value of optim because 'adamw_hf' is deprecated
     optim: Optional[Union[OptimizerNames, str]] = field(
         default="adamw_torch",

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -242,7 +242,7 @@ class GaudiTrainingArguments(TrainingArguments):
         default=True,
         metadata={"help": ("Record shapes when enabling profiling.")},
     )
-    
+
     profiling_with_stack: Optional[bool] = field(
         default=False,
         metadata={"help": ("record source information (file and line number) for the ops when enabling profiling.")},

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -285,6 +285,7 @@ class HabanaProfile(object):
         warmup: int = 0,
         active: int = 0,
         record_shapes: bool = True,
+        with_stack: bool = False,
         output_dir: str = "./hpu_profile",
         wait: int = 0,
     ):
@@ -306,7 +307,7 @@ class HabanaProfile(object):
                 activities=activities,
                 on_trace_ready=torch.profiler.tensorboard_trace_handler(output_dir),
                 record_shapes=record_shapes,
-                with_stack=False,
+                with_stack=with_stack,
             )
             self.start = profiler.start
             self.stop = profiler.stop


### PR DESCRIPTION
The default argument of profiler `with_stack ` is `False`. Enabling this can help performance analysis align with model function，through it need more memory usage, we still need it to locate problem code. 
This pr makes the `with_stack` changeable (for customer demands).
