### PR TITLE
Fixed Adalora Test for OH 1.15

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1023,6 +1023,7 @@ class MultiCardCausalLanguageModelingAdaloraExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_lora_clm", multi_card=True
 ):
     TASK_NAME = "adalora"
+    DATASET_NAME = "tatsu-lab/alpaca"
 
 
 class MultiCardCausalLanguageModelingLoRACPExampleTester(


### PR DESCRIPTION
Fixed issue with adalora example tester.  Fix regarded "Dataset_name" under "class MultiCardCausalLanguageModelingAdaloraExampleTester".
