### PR TITLE
Enable wav2vec-large model for speech_recognition test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ MODELS_TO_TEST_MAPPING = {
     ],
     "wav2vec2": [
         ("facebook/wav2vec2-base", "Habana/wav2vec2"),
-        # ("facebook/wav2vec2-large-lv60", "Habana/wav2vec2"),
+        ("facebook/wav2vec2-large-lv60", "Habana/wav2vec2"),
     ],
     "swin": [("microsoft/swin-base-patch4-window7-224-in22k", "Habana/swin")],
     "clip": [("./clip-roberta", "Habana/clip")],


### PR DESCRIPTION
# What does this PR do?
Re-enable wav2vec-large model for speech_recognition test.  This is the only model that's enabled for the speech_recognition. 

   <Module test_examples.py>
      <UnitTestCase MultiCardAudioClassificationExampleTester>
        <TestCaseFunction test_run_audio_classification_wav2vec2-base_multi_card>
      <UnitTestCase MultiCardSpeechRecognitionExampleTester>
        <TestCaseFunction test_run_speech_recognition_ctc_wav2vec2-large-lv60_multi_card>


<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
