### PR TITLE
remove argument from save_lora_weights

### DIFF
--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -392,13 +392,14 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
             unet_lora_layers = to_device_dtype(unet_lora_layers, target_device=torch.device("cpu"))
         if text_encoder_lora_layers:
             text_encoder_lora_layers = to_device_dtype(text_encoder_lora_layers, target_device=torch.device("cpu"))
-        if text_encoder_2_lora_layers:
-            text_encoder_2_lora_layers = to_device_dtype(text_encoder_2_lora_layers, target_device=torch.device("cpu"))
+        # TODO: add back text_encoder_2_lora_layers when the correct save_lora_weights function is identified
+        #if text_encoder_2_lora_layers:
+        #    text_encoder_2_lora_layers = to_device_dtype(text_encoder_2_lora_layers, target_device=torch.device("cpu"))
         return super().save_lora_weights(
             save_directory,
             unet_lora_layers,
             text_encoder_lora_layers,
-            text_encoder_2_lora_layers,
+            #text_encoder_2_lora_layers,
             is_main_process,
             weight_name,
             save_function,


### PR DESCRIPTION
In order to resolve below issue when running first command in TRL readme under the ddpo section, remove text_encoder_2_lora_layers as an argument to save_lora_weights



```
Traceback (most recent call last):
  File "/root/optimum-habana/examples/trl/ddpo.py", line 245, in <module>
    trainer.train()
  File "/usr/local/lib/python3.10/dist-packages/trl/trainer/ddpo_trainer.py", line 604, in train
    global_step = self.step(epoch, global_step)
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/trl/trainer/ddpo_trainer.py", line 315, in step
    self.accelerator.save_state()
  File "/usr/local/lib/python3.10/dist-packages/accelerate/accelerator.py", line 2987, in save_state
    hook(self._models, weights, output_dir)
  File "/usr/local/lib/python3.10/dist-packages/trl/trainer/ddpo_trainer.py", line 439, in _save_model_hook
    self.sd_pipeline.save_checkpoint(models, weights, output_dir)
  File "/usr/local/lib/python3.10/dist-packages/trl/models/modeling_sd_base.py", line 883, in save_checkpoint
    self.sd_pipeline.save_lora_weights(save_directory=output_dir, unet_lora_layers=state_dict)
  File "/usr/local/lib/python3.10/dist-packages/optimum/habana/diffusers/pipelines/pipeline_utils.py", line 397, in save_lora_weights
    return super().save_lora_weights(
TypeError: StableDiffusionLoraLoaderMixin.save_lora_weights() takes from 2 to 8 positional arguments but 9 were given
```