### PR TITLE
text_generation: improve parameters check

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1062,9 +1062,10 @@ class GaudiGenerationMixin(GenerationMixin):
         )
         if model_kwargs["reduce_recompile"]:
             assert generation_config.bucket_size
-        # Below condition checked explicitly since llama supports bucket_internal even without reuse_cache
+        # Below condition checked explicitly since some models (like llama and gpt_bigcode) support bucket_internal even without reuse_cache
         if generation_config.bucket_internal:
             assert generation_config.bucket_size >= 0, "please set bucket_size to use bucket_internal"
+            assert generation_config.use_cache, "please set use_cache flag to use bucket_internal"
         if generation_config.reuse_cache:
             assert (
                 self.config.model_type


### PR DESCRIPTION
Improves error reporting for case when internal_bucketing requested without kv-cache enabled

For example command line (note the absence of ```--use_kv_cache``` parameter)
```
python3 run_generation.py --model_name_or_path bigcode/starcoder --batch_size 2 --max_new_tokens 100 --bucket_size 128 --bucket_internal --use_hpu_graphs --bf16  --prompt 'def print_hello_world():'
```

Before fix:
```
Traceback (most recent call last):
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 758, in <module>
    main()
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 523, in main
    generate(None, args.reduce_recompile)
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 494, in generate
    outputs = model.generate(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/var/work/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1442, in generate
    result = self._sample(
  File "/var/work/optimum-habana/optimum/habana/transformers/generation/utils.py", line 2513, in _sample
    if model_kwargs.get("token_idx_cpu") <= (model_kwargs["kv_cache_len"] // bucket_size) * bucket_size:
KeyError: 'kv_cache_len'
```

After fix:
```
Traceback (most recent call last):
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 758, in <module>
    main()
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 523, in main
    generate(None, args.reduce_recompile)
  File "/var/work/optimum-habana/examples/text-generation/run_generation.py", line 494, in generate
    outputs = model.generate(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/var/work/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1065, in generate
    assert generation_config.use_cache, "please set use_cache flag to use bucket_internal"
AssertionError: please set use_cache flag to use bucket_internal
```

Error message is much more clear with this fix

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
