### PR TITLE
Added missing parameter for llama function call

### DIFF
--- a/examples/pytorch-image-models/README.md
+++ b/examples/pytorch-image-models/README.md
@@ -51,7 +51,7 @@ Here we show how to fine-tune the [imagenette2-320 dataset](https://huggingface.
 ```bash
 python train_hpu_lazy.py \
     --data-dir ./ \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device 'hpu' \
     --model resnet50.a1_in1k \
     --train-split train \
@@ -65,7 +65,7 @@ python train_hpu_lazy.py --data-dir='./' --dataset hfds/johnowhitaker/imagenette
 ```bash
 python train_hpu_graph.py \
     --data-dir ./ \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device 'hpu' \
     --model resnet50.a1_in1k \
     --train-split train \
@@ -98,7 +98,7 @@ Here we show how to fine-tune the [imagenette2-320 dataset](https://huggingface.
 torchrun --nnodes 1 --nproc_per_node 2 \
     train_hpu_lazy.py \
     --data-dir ./ \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device 'hpu' \
     --model resnet50.a1_in1k \
     --train-split train \
@@ -111,7 +111,7 @@ torchrun --nnodes 1 --nproc_per_node 2 \
 torchrun --nnodes 1 --nproc_per_node 2 \
     train_hpu_graph.py \
     --data-dir ./ \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device 'hpu' \
     --model resnet50.a1_in1k \
     --train-split train \
@@ -142,7 +142,7 @@ Here we show how to fine-tune the [imagenette2-320 dataset](https://huggingface.
 ```bash
 python inference.py \
     --data-dir='./' \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device='hpu' \
     --model resnet50.a1_in1k \
     --split train \
@@ -153,7 +153,7 @@ python inference.py \
 ```bash
 python inference.py \
     --data-dir='./' \
-    --dataset hfds/johnowhitaker/imagenette2-320 \    
+    --dataset hfds/johnowhitaker/imagenette2-320 \
     --device='hpu' \
     --model resnet50.a1_in1k \
     --split train

--- a/examples/trl/README.md
+++ b/examples/trl/README.md
@@ -362,6 +362,9 @@ python ddpo.py \
   --hf_hub_model_id="ddpo-finetuned-stable-diffusion" \
   --push_to_hub False
 ```
+> [!NOTE]
+> Due to a known issue on Gaudi3, sample_batch_sizes should be changed to 3. It will be fixed in the future release.
+
 
 2. Inference using the fine-tuned LoRA weights as shown in the example below:
 ```python

--- a/examples/trl/README.md
+++ b/examples/trl/README.md
@@ -363,7 +363,7 @@ python ddpo.py \
   --push_to_hub False
 ```
 > [!NOTE]
-> Due to a known issue on Gaudi3, sample_batch_sizes should be changed to 3. It will be fixed in the future release.
+> Due to a known issue on Gaudi3, sample_batch_sizes should be changed to 3. The issue will be fixed in the future release.
 
 
 2. Inference using the fine-tuned LoRA weights as shown in the example below:

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -634,7 +634,7 @@ class GaudiLlamaAttention(LlamaAttention):
             )
             position_ids = position_ids.unsqueeze(0)
 
-        query_states, key_states = apply_customized_rope(query_states, key_states, cos, sin, position_ids)
+        query_states, key_states = apply_customized_rope(query_states, key_states, cos, sin, position_ids, self.training)
 
         if use_cache:
             # reuse k, v, self_attention


### PR DESCRIPTION
# What does this PR do?
From PR https://github.com/huggingface/optimum-habana/pull/1148, we need 'training' parameter set for apply_customized_rope(). Otherwise it's True by default.
But when apply_customized_rope() is called in modling_llama, we don't set it.
I think it's missed by mistake. Other model files are updated properly.
 
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
