### PR TITLE
Accuracy fix for llama3.1-70B in eager/torch.compile mode

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -136,7 +136,8 @@ class GaudiLlamaRotaryEmbedding(torch.nn.Module):
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
         self.max_seq_len_cached = seq_len
-        t = torch.arange(self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype)
+        # Use torch.int32 to avoid loss due to low precision with BF16 (refer to SW-215204)
+        t = torch.arange(self.max_seq_len_cached, device=device, dtype=torch.int32)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation


### PR DESCRIPTION
**Issue**: Low accuracy in Llama3.1-70B with eager/torch.compile mode

(Following details extracted from https://github.com/huggingface/transformers/issues/28685)
Use a number of transformers models that utilize arange for integer enumerations in the calculation of position embeddings with DeepSpeed zero.Init() and a low precision dtype (float16, bfloat16), and the generated embeddings will differ significantly from intended.
 
1) Using Llama as an example
t = torch.arange(self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype)
The inv_freq.dtype == float32. Single precision float can cover the required integer range for the enumeration (I believe it's in the 2k-8k range for Llama?).
 
2) However, when DeepSpeed zero.Init is used the init function patching will override the float dtype passed in with a low precision float dtype, so float32 -> bfloat16 or float16. Thus the integer range that can be represented without significant loss drops down to 256 for bfloat16 or 2048 for float16. [DeepSpeed's patching](https://github.com/habana-internal/deepspeed-fork/blob/master_next/deepspeed/runtime/zero/partition_parameters.py#L256-L257) has an exception for integer dtype, it will not cast arange to the low precision float dtype if arange dtype is an int type.
 
**Fix: Simply set the dtype as torch.int32 for torch.arange**.

torch.int64 is not used because it generates incorrect values (and corresponding JIT_IR graph is not as expected).
