### PR TITLE
Resolve 'NoneType' object has no attribute 'gate_proj' err when applying EP in DeepSeek-V2

### DIFF
--- a/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -669,13 +669,16 @@ class DeepseekV2MoE(nn.Module):
             for idx in range(self.expert_slice):
                 experts_range = range(self.expert_chunk)
                 gate_proj_list = [
-                    self.experts[idx * self.expert_chunk + i].gate_proj.weight.squeeze() for i in experts_range
+                    self.experts[idx * self.expert_chunk + i].gate_proj.weight.squeeze()
+                    for i in experts_range if self.experts[idx * self.expert_chunk + i] is not None
                 ]
                 down_proj_list = [
-                    self.experts[idx * self.expert_chunk + i].down_proj.weight.squeeze() for i in experts_range
+                    self.experts[idx * self.expert_chunk + i].down_proj.weight.squeeze()
+                    for i in experts_range if self.experts[idx * self.expert_chunk + i] is not None
                 ]
                 up_proj_list = [
-                    self.experts[idx * self.expert_chunk + i].up_proj.weight.squeeze() for i in experts_range
+                    self.experts[idx * self.expert_chunk + i].up_proj.weight.squeeze()
+                    for i in experts_range if self.experts[idx * self.expert_chunk + i] is not None
                 ]
 
                 hidden_states_slice = torch.ops.hpu.mixture_of_experts(


### PR DESCRIPTION
Resolve the error of no gate_proj attribute during the Expert Parallelism of DeepSeek-V2

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

Currently, EP doesn't work in the latest OH main. It fails with the following error
```
[rank3]:     self.experts[idx * self.expert_chunk + i].gate_proj.weight.squeeze() for i in experts_range
[rank3]: AttributeError: 'NoneType' object has no attribute 'gate_proj'
```
This PR will resolve the Error by skipping the NonType object

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
