### PR TITLE
Remove the workaround

### DIFF
--- a/optimum/habana/diffusers/models/unet_2d_condition.py
+++ b/optimum/habana/diffusers/models/unet_2d_condition.py
@@ -213,7 +213,6 @@ def gaudi_unet_2d_condition_model_forward(
         encoder_hidden_states = (encoder_hidden_states, image_embeds)
 
     # 2. pre-process
-    import habana_frameworks.torch.hpu as hthpu
 
     sample = self.conv_in(sample)
 

--- a/optimum/habana/diffusers/models/unet_2d_condition.py
+++ b/optimum/habana/diffusers/models/unet_2d_condition.py
@@ -215,15 +215,7 @@ def gaudi_unet_2d_condition_model_forward(
     # 2. pre-process
     import habana_frameworks.torch.hpu as hthpu
 
-    # Workaround for SynapseAI 1.11 for Torch Autocast
-    # TODO: to remove in SynapseAI 1.13?
-    if hthpu.is_autocast_hpu_enabled():
-        sample = self.conv_in(sample.to(torch.float))
-    # Workaround for Synapse 1.11 for full bf16
-    elif self.conv_in.bias.dtype == torch.float and sample.dtype == torch.bfloat16:
-        sample = self.conv_in(sample.to(torch.float)).to(torch.bfloat16)
-    else:
-        sample = self.conv_in(sample)
+    sample = self.conv_in(sample)
 
     # 2.5 GLIGEN position net
     if cross_attention_kwargs is not None and cross_attention_kwargs.get("gligen", None) is not None:

--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -159,14 +159,7 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
                 )
 
             if self.gaudi_config.use_torch_autocast:
-                if bf16_full_eval:
-                    logger.warning(
-                        "`use_torch_autocast` is True in the given Gaudi configuration but "
-                        "`torch_dtype=torch.bfloat16` was given. Disabling mixed precision and continuing in bf16 only."
-                    )
-                    self.gaudi_config.use_torch_autocast = False
-                else:
-                    self.gaudi_config.declare_autocast_bf16_fp32_ops()
+                self.gaudi_config.declare_autocast_bf16_fp32_ops()
 
             # Workaround for Synapse 1.11 for full bf16 and Torch Autocast
             if bf16_full_eval or self.gaudi_config.use_torch_autocast:

--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -158,9 +158,6 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
                     f"`gaudi_config` must be a string or a GaudiConfig object but is {type(gaudi_config)}."
                 )
 
-            if self.gaudi_config.use_torch_autocast:
-                self.gaudi_config.declare_autocast_bf16_fp32_ops()
-
             if bf16_full_eval or self.gaudi_config.use_torch_autocast:
                 import diffusers
 

--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -161,7 +161,6 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
             if self.gaudi_config.use_torch_autocast:
                 self.gaudi_config.declare_autocast_bf16_fp32_ops()
 
-            # Workaround for Synapse 1.11 for full bf16 and Torch Autocast
             if bf16_full_eval or self.gaudi_config.use_torch_autocast:
                 import diffusers
 

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -366,7 +366,7 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
                 "Passing `callback_steps` as an input argument to `__call__` is deprecated, consider use `callback_on_step_end`",
             )
 
-        with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=self.gaudi_config.use_torch_autocast):
+        with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=(self.dtype != torch.float)):
             # 0. Default height and width to unet
             height = height or self.unet.config.sample_size * self.vae_scale_factor
             width = width or self.unet.config.sample_size * self.vae_scale_factor

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -460,7 +460,7 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
                 "Passing `callback_steps` as an input argument to `__call__` is deprecated, consider use `callback_on_step_end`",
             )
 
-        with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=self.gaudi_config.use_torch_autocast):
+        with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=(self.dtype != torch.float)):
             # 0. Default height and width to unet
             height = height or self.unet.config.sample_size * self.vae_scale_factor
             width = width or self.unet.config.sample_size * self.vae_scale_factor

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -4356,7 +4356,6 @@ class PipelineTesterMixin:
         pipe = self.pipeline_class(**init_components)
         init_components.pop("use_habana")
         init_components.pop("use_hpu_graphs")
-        init_components.pop("bf16_full_eval")
         init_components.pop("gaudi_config")
 
         self.assertTrue(hasattr(pipe, "components"))
@@ -5624,7 +5623,6 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         init_components.pop("requires_aesthetics_score")
         init_components.pop("use_habana")
         init_components.pop("use_hpu_graphs")
-        init_components.pop("bf16_full_eval")
         init_components.pop("gaudi_config")
         pipe = self.pipeline_class(**init_components)
         self.assertTrue(hasattr(pipe, "components"))

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -5663,7 +5663,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         expected_slice = np.array([0.6611, 0.5569, 0.5531, 0.5471, 0.5918, 0.6393, 0.5074, 0.5468, 0.5185])
 
-        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-1
 
     def test_stable_diffusion_xl_inpaint_euler_lcm_custom_timesteps(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -5682,7 +5682,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         expected_slice = np.array([0.6611, 0.5569, 0.5531, 0.5471, 0.5918, 0.6393, 0.5074, 0.5468, 0.5185])
 
-        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-1
 
     def test_attention_slicing_forward_pass(self):
         super().test_attention_slicing_forward_pass(expected_max_diff=3e-3)
@@ -5731,7 +5731,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         image_slice_2 = output.images[0, -3:, -3:, -1]
 
         # make sure that it's equal
-        assert np.abs(image_slice_1.flatten() - image_slice_2.flatten()).max() < 1e-4
+        assert np.abs(image_slice_1.flatten() - image_slice_2.flatten()).max() < 1e-2
 
     def test_stable_diffusion_xl_refiner(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -6086,7 +6086,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         torch.randn((1, 4, 32, 32), generator=generator)
         inputs["generator"] = generator
         out_1 = sd_pipe(**inputs).images
-        assert np.abs(out_0 - out_1).max() < 1e-2
+        assert np.abs(out_0 - out_1).max() < 1.5
 
     def test_stable_diffusion_xl_inpaint_2_images(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -5663,7 +5663,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         expected_slice = np.array([0.6611, 0.5569, 0.5531, 0.5471, 0.5918, 0.6393, 0.5074, 0.5468, 0.5185])
 
-        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-1
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
     def test_stable_diffusion_xl_inpaint_euler_lcm_custom_timesteps(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -5682,7 +5682,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         expected_slice = np.array([0.6611, 0.5569, 0.5531, 0.5471, 0.5918, 0.6393, 0.5074, 0.5468, 0.5185])
 
-        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-1
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
     def test_attention_slicing_forward_pass(self):
         super().test_attention_slicing_forward_pass(expected_max_diff=3e-3)
@@ -5731,7 +5731,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         image_slice_2 = output.images[0, -3:, -3:, -1]
 
         # make sure that it's equal
-        assert np.abs(image_slice_1.flatten() - image_slice_2.flatten()).max() < 1e-2
+        assert np.abs(image_slice_1.flatten() - image_slice_2.flatten()).max() < 1e-4
 
     def test_stable_diffusion_xl_refiner(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -6086,7 +6086,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         torch.randn((1, 4, 32, 32), generator=generator)
         inputs["generator"] = generator
         out_1 = sd_pipe(**inputs).images
-        assert np.abs(out_0 - out_1).max() < 1.5
+        assert np.abs(out_0 - out_1).max() < 1e-2
 
     def test_stable_diffusion_xl_inpaint_2_images(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -5128,7 +5128,6 @@ class StableDiffusionInpaintPipelineFastTests(
             "use_habana": True,
             "use_hpu_graphs": True,
             "gaudi_config": "Habana/stable-diffusion-2",
-            "bf16_full_eval": True,
         }
         return components
 
@@ -5558,7 +5557,6 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
             "use_habana": True,
             "use_hpu_graphs": True,
             "gaudi_config": "Habana/stable-diffusion",
-            "bf16_full_eval": True,
         }
         return components
 


### PR DESCRIPTION
# What does this PR do?
Fixed the SD examples failed on Gauid2D.
For Gaudi2D, MME cannot support the FP32 data type. It needs the autocast feature. Remove the workaround for Synapse 1.11. It should be replaced by using the autocast.


Traceback (most recent call last):
  File "/root/optimum-habana/examples/stable-diffusion/text_to_image_generation.py", line 704, in <module>
    main()
  File "/root/optimum-habana/examples/stable-diffusion/text_to_image_generation.py", line 667, in main
    outputs = pipeline(prompt=args.prompts, **kwargs_call)
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/root/optimum-habana/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 536, in __call__
    noise_pred = self.unet_hpu(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/root/optimum-habana/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 676, in unet_hpu
    return self.unet(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/optimum-habana/optimum/habana/diffusers/models/unet_2d_condition.py", line 224, in gaudi_unet_2d_condition_model_forward
    sample = self.conv_in(sample.to(torch.float)).to(torch.bfloat16)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/conv.py", line 554, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/conv.py", line 549, in _conv_forward
    return F.conv2d(
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 75, in __torch_function__
    return super().__torch_function__(func, types, new_args, kwargs)
RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_BRIDGE Exception in Launch thread...
Check $HABANA_LOGS/ for detailssynNodeCreateWithId failed for node: spatial_convolution with synStatus 26 [Generic failure]. .
[Rank:0] Habana exception raised from add_node at graph.cpp:509  


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
