### PR TITLE
Replace the UNET custom attention processors

### DIFF
--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -3745,6 +3745,7 @@ class GaudiDeterministicImageGenerationTester(TestCase):
             "CompVis/stable-diffusion-v1-4",
             **kwargs,
         )
+        pipeline.unet.set_default_attn_processor(pipeline.unet)
 
         num_images_per_prompt = 20
         res = {}

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -660,6 +660,7 @@ class GaudiStableDiffusionPipelineTester(TestCase):
             gaudi_config=GaudiConfig.from_pretrained("Habana/stable-diffusion"),
             torch_dtype=torch.bfloat16,
         )
+        pipeline.unet.set_default_attn_processor(pipeline.unet)
         set_seed(27)
         outputs = pipeline(
             prompt=prompts,
@@ -714,6 +715,7 @@ class GaudiStableDiffusionPipelineTester(TestCase):
             use_hpu_graphs=True,
             gaudi_config=GaudiConfig(use_torch_autocast=False),
         )
+        pipeline.unet.set_default_attn_processor(pipeline.unet)
 
         prompt = "An image of a squirrel in Picasso style"
         generator = torch.manual_seed(seed)


### PR DESCRIPTION
- Replace the the UNET custom attention processors with the default implementation on HPU.

# What does this PR do?

Fixes # (issue) on G3

```sh
>>> python -m pytest tests/test_diffusers.py -v -s -k test_deterministic_image_generation --junitxml=report4.xml

tests/test_diffusers.py:3752:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py:116: in decorate_context
    return func(*args, **kwargs)
optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py:594: in __call__
    noise_pred = self.unet_hpu(
/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py:116: in decorate_context
    return func(*args, **kwargs)
optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py:732: in unet_hpu
    return self.capture_replay(latent_model_input, timestep, encoder_hidden_states)
/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py:116: in decorate_context
    return func(*args, **kwargs)
optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py:756: in capture_replay
    graph.capture_end()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <habana_frameworks.torch.hpu.graphs.HPUGraph object at 0x7f8eb9186d40>

    def capture_end(self):
        r"""
        Ends HPU graph capture on the current stream.
        After ``capture_end``, ``replay`` may be called on this instance.
        """
>       _hpu_C.capture_end(self.hpu_graph)
E       RuntimeError: Graph compile failed. synStatus=synStatus 26 [Generic failure].

/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py:64: RuntimeError
```

It sounds like that the UNET custom attention processors is the issue, if we replace it with the default implementation. The error goes away

This PR fixes the issue
```sh
>>> python -m pytest tests/test_diffusers.py -v -s -k test_deterministic_image_generation --junitxml=report4.xml

-------------------------------------- generated xml file: /root/optimum-habana/report4.xml ---------------------------------------
======================================= 2 passed, 163 deselected, 4 warnings in 154.12s (0:02:34) ========================================
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
