### PR TITLE
Revert LlamaKVCache due to memory increase

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -30,7 +30,7 @@ from ....distributed.tp import TPModule
 from ...modeling_attn_mask_utils import (
     _gaudi_prepare_4d_causal_attention_mask,
 )
-from ..modeling_all_models import KVCache, Matmul, apply_customized_rope_module
+from ..modeling_all_models import Matmul, apply_customized_rope_module
 from .configuration_llama import LlamaConfig
 
 
@@ -385,7 +385,22 @@ class ModuleFusedSDPA(torch.nn.Module):
         )
 
 
-class LlamaKVCache(KVCache):
+class KVCache(torch.nn.Module):
+    def __init__(self):
+        super(KVCache, self).__init__()
+        self.cache = None
+        self.inp_seq_len = -1
+
+    def allocate(self, inp_seq_len, dtype, device, shape):
+        if self.cache is None or self.cache.shape != shape:
+            self.inp_seq_len = inp_seq_len
+            self.cache = torch.zeros(shape, dtype=dtype, device=device)
+        else:
+            assert (
+                self.inp_seq_len == inp_seq_len
+            ), f"inp_seq_len must be the same. self.inp_seq_len:{self.inp_seq_len} inp_seq_len:{inp_seq_len}"
+            self.cache.fill_(0)
+
     @staticmethod
     def update(prev, cur, dim, idx, inp_seq_len):
         orig_cur = cur
@@ -402,6 +417,13 @@ class LlamaKVCache(KVCache):
         else:
             return torch.cat((prev, cur), dim=dim)
 
+    def get_shape(self):
+        if self.cache is None:
+            return None
+        return self.cache.shape
+
+    def forward(self, cur, dim, idx):
+        return self.update(self.cache, cur, dim, idx, self.inp_seq_len)
 
 def GaudiDistributedAttention(fused_scaled_dot_product_attention, fused_scaled_dot_product_attention_distributed):
     if parallel_state.sequence_parallel_is_initialized() and parallel_state.get_sequence_parallel_world_size() > 1:
@@ -416,8 +438,8 @@ class GaudiLlamaAttention(LlamaAttention):
 
         self.matmul_qk = Matmul()
         self.matmul_av = Matmul()
-        self.k_cache = LlamaKVCache()
-        self.v_cache = LlamaKVCache()
+        self.k_cache = KVCache()
+        self.v_cache = KVCache()
 
         if hasattr(config, "fused_qkv") and config.fused_qkv:
             self.num_heads = config.num_attention_heads


### PR DESCRIPTION
# What does this PR do?
Inherit KVCache to specific model(LlamaKVCache) cause memory increase and failing the max-batch run on llama model, get OOM on below command. Keep the KVCache it's own to llama model. 

QUANT_CONFIG=./quantization_config/maxabs_quant.json python ../gaudi_spawn.py \
--use_deepspeed --world_size 8 run_generation.py \
--model_name_or_path meta-llama/Llama-2-70b-hf \
--attn_softmax_bf16 \
--use_hpu_graphs \
--trim_logits \
--use_kv_cache \
--reuse_cache \
--use_flash_attention \
--flash_attention_recompute \
--bf16 \
--batch_size 350 \
--max_new_tokens 2048 \
--max_input_tokens 2048 \
--limit_hpu_graphs



For batch 300, this is the result I got. 

```
With LlamaKVCache:
----------------------------------------------------------------------------------
Input tokens
Throughput (including tokenization) = 4500.597792783069 tokens/second
Memory allocated                    = 61.07 GB
Max memory allocated                = 91.56 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 712.8430477110669 seconds
----------------------------------------------------------------------------------
```

With it's own KVCache:
```
-----------------------------------------------------------------------------------
Input tokens
Throughput (including tokenization) = 5467.5820329440785 tokens/second
Memory allocated                    = 37.58 GB
Max memory allocated                = 86.88 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 577.1543124481104 seconds
---------------------------------------------------------------------
```




<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
