### PR TITLE
Fix dtype issue with valid sequence length in torch.compile bs=1

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -462,7 +462,7 @@ def main():
 
                 def compute_valid_sequence_lengths_tensor(input_tokens):
                     attn_mask = input_tokens["attention_mask"]
-                    return torch.sum(attn_mask, dim=1)
+                    return torch.sum(attn_mask, dim=1, dtype=torch.int32)
 
                 valid_sequence_lengths = compute_valid_sequence_lengths_tensor(input_tokens).to(args.device)
                 generation_config.valid_sequence_lengths = valid_sequence_lengths


### PR DESCRIPTION
Change dtype of valid sequence length tensor to explicit torch.int32.

Previously this caused issue on bs=1 configs with torch.compile.

affected command:
PT_HPU_LAZY_MODE=0  python /root/optimum-habana-fork/examples/text-generation/run_generation.py --attn_softmax_bf16 --use_hpu_graphs --use_kv_cache --bf16 --model_name_or_path /qa/inference/helper_files/granite/granite-8b --batch_size 1 --bucket_size 128 --bucket_internal --n_iterations 1 --warmup 1 --max_input_tokens 2048 --max_new_tokens 1 --use_flash_attention --flash_attention_recompute --flash_attention_causal_mask --book_source --torch_compile