### PR TITLE
Fix mpt model generation

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -610,6 +610,12 @@ def setup_tokenizer(args, model, assistant_model, logger):
         )
         model.generation_config.eos_token_id = model.generation_config.eos_token_id[-1]
 
+    if model.config.model_type == "mpt":
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        if model.generation_config.pad_token_id is None:
+            model.generation_config.pad_token_id = tokenizer.eos_token_id
+
     # Some models like GPT2 do not have a PAD token so we have to set it if necessary
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
Fixes # (issue)

python run_generation.py --model_name_or_path mosaicml/mpt-7b-chat --use_hpu_graphs --use_kv_cache --bf16 --batch_size=1

File "/optimum-habana/examples/text-generation/run_generation.py", line 773, in <module>
  main()
File "/optimum-habana/examples/text-generation/run_generation.py", line 533, in main
  generate(None, args.reduce_recompile)
File "/optimum-habana/examples/text-generation/run_generation.py", line 504, in generate
  outputs = model.generate(
File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
  return func(*args, **kwargs)
File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/generation/utils.py", line 997, in generate
  generation_config, model_kwargs = self._prepare_generation_config(generation_config, **kwargs)
File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/generation/utils.py", line 734, in _prepare_generation_config
  model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs
File "/usr/local/lib/python3.10/dist-packages/transformers/generation/configuration_utils.py", line 1282, in update
  self.validate()
File "/usr/local/lib/python3.10/dist-packages/transformers/generation/configuration_utils.py", line 578, in validate
  if self.pad_token_id is not None and self.pad_token_id < 0:
TypeError: '<' not supported between instances of 'list' and 'int'