### PR TITLE
Update baseline number for vit-base-patch16-224-in21k on G1 and G2

### DIFF
--- a/tests/baselines/vit_base_patch16_224_in21k.json
+++ b/tests/baselines/vit_base_patch16_224_in21k.json
@@ -8,24 +8,8 @@
                     "learning_rate": 5e-5,
                     "train_batch_size": 64,
                     "eval_accuracy": 0.9812,
-                    "train_runtime": 136.9418,
-                    "train_samples_per_second": 359.584,
-                    "extra_arguments": [
-                        "--remove_unused_columns False",
-                        "--image_column_name img",
-                        "--seed 1337",
-                        "--use_hpu_graphs_for_inference",
-                        "--dataloader_num_workers 1",
-                        "--pipelining_fwd_bwd True",
-                        "--non_blocking_data_copy True"
-                    ]
-                },
-                "multi_card": {
-                    "learning_rate": 2e-4,
-                    "train_batch_size": 64,
-                    "eval_accuracy": 0.9803,
-                    "train_runtime": 59.972,
-                    "train_samples_per_second": 2508.955,
+                    "train_runtime": 166.79,
+                    "train_samples_per_second": 278.8,
                     "extra_arguments": [
                         "--remove_unused_columns False",
                         "--image_column_name img",
@@ -34,7 +18,25 @@
                         "--dataloader_num_workers 1",
                         "--pipelining_fwd_bwd True",
                         "--non_blocking_data_copy True",
-                        "--throughput_warmup_steps 10"
+                        "--sdp_on_bf16"
+                    ]
+                },
+                "multi_card": {
+                    "learning_rate": 2e-4,
+                    "train_batch_size": 64,
+                    "eval_accuracy": 0.9803,
+                    "train_runtime": 59.25,
+                    "train_samples_per_second": 1980.284,
+                    "extra_arguments": [
+                        "--remove_unused_columns False",
+                        "--image_column_name img",
+                        "--seed 1337",
+                        "--use_hpu_graphs_for_inference",
+                        "--dataloader_num_workers 1",
+                        "--pipelining_fwd_bwd True",
+                        "--non_blocking_data_copy True",
+                        "--throughput_warmup_steps 10",
+                        "--sdp_on_bf16"
                     ]
                 }
             }
@@ -49,24 +51,8 @@
                     "learning_rate": 3e-5,
                     "train_batch_size": 128,
                     "eval_accuracy": 0.9690666666666666,
-                    "train_runtime": 54.9734,
-                    "train_samples_per_second": 870.272,
-                    "extra_arguments": [
-                        "--remove_unused_columns False",
-                        "--image_column_name img",
-                        "--seed 1337",
-                        "--use_hpu_graphs_for_inference",
-                        "--dataloader_num_workers 1",
-                        "--pipelining_fwd_bwd True",
-                        "--non_blocking_data_copy True"
-                    ]
-                },
-                "multi_card": {
-                    "learning_rate": 2e-4,
-                    "train_batch_size": 128,
-                    "eval_accuracy": 0.9679,
-                    "train_runtime": 23.99,
-                    "train_samples_per_second": 6718.643,
+                    "train_runtime": 60.93758,
+                    "train_samples_per_second": 773.5714,
                     "extra_arguments": [
                         "--remove_unused_columns False",
                         "--image_column_name img",
@@ -75,7 +61,25 @@
                         "--dataloader_num_workers 1",
                         "--pipelining_fwd_bwd True",
                         "--non_blocking_data_copy True",
-                        "--throughput_warmup_steps 8"
+                        "--sdp_on_bf16"
+                    ]
+                },
+                "multi_card": {
+                    "learning_rate": 2e-4,
+                    "train_batch_size": 128,
+                    "eval_accuracy": 0.9679,
+                    "train_runtime": 28.217,
+                    "train_samples_per_second": 6349.804,
+                    "extra_arguments": [
+                        "--remove_unused_columns False",
+                        "--image_column_name img",
+                        "--seed 1337",
+                        "--use_hpu_graphs_for_inference",
+                        "--dataloader_num_workers 1",
+                        "--pipelining_fwd_bwd True",
+                        "--non_blocking_data_copy True",
+                        "--throughput_warmup_steps 8",
+                        "--sdp_on_bf16"
                     ]
                 }
             }


### PR DESCRIPTION
# What does this PR do?

Resolve test case failure observed for model vit-base-patch16-224-in21k with PyTorch 2.5 version

PR does the follow:
1. Updates G1 and G2 baseline performance numbers of the model vit-base-patch16-224-in21k 
2. Add an extra parameter --sdp_on_bf16 for the tests 

( Referenced the implementation of --sdp_on_bf16 from the related pull request : https://github.com/huggingface/optimum-habana/pull/1555 )


Test Results : 

tests/test_examples.py::ImageClassificationExampleTester::test_run_image_classification_vit-base-patch16-224-in21k_single_card
tests/test_examples.py::ImageClassificationExampleTester::test_run_image_classification_vit-base-patch16-224-in21k_multi_card

**Gaudi 1 single and multi card**
PASSED
1 passed, 33 deselected in 205.85s (0:03:25)
PASSED
1 passed, 33 deselected in 126.20s (0:02:06)

**Gaudi 2 single and multi card**
PASSED
 1 passed, 69 deselected in 91.75s (0:01:31)
PASSED
 1 passed, 69 deselected in 57.03s 


**-make style**
ruff check . setup.py --fix
All checks passed!
ruff format . setup.py
410 files left unchanged


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
