### PR TITLE
update audio-classification/requirements.txt to fix numpy version con…

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,3 +1,4 @@
-numpy==1.24.0
+datasets>=1.14.0
 evaluate
+numba==0.60.0
 librosa

--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,3 +1,3 @@
-datasets>=1.14.0
+numpy==1.24.0
 evaluate
 librosa

--- a/examples/speech-recognition/requirements.txt
+++ b/examples/speech-recognition/requirements.txt
@@ -1,4 +1,5 @@
 datasets >= 1.18.0, <= 2.19.2
+numba==0.60.0
 librosa
 jiwer
 evaluate


### PR DESCRIPTION
numpy version conflicts fix for audio-classification

librosa installs numba latest which got upgraded recently and causes latest numpy to be installed. This causes a break in our runs in both released 1.19 versions and newer versions.

this change specificies the workign version of numba so that it doesnt upgrade numpy.