### PR TITLE
Fix Experts Indexing in MoE for Mixtral: Align experts_max with Number of Available Experts

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -451,7 +451,7 @@ def gaudi_mixtral_block_dynamic_moe_forward(self, hidden_states: torch.Tensor) -
         permuted_weights=True,
         activation="silu",
         experts_min=0,
-        experts_max=1,
+        experts_max= len(self.experts) - 1,
     )
     if is_deepspeed_available() and (not self.training):
         from deepspeed import comm as dist

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -451,7 +451,7 @@ def gaudi_mixtral_block_dynamic_moe_forward(self, hidden_states: torch.Tensor) -
         permuted_weights=True,
         activation="silu",
         experts_min=0,
-        experts_max=7,
+        experts_max=1,
     )
     if is_deepspeed_available() and (not self.training):
         from deepspeed import comm as dist

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -451,7 +451,7 @@ def gaudi_mixtral_block_dynamic_moe_forward(self, hidden_states: torch.Tensor) -
         permuted_weights=True,
         activation="silu",
         experts_min=0,
-        experts_max= len(self.experts) - 1,
+        experts_max=len(self.experts) - 1,
     )
     if is_deepspeed_available() and (not self.training):
         from deepspeed import comm as dist


### PR DESCRIPTION
# What does this PR do?
**Fixes** # (issue)
Segfault on Mixtral transformer test due to out-of-bound reference of experts Index in MOE block
- The test fails with changes to Sparse MOE block from docker build 1.20.0-301 

In this particular failing test, the expert parameter values do not align with the number of weight tensors provided to the MOE. Specifically, the test inputs are as follows:
Expert_max = 7 , number of experts being used in this test is 2.

Hence segmentation fault occurs when it tries to access experts of index range [2-7] as only 2 experts are available.

Changes made in PR:
- Update expert max to ( number of experts - 1 ) , as this is inclusive index range starts from 0.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
