### PR TITLE
Adds requirements.txt to sentence transformers training paraphrases

### DIFF
--- a/examples/sentence-transformers-training/paraphrases/README.md
+++ b/examples/sentence-transformers-training/paraphrases/README.md
@@ -4,6 +4,12 @@
 
 To fine-tune on the paraphrase task:
 
+0. Install required packages
+
+    ```sh
+    pip install -r requirements.txt
+    ```
+
 1. Choose a pre-trained model `<model_name>` (For example: `bert-base-uncased`).
 
 2. Choose the training, evaluation, and test dataset(s). Here, we use a dataset dictionary to include multiple datasets.

--- a/examples/sentence-transformers-training/paraphrases/requirements.txt
+++ b/examples/sentence-transformers-training/paraphrases/requirements.txt
@@ -1,0 +1,1 @@
+datasets


### PR DESCRIPTION
# What does this PR do?

Previously if you were following the README, you would run into `ModuleNotFoundError: No module named 'datasets'`. This PR fixes that by adding a `requirements.txt` with `datasets` and instructions in the README.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
