### PR TITLE
Process getting killed while loading data for Llama3.2 90b, 8x

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -192,6 +192,8 @@ def main():
     os.environ.setdefault("EXPERIMENTAL_WEIGHT_SHARING", "FALSE")
     if args.world_size > 0:
         os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")
+        os.environ.setdefault("DEEPSPEED_USE_HABANA_FRAMEWORKS_DETERMINISTIC_API", "1")
+
 
     from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 

--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -194,7 +194,6 @@ def main():
         os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")
         os.environ.setdefault("DEEPSPEED_USE_HABANA_FRAMEWORKS_DETERMINISTIC_API", "1")
 
-
     from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
     adapt_transformers_to_gaudi()


### PR DESCRIPTION
Setting DEEPSPEED_USE_HABANA_FRAMEWORKS_DETERMINISTIC_API=1 solves the data loading issue.