### PR TITLE
fix diffuser save_lora_weights crash

### DIFF
--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -381,7 +381,6 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
         save_directory: Union[str, os.PathLike],
         unet_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
         text_encoder_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
-        text_encoder_2_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
         is_main_process: bool = True,
         weight_name: str = None,
         save_function: Callable = None,
@@ -392,13 +391,10 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
             unet_lora_layers = to_device_dtype(unet_lora_layers, target_device=torch.device("cpu"))
         if text_encoder_lora_layers:
             text_encoder_lora_layers = to_device_dtype(text_encoder_lora_layers, target_device=torch.device("cpu"))
-        if text_encoder_2_lora_layers:
-            text_encoder_2_lora_layers = to_device_dtype(text_encoder_2_lora_layers, target_device=torch.device("cpu"))
         return super().save_lora_weights(
             save_directory,
             unet_lora_layers,
             text_encoder_lora_layers,
-            text_encoder_2_lora_layers,
             is_main_process,
             weight_name,
             save_function,


### PR DESCRIPTION
fix crash in train_dreambooth_lora_sdxl.py in save_lora_weights
python ../../gaudi_spawn.py --world_size 8 --use_mpi train_dreambooth_lora_sdxl.py   --pretrained_model_name_or_path="stabilityai/stable-diffusion-xl-base-1.0"    --instance_data_dir="dog"   --pretrained_vae_model_name_or_path="madebyollin/sdxl-vae-fp16-fix"   --output_dir="lora-trained-xl"   --mixed_precision="bf16"   --instance_prompt="a photo of sks dog"   --resolution=1024   --train_batch_size=1   --gradient_accumulation_steps=4   --learning_rate=1e-4   --lr_scheduler="constant"   --lr_warmup_steps=0   --max_train_steps=100   --validation_prompt="A photo of sks dog in a bucket"   --validation_epochs=25   --seed=0   --use_hpu_graphs_for_inference   --use_hpu_graphs_for_training   --gaudi_config_name Habana/stable-diffusion