### PR TITLE
Check rope_scaling attr

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -433,7 +433,7 @@ def setup_distributed_model(args, model_dtype, model_kwargs, logger):
         # Construct model with fake meta tensors, later will be replaced on devices during ds-inference ckpt load
         with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
             if (
-                config.rope_scaling
+                hasattr(config, 'rope_scaling') and config.rope_scaling
                 and config.rope_scaling["rope_type"] == "llama3"
                 and config.max_position_embeddings > 8192
             ):


### PR DESCRIPTION
# What does this PR do?
Some of old models doesn't have this rope_scaling  attribute and failing to run.  
Adding attribute check. 

<!-- Remove if not applicable -->

Fixes # (issue)

Command to test: 
 `python3 /root/optimum-habana/examples/gaudi_spawn.py --use_deepspeed --world_size 8 /root/optimum-habana/examples/text-generation/run_generation.py --model_name_or_path bigscience/bloomz --batch_size 1 --use_kv_cache --max_new_tokens 100 --use_hpu_graphs --output_dir /tmp/tmp20f06_pq
`


49874 [rank1]:   File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 202, in __getattribute__
49875 [rank1]:     return super().__getattribute__(key)
49876 [rank1]: AttributeError: 'BloomConfig' object has no attribute 'rope_scaling'

```
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
