### PR TITLE
Adjust Qwen2-7B test case

### DIFF
--- a/tests/test_text_generation_example.py
+++ b/tests/test_text_generation_example.py
@@ -51,7 +51,7 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
             ("google/gemma-2-9b", 1, False, 92.302359446567, True),
             ("state-spaces/mamba-130m-hf", 1536, False, 5385.511100161605, False),
             ("Deci/DeciLM-7B", 1, False, 120, False),
-            ("Qwen/Qwen2-7B", 512, False, 9669.45787, True),
+            ("Qwen/Qwen2-7B", 256, False, 8870.945160540245, True),
             ("Qwen/Qwen1.5-MoE-A2.7B", 1, True, 44.25834541569395, False),
             ("EleutherAI/gpt-neo-2.7B", 1, False, 257.2476416844122, False),
             ("facebook/xglm-1.7B", 1, False, 357.46365062825083, False),
@@ -117,7 +117,7 @@ if os.environ.get("GAUDI2_CI", "0") == "1":
         "meta-llama/Llama-2-7b-hf": "DeepSpeed is a machine learning framework for deep learning. It is designed to be fast and efficient, while also being easy to use. DeepSpeed is based on the TensorFlow framework, and it uses the TensorFlow library to perform computations.\nDeepSpeed is a deep learning framework that is designed to be fast and efficient. It is based on the TensorFlow library and uses the TensorFlow library to perform computations. DeepSpeed is designed to be easy to use and to provide a high level of flex",
         "mistralai/Mistral-7B-v0.1": "DeepSpeed is a machine learning framework that accelerates training of large models on a single machine or distributed systems. It is designed to be compatible with PyTorch and TensorFlow, and can be used to train models on a single machine or on a distributed system.\n\nDeepSpeed is a machine learning framework that accelerates training of large models on a single machine or distributed systems. It is designed to be compatible with PyTorch and TensorFlow, and can be used to train models on a single machine or on a distributed system",
         "mistralai/Mixtral-8x7B-v0.1": "DeepSpeed is a machine learning framework that enables training of large models on a single machine with a single GPU. It is designed to be easy to use and efficient, and it can be used to train models on a variety of tasks.\n\n## Introduction\n\nDeepSpeed is a machine learning framework that enables training of large models on a single machine with a single GPU. It is designed to be easy to use and efficient, and it can be used to train models on a variety of tasks.\n\n## What is DeepSpeed",
-        "Qwen/Qwen2-7B": "DeepSpeed is a machine learning framework that provides a suite of toolskits for building and training deep learning models. It is designed to be highly scalable and efficient, and it supports a wide range of deep learning frameworks, including PyTorch, TensorFlow, and MXNet. DeepSpeed is particularly well-suited for training large-scale models on distributed systems, and it provides a number of features that make it easy to use and configure. Some of the key features of DeepSpeed include:\n\n- Distributed training: DeepSpeed supports distributed training on multiple",
+        "Qwen/Qwen2-7B": "DeepSpeed is a machine learning framework that provides a unified interface for training deep learning models. It is designed to be easy to use and to provide high performance. DeepSpeed is built on top of PyTorch and TensorFlow, and it supports a wide range of models, including transformers, convolutional neural networks, and recurrent neural networks.\nDeepSpeed is a machine learning framework that provides a unified interface for training deep learning models. It is designed to be easy to use and to provide high performance. DeepSpeed is built on top of Py",
     }
 else:
     # Gaudi1 CI baselines


### PR DESCRIPTION
# What does this PR do?

Since the accuracy patch for Qwen2 family [(PR Link)](https://github.com/huggingface/optimum-habana/pull/1541) was merged, the test case should be also adjusted for the batch size and output.

```
GAUDI2_CI=1  RUN_SLOW=1 python3.10 -m pytest tests/test_text_generation_example.py -s -v -k generation_bf16_1x[token0-Qwen/Qwen2-7B-256
```

Result:
```
Stats:
----------------------------------------------------------------------------------
Input tokens
Throughput (including tokenization) = 8871.747465242199 tokens/second
Memory allocated                    = 62.52 GB
Max memory allocated                = 65.15 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 10.456412034000095 seconds
----------------------------------------------------------------------------------

PASSED

========================================================================================================== warnings summary ===========================================================================================================
tests/test_text_generation_example.py::test_text_generation_bf16_1x[token0-Qwen/Qwen2-7B-256-False-8870.945160540245-True]
  /usr/lib/python3.10/inspect.py:288: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
    return isinstance(object, types.FunctionType)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================ 1 passed, 65 deselected, 1 warning in 45.94s =============================================================================================
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
