### PR TITLE
Fix for image2text lora llama test

### DIFF
--- a/tests/baselines/Llama_3_2_11B_Vision_Instruct.json
+++ b/tests/baselines/Llama_3_2_11B_Vision_Instruct.json
@@ -1,13 +1,13 @@
 {
     "gaudi2": {
         "image2text_lora_finetune": {
-            "num_train_epochs": 2,
+            "num_train_epochs": 1,
             "eval_batch_size": 4,
             "distribution": {
                 "multi_card": {
                     "learning_rate": 5e-5,
                     "train_batch_size": 2,
-                    "train_runtime": 470,
+                    "train_runtime": 350,
                     "train_samples_per_second": 20.48,
                     "eval_accuracy": 0.6,
                     "extra_arguments": [


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
Following test `python -m pytest -s -v tests/test_examples.py -k test_run_image2text_lora_finetune_Llama-3.2-11B-Vision-Instruct_multi_card
` fails on transformers_future but passes on main:
```
tests/test_examples.py:758: in assert_no_regression
    assert_function(
E   AssertionError: 18.229 not greater than or equal to 19.456 : for metric train_samples_per_second. 
E   ===== Assessed metrics (measured vs thresholded baseline) =====
E   eval_accuracy: 0.9252059885818973 vs 0.594
E   train_runtime: 396.1691 vs 493.5
E   train_samples_per_second: 18.229 vs 19.456
=========================== short test summary info ============================
FAILED tests/test_examples.py::MultiCardImageToTextModelingLoRAExampleTester::test_run_image2text_lora_finetune_Llama-3.2-11B-Vision-Instruct_multi_card
```

After updating test baseline per main:
```
***** train metrics *****
  epoch                       =     0.8889
  max_memory_allocated (GB)   =      82.72
  memory_allocated (GB)       =      47.26
  total_flos                  = 25883935GF
  total_memory_available (GB) =      94.62
  train_loss                  =     1.9462
  train_runtime               = 0:05:39.18
  train_samples_per_second    =     19.483
  train_steps_per_second      =      0.127
01/27/2025 20:05:02 - INFO - __main__ -   generated: ['\n\nBengaluru']
100%|██████████| 50/50 [02:01<00:00,  2.43s/it]
***** eval metrics *****
  eval_accuracy = 0.8919
PASSED

========================================================== 1 passed, 69 deselected in 545.38s (0:09:05) =========================================================
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
