### PR TITLE
Add dynamo cache size limit option

### DIFF
--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -103,6 +103,8 @@ class GaudiTrainingArguments(TrainingArguments):
             Set value of 'dynamic' parameter for torch.compile.
         use_regional_compilation (`bool`, *optional*, defaults to `False`):
             Whether to use regional compile with deepspeed
+        cache_size_limit(`int`, *optional*, defaults to 'None'):
+            Set value of 'cache_size_limit' parameter for torch._dynamo.config
         disable_tensor_cache_hpu_graphs (`bool`, *optional*, defaults to `False`):
             Whether to disable tensor cache when using hpu graphs. If True, tensors won't be cached in hpu graph and memory can be saved.
         max_hpu_graphs (`int`, *optional*):
@@ -170,6 +172,11 @@ class GaudiTrainingArguments(TrainingArguments):
     compile_dynamic: Optional[bool | None] = field(
         default=None,
         metadata={"help": ("Set value of 'dynamic' parameter for torch.compile.")},
+    )
+
+    cache_size_limit: Optional[int] = field(
+        default=None,
+        metadata={"help": "Set value of 'cache_size_limit' parameter for torch._dynamo.config."},
     )
 
     use_regional_compilation: Optional[bool] = field(
@@ -871,6 +878,9 @@ class GaudiTrainingArguments(TrainingArguments):
 
         if self.sdp_on_bf16:
             torch._C._set_math_sdp_allow_fp16_bf16_reduction(True)
+
+        if self.torch_compile and self.cache_size_limit is not None:
+            torch._dynamo.config.cache_size_limit = self.cache_size_limit
 
         logger.info("PyTorch: setting up devices")
         if not is_accelerate_available():


### PR DESCRIPTION
# What does this PR do?
The default value of option torch._dynamo.config.cache_size_limit is 8

This default value might be too small, often leading to out-of-memory (OOM) errors when dynamo compiles certain models. We need to an option in optimum-habana to increase this value to prevent OOM.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
