### PR TITLE
fix prefix llama ci failure

### DIFF
--- a/optimum/habana/transformers/models/modeling_all_models.py
+++ b/optimum/habana/transformers/models/modeling_all_models.py
@@ -59,11 +59,10 @@ class KVCache(torch.nn.Module):
         if prev.shape == cur.shape:
             prev.copy_(cur)
             return orig_cur
-        if cur.shape[2] > 1 and cur.shape[2] <= prev.shape[2]:
+        if idx is not None and cur.shape[2] > 1 and cur.shape[2] <= prev.shape[2]:
             # Initialize
             prev[:, :, :inp_seq_len, :].copy_(cur)
             return orig_cur
-        assert cur.shape[2] == 1, f"Cannot update kv-cache. Unsupported shapes. prev:{prev.shape} cur:{cur.shape}"
         if idx is not None:
             prev.index_copy_(dim, idx - 1, cur)
             return prev


### PR DESCRIPTION
FAILED tests/test_examples.py::MultiCardCausalLanguageModelingPrefixTuningExampleTester::test_run_prompt_tuning_clm_llama-7b_multi_card - AssertionError:
1 != 0


[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1565, in _call_impl
[rank2]:     return forward_call(*args, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/peft/peft_model.py", line 1612, in forward
[rank2]:     return self.base_model(
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl
[rank2]:     return self._call_impl(*args, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1606, in _call_impl
[rank2]:     result = forward_call(*args, **kwargs)
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/llama/modeling_llama.py", line 1333, in forward
[rank2]:     outputs = self.model(
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl
[rank2]:     return self._call_impl(*args, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1606, in _call_impl
[rank2]:     result = forward_call(*args, **kwargs)
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/llama/modeling_llama.py", line 1223, in forward
[rank2]:     layer_outputs = decoder_layer(
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1556, in _wrapped_call_impl
[rank2]:     return self._call_impl(*args, **kwargs)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1606, in _call_impl
[rank2]:     result = forward_call(*args, **kwargs)
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/llama/modeling_llama.py", line 912, in forward
[rank2]:     hidden_states, self_attn_weights, present_key_value = self.pre_attn(
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/llama/modeling_llama.py", line 969, in pre_attn
[rank2]:     hidden_states, attn_weights, present_key_value = self.self_attn.pre_attn_forward(
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/llama/modeling_llama.py", line 634, in pre_attn_forward
[rank2]:     key_states = self.k_cache.update(past_key_value[0], key_states, 2, token_idx, self.inp_seq_len)
[rank2]:   File "/workspace/wangyi/optimum-habana/optimum/habana/transformers/models/modeling_all_models.py", line 66, in update
[rank2]:     assert cur.shape[2] == 1, f"Cannot update kv-cache. Unsupported shapes. prev:{prev.shape} cur:{cur.shape}"
[rank2]: AssertionError: Cannot update kv-cache. Unsupported shapes. prev:torch.Size([1, 32, 8, 128]) cur:torch.Size([1, 32, 64, 128])

