### PR TITLE
fix mllama test

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -2407,9 +2407,11 @@ class GaudiGenerationMixin(GenerationMixin):
                 assert "position_ids" not in model_kwargs, "Untested path"
 
         token_idx = model_kwargs.get("token_idx", None)
+        start_token_idx = cur_len
         if token_idx is not None:
             # Update cur_len in case of static shapes
             cur_len = (token_idx + model_kwargs.get("inputs_embeds_offset", 0)).item()
+            start_token_idx = token_idx
 
         time_to_first_token_done = False
         model_kwargs["pad_done"] = False
@@ -2617,7 +2619,10 @@ class GaudiGenerationMixin(GenerationMixin):
         if batch_size > 1 and has_eos_stopping_criteria:
             eos_token_id = generation_config.eos_token_id
             # Find the positions of the first eos_token_id in each sequence
-            eos_positions = (input_ids[:, INITIAL_TOKEN_IDX:] == eos_token_id).int().argmax(dim=1) + INITIAL_TOKEN_IDX
+            eos_positions = (
+                torch.isin(input_ids[:, start_token_idx:], torch.tensor(eos_token_id)).int().argmax(dim=1)
+                + start_token_idx
+            )
             # Create a mask for positions greater than the first eos_token_id
             mask = torch.arange(max_length).expand(batch_size, max_length) > eos_positions.unsqueeze(1)
             # Apply the mask to set positions greater than the first eos_token_id to pad_token_id


### PR DESCRIPTION
pytest tests/test_examples.py::MultiCardImageToTextModelingLoRAExampleTester::test_run_image2text_lora_finetune_Llama-3.2-11B-Vision-Instruct_multi_card -v -s


Traceback (most recent call last):
File "/workspace/wangyi/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py", line 553, in
main()
File "/workspace/wangyi/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py", line 538, in main
anls = eval(
File "/workspace/wangyi/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py", line 334, in eval
generated_ids = model.generate(
File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
return func(*args, **kwargs)
File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1462, in generate
result = self._sample(
File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/generation/utils.py", line 2620, in _sample
eos_positions = (input_ids[:, INITIAL_TOKEN_IDX:] == eos_token_id).int().argmax(dim=1) + INITIAL_TOKEN_IDX
AttributeError: 'bool' object has no attribute 'int'


failure caused by https://github.com/huggingface/optimum-habana/pull/1546
