### PR TITLE
fix the output length in image_to_text test to make sure the outpu…

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -388,7 +388,12 @@ def main():
     n_output_tokens = 0
     for sequence in result:
         # We have to subtract the number of input tokens as they are part of the returned sequence
-        n_output_tokens += len(generator.tokenizer(sequence[0]["generated_text"]).input_ids) - n_input_tokens
+        # TODO this is not accurate, args.prompt contains flag like <|im_start|>, <|im_end|>, while generated_text does not contain it
+        # if it's text+image prompt, should use "image-text-to-text" pipeline after transformers 4.47
+        if not args.ignore_eos:
+            n_output_tokens += len(generator.tokenizer(sequence[0]["generated_text"]).input_ids) - n_input_tokens
+        else:
+            n_output_tokens += args.max_new_tokens
 
     total_new_tokens_generated = args.n_iterations * n_output_tokens
     throughput = total_new_tokens_generated / duration

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -63,6 +63,7 @@ def _test_image_to_text(
         f"--model_name_or_path {model_name}",
         f"--batch_size {batch_size}",
         "--max_new_tokens 20",
+        "--ignore_eos",
     ]
 
     command += [


### PR DESCRIPTION
…t len not be changed in benchmark along with example change

FAILED tests/test_image_to_text_example.py::test_image_to_text_fp8[token0-llava-hf/llava-v1.6-vicuna-13b-hf-1-30.9535718774675] - assert 19.668658371716237 >= ((2 - 1.05) * 30.9535718774675)

