### PR TITLE
Fix: Adjust recipe to fit within QueueComputeScal HBM global memory size limit

### DIFF
--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -695,7 +695,7 @@ class GaudiMllamaTextModel(MllamaTextModel):
 
         for idx, decoder_layer in enumerate(self.layers):
             if not self.training and (
-                torch.distributed.is_initialized() is False or torch.distributed.get_world_size() == 1
+                not torch.distributed.is_initialized() or torch.distributed.get_world_size() == 1
             ):
                 htcore.mark_step()
             if output_hidden_states:

--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -694,6 +694,10 @@ class GaudiMllamaTextModel(MllamaTextModel):
         next_decoder_cache = None if isinstance(past_key_values, Cache) else ()
 
         for idx, decoder_layer in enumerate(self.layers):
+            if not self.training and (
+                torch.distributed.is_initialized() is False or torch.distributed.get_world_size() == 1
+            ):
+                htcore.mark_step()
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 


### PR DESCRIPTION
The recipe's global HBM memory size (78,888,400) exceeds the QueueComputeScal HBM global memory size limit (67,108,864). Adjusted the recipe to ensure it fits within the required constraints.

command to reproduce the issue 
BS=16;TKI=1024;TKO=1024;python3 examples/image-to-text/run_pipeline.py --model_name_or_path /mnt/weka/data/pytorch/llama3.2/Meta-Llama-3.2-11B-Vision-Instruct/  --bf16 --use_hpu_graphs --use_flash_attention --flash_attention_recompute --batch_size=${BS} --max_input_tokens ${TKI} --max_new_tokens ${TKO} 


Error:
  File "/software/users/kkumar/work/optimum-habana-fork/optimum/habana/transformers/generation/utils.py", line 1439, in generate
    result = self._sample(
  File "/software/users/kkumar/work/optimum-habana-fork/optimum/habana/transformers/generation/utils.py", line 2556, in _sample
    model_kwargs = self._update_model_kwargs_for_generation(
  File "/software/users/kkumar/work/optimum-habana-fork/optimum/habana/transformers/models/mllama/modeling_mllama.py", line 1167, in _update_model_kwargs_for_generation
    mask = cross_attention_mask_prev[:, token_idx - 2 : token_idx - 1, ...]
RuntimeError: Graph compile failed. synStatus=synStatus 26 [Generic failure].

synapse_runtime.log:

recipe global hbm memory size 78888400 exceeds QueueComputeScal hbm global memory size for recipe 67108864
process: Can't verifyRecipe 0[synSuccess]
processRecipe: DeviceAgnosticRecipeProcessor failed processing 0x55fda381b100
addRecipeHandleAndCompileGraph: processRecipe failed 0x55fda381b100
compileGraph: Failed to add recipe handle into Recipe-Singleton status 26[synFail]
synGraphCompile: SYN_API_CALL failed status: 26[synFail]. graphHandle 0x55fdd26bb3c8
synDeviceRelease, status 0[synSuccess]
synDestroy, status 0[synSuccess]

