### PR TITLE
Update README.md - correction in diffusers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ model_name = "CompVis/stable-diffusion-v1-4"
 +   gaudi_config="Habana/stable-diffusion",
 )
 
-outputs = generator(
+outputs = pipeline(
     ["An image of a squirrel in Picasso style"],
     num_images_per_prompt=16,
 +   batch_size=4,


### PR DESCRIPTION
in the Diffusers example, the ouputs= called "generator" function which is not defined in the example. Replacing with the "pipeline" object works

# What does this PR do?



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
