### PR TITLE
Fix formatting of the kubeVersion range in Kubernetes helm chart

### DIFF
--- a/examples/kubernetes/Chart.yaml
+++ b/examples/kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: optimum-habana-example-chart
 description: This Helm chart deploys example jobs using Optimum for Intel® Gaudi® Accelerators to a Kubernetes cluster.
 
 # Compatible Kubernetes versions
-kubeVersion: 1.27-1.29
+kubeVersion: 1.27 - 1.29
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.


### PR DESCRIPTION
# What does this PR do?

This PR fixes the formatting of the `kubeVersion` in the Kubernetes example helm chart. Without this change, the helm chart fails to install when using Kubernetes v1.28:
```
Error: INSTALLATION FAILED: chart requires kubeVersion: 1.27-1.29 which is incompatible with Kubernetes v1.28.7
```
Formatting the range with spaces around the `-` has fixed the issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
There are no automated tests for this, but I manually tested with Kubernetes v1.28.7 using the single card glue fine tuning example.
