### PR TITLE
add sdp_on_bf16 to controlnet

### DIFF
--- a/examples/stable-diffusion/text_to_image_generation.py
+++ b/examples/stable-diffusion/text_to_image_generation.py
@@ -441,7 +441,7 @@ def main():
     kwargs_call["quant_mode"] = args.quant_mode
 
     # Instantiate a Stable Diffusion pipeline class
-    #import habana_frameworks.torch.core as htcore  # noqa: F401
+    import habana_frameworks.torch.core as htcore  # noqa: F401
 
     if sdxl:
         # SDXL pipelines

--- a/examples/stable-diffusion/text_to_image_generation.py
+++ b/examples/stable-diffusion/text_to_image_generation.py
@@ -441,7 +441,7 @@ def main():
     kwargs_call["quant_mode"] = args.quant_mode
 
     # Instantiate a Stable Diffusion pipeline class
-    import habana_frameworks.torch.core as htcore  # noqa: F401
+    #import habana_frameworks.torch.core as htcore  # noqa: F401
 
     if sdxl:
         # SDXL pipelines

--- a/examples/stable-diffusion/training/train_controlnet.py
+++ b/examples/stable-diffusion/training/train_controlnet.py
@@ -120,6 +120,7 @@ def log_validation(
         use_habana=True,
         use_hpu_graphs=args.use_hpu_graphs,
         gaudi_config=gaudi_config,
+        sdp_on_bf16=args.sdp_on_bf16,
     )
     pipeline.scheduler = UniPCMultistepScheduler.from_config(pipeline.scheduler.config)
     pipeline = pipeline.to(accelerator.device)
@@ -437,6 +438,12 @@ def parse_args(input_args=None):
             'The integration to report the results and logs to. Supported platforms are `"tensorboard"`'
             ' (default), `"wandb"` and `"comet_ml"`. Use `"all"` to report to all integrations.'
         ),
+    )
+    parser.add_argument(
+        "--sdp_on_bf16",
+        action="store_true",
+        default=False,
+        help="Allow pyTorch to use reduced precision in the SDPA math backend",
     )
     parser.add_argument(
         "--bf16",

--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -100,6 +100,7 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
         use_hpu_graphs: bool = False,
         gaudi_config: Union[str, GaudiConfig] = None,
         bf16_full_eval: bool = False,
+        sdp_on_bf16: bool = True,
     ):
         GaudiDiffusionPipeline.__init__(
             self,
@@ -107,6 +108,7 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
             use_hpu_graphs,
             gaudi_config,
             bf16_full_eval,
+            sdp_on_bf16,
         )
 
         StableDiffusionControlNetPipeline.__init__(


### PR DESCRIPTION
add sdp_on_bf16 in train_controlnet script. allows corresponding diffusers CI test to pass.