### PR TITLE
fix lazy_mode assignment

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -986,7 +986,10 @@ class GaudiTrainer(Trainer):
                             inputs["flash_attention_causal_mask"] = True
                 if self.model.config is not None:
                     if self.model.config.model_type in ["llama", "qwen2", "mistral", "starcoder2"]:
-                        forward_method = getattr(self.model, "forward")
+                        if _is_peft_model(model):
+                            forward_method = getattr(model.get_base_model(), "forward")
+                        else:
+                            forward_method = getattr(model, "forward")
                         signature = inspect.signature(forward_method)
                         if "lazy_mode" in signature.parameters:
                             inputs["lazy_mode"] = args.use_lazy_mode

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -986,7 +986,10 @@ class GaudiTrainer(Trainer):
                             inputs["flash_attention_causal_mask"] = True
                 if self.model.config is not None:
                     if self.model.config.model_type in ["llama", "qwen2", "mistral", "starcoder2"]:
-                        inputs["lazy_mode"] = args.use_lazy_mode
+                        forward_method = getattr(self.model, "forward")
+                        signature = inspect.signature(forward_method)
+                        if "lazy_mode" in signature.parameters:
+                            inputs["lazy_mode"] = args.use_lazy_mode
                 # TODO: keep syncs for fast DDP?
                 with self.accelerator.accumulate(model):
                     tr_loss_step = self.training_step(model, inputs)


### PR DESCRIPTION
# What does this PR do?
credit: @yafshar for fix
Fix for failing test:
```
 GAUDI2_CI=1  RUN_SLOW=1 python3.10 -m pytest tests/test_examples.py -s -v -k test_run_glue_LlamaGuard-7b_deepspeed
```
```
[rank2]:     return forward_call(*args, **kwargs)
[rank2]:   File "/root/tf/deepspeed-fork/deepspeed/utils/nvtx.py", line 15, in wrapped_fn
[rank2]:     ret_val = func(*args, **kwargs)
[rank2]:   File "/root/tf/deepspeed-fork/deepspeed/runtime/engine.py", line 1907, in forward
[rank2]:     loss = self.module(*inputs, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
[rank2]:     return self._call_impl(*args, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
[rank2]:     return forward_call(*args, **kwargs)
[rank2]: TypeError: LlamaForSequenceClassification.forward() got an unexpected keyword argument 'lazy_mode'
```
#### Testing on 8 HPU -testcase above
(thanks @yafshar ):
![image](https://github.com/user-attachments/assets/da438dee-c99c-4bc9-a52d-6e33cc057c9e)

#### Testing 1 HPU - llama: examples/language-modelling/readme
```
python3 run_lora_clm.py \
    --model_name_or_path huggyllama/llama-7b \
    --dataset_name tatsu-lab/alpaca \
    --bf16 True \
    --output_dir ./model_lora_llama \
    --num_train_epochs 3 \
    --per_device_train_batch_size 16 \
    --eval_strategy "no" \
    --save_strategy "no" \
    --learning_rate 1e-4 \
    --warmup_ratio  0.03 \
    --lr_scheduler_type "constant" \
    --max_grad_norm  0.3 \
    --logging_steps 1 \
    --do_train \
    --do_eval \
    --use_habana \
    --use_lazy_mode \
    --throughput_warmup_steps 3 \
    --lora_rank=8 \
    --lora_alpha=16 \
    --lora_dropout=0.05 \
    --lora_target_modules "q_proj" "v_proj" \
    --dataset_concatenation \
    --max_seq_length 512 \
    --low_cpu_mem_usage True \
    --validation_split_percentage 4 \
    --adam_epsilon 1e-08
```
output
```
***** train metrics *****
  epoch                       =         3.0
  max_memory_allocated (GB)   =       72.67
  memory_allocated (GB)       =       55.43
  total_flos                  = 703666335GF
  total_memory_available (GB) =       94.62
  train_loss                  =      0.9087
  train_runtime               =  0:34:09.84
  train_samples_per_second    =      18.361
  train_steps_per_second      =       1.149
12/06/2024 18:58:03 - INFO - __main__ -   *** Evaluate ***
[INFO|trainer.py:1922] 2024-12-06 18:58:03,581 >> 
***** Running Evaluation *****
[INFO|trainer.py:1924] 2024-12-06 18:58:03,582 >>   Num examples = 501
[INFO|trainer.py:1927] 2024-12-06 18:58:03,582 >>   Batch size = 8
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 63/63 [00:12<00:00,  5.19it/s]
***** eval metrics *****
  epoch                           =        3.0
  eval_accuracy                   =     0.7748
  eval_graph_compliation_duration =     0.9339
  eval_loss                       =     0.8523
  eval_runtime                    = 0:00:12.88
  eval_samples                    =        501
  eval_samples_per_second         =     39.947
  eval_steps_per_second           =      5.025
  max_memory_allocated (GB)       =       94.6
  memory_allocated (GB)           =      55.43
  perplexity                      =     2.3449
  total_memory_available (GB)     =      94.62
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
