### PR TITLE
Add _prepare_inputs_for_generation

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -312,6 +312,9 @@ def adapt_transformers_to_gaudi():
     transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2SdpaAttention = GaudiWav2Vec2SdpaAttention
 
     # Generation is modified to run faster in lazy mode
+    transformers.generation.GenerationMixin.prepare_inputs_for_generation = (
+        GaudiGenerationMixin._prepare_inputs_for_generation
+    )
     transformers.generation.GenerationMixin.generate = GaudiGenerationMixin.generate
     transformers.generation.GenerationMixin._update_model_kwargs_for_generation = (
         GaudiGenerationMixin._update_model_kwargs_for_generation


### PR DESCRIPTION
# What does this PR do?

This PR addresses an issue with upgrade to transformers 4.48.2

- Added _prepare_inputs_for_generation overwriting GenerationMixin.prepare_inputs_for_generation to remove unused keys
- Added custom logic to filter out keys not used in the forward method

```sh
>>> GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/roberta/ -s -v -k test_greedy_generate_dict_outputs

FAILED tests/transformers/tests/models/roberta/test_modeling_roberta.py::RobertaModelTest::test_contrastive_generate_low_memory - TypeError: RobertaForCausalLM.forward() got an unexpected keyword argument 'bucket_size'
```

The issue arises from a recent upgrade in the Transformers library, which revises the GenerationMixin.prepare_inputs_for_generation method to better handle models. This update also removes the function from most decoder-only language models. Some details are mentioned in https://github.com/huggingface/transformers/pull/33870

With this PR

```sh
>>> GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/roberta/ -s -v -k test_greedy_generate_dict_outputs
3 passed, 89 deselected, 3 warnings in 10.77s

>>> GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/roberta/ -v
1 failed, 71 passed, 20 skipped, 9 warnings in 95.23s (0:01:35)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
