### PR TITLE
Fix `save_lora_weights` in `pipeline_utils.py`

### DIFF
--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -28,10 +28,10 @@ from diffusers.utils.hub_utils import load_or_create_model_card, populate_model_
 from diffusers.utils.torch_utils import is_compiled_module
 from huggingface_hub import create_repo
 
-from optimum.habana.utils import to_device_dtype
 from optimum.utils import logging
 
 from ...transformers.gaudi_configuration import GaudiConfig
+from ...utils import to_device_dtype
 
 
 logger = logging.get_logger(__name__)
@@ -396,7 +396,8 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
             text_encoder_2_lora_layers = to_device_dtype(text_encoder_2_lora_layers, target_device=torch.device("cpu"))
 
         # text_encoder_2_lora_layers is only supported by some diffuser pipelines
-        if text_encoder_2_lora_layers:
+        signature = inspect.signature(super().save_lora_weights)
+        if "text_encoder_2_lora_layers" in signature.parameters:
             return super().save_lora_weights(
                 save_directory,
                 unet_lora_layers,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

https://github.com/huggingface/optimum-habana/pull/1626 introduced a condition check on whether `text_encoder_2_lora_layers` is None or not and then call `save_lora_weights` in different ways: https://github.com/huggingface/optimum-habana/pull/1626/files#diff-bfc760c4e8acf1425990d609ecd6f1cadb2e027a0d20f027f652375f012e484dR399

However, `text_encoder_2_lora_layers` can be None and still be passed as an argument to `save_lora_weights`, as shown with SDXL in https://github.com/huggingface/optimum-habana/pull/1633#issuecomment-2553393043.

This PR changes the check so that `text_encoder_2_lora_layers` is passed if and only if it is part of the signature of `save_lora_weights`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
