### PR TITLE
fix bug when preparing quant files, starcoder model does not support

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -118,8 +118,17 @@ class HabanaModelAdapter(lm_eval.base.BaseLM):
                     "reuse_cache": self.options.reuse_cache,
                 }
             )
-        if self.model.config.model_type in ["llama", "mistral", "qwen2", "falcon", "starcoder2", "gemma", "baichuan"]:
-            if self.model.config.model_type != "falcon":
+        if self.model.config.model_type in [
+            "llama",
+            "mistral",
+            "qwen2",
+            "falcon",
+            "starcoder2",
+            "gemma",
+            "baichuan",
+            "gpt_bigcode",
+        ]:
+            if self.model.config.model_type not in ["falcon", "gpt_bigcode"]:
                 self.model_inputs.update(
                     {
                         "attn_softmax_bf16": self.options.attn_softmax_bf16,

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -137,11 +137,12 @@ class HabanaModelAdapter(lm_eval.base.BaseLM):
             self.model_inputs.update(
                 {
                     "use_flash_attention": self.options.use_flash_attention,
-                    "flash_attention_fast_softmax": self.options.flash_attention_fast_softmax,
                     "flash_attention_recompute": self.options.flash_attention_recompute,
                     "flash_attention_causal_mask": self.options.flash_attention_causal_mask,
                 }
             )
+            if self.model.config.model_type in ["llama", "qwen2", "baichuan", "gpt_bigcode"]:
+                self.model_inputs.update({"flash_attention_fast_softmax": self.options.flash_attention_fast_softmax})
         if args.warmup:
             self.warm_up()
 

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -137,6 +137,7 @@ class HabanaModelAdapter(lm_eval.base.BaseLM):
             self.model_inputs.update(
                 {
                     "use_flash_attention": self.options.use_flash_attention,
+                    "flash_attention_fast_softmax": self.options.flash_attention_fast_softmax,
                     "flash_attention_recompute": self.options.flash_attention_recompute,
                     "flash_attention_causal_mask": self.options.flash_attention_causal_mask,
                 }


### PR DESCRIPTION
When generate FP8 quant files for model `bigcode/starcoder`, even we add `--use_flash_attention` flag, it can not pass to modeling part. This PR fixes it.