### PR TITLE
Add device auto-discovery and cli option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,11 @@
 import json
 import logging
+import os
 from pathlib import Path
 
 import pytest
+
+import tests.utils as oh_testutils
 
 
 BASELINE_DIRECTORY = Path(__file__).parent.resolve() / Path("tests") / Path("baselines") / Path("fixture")
@@ -89,6 +92,7 @@ class Secret:
 def pytest_addoption(parser):
     parser.addoption("--token", action="store", default=None)
     parser.addoption("--rebase", action="store_true", help="rebase baseline references from current run")
+    parser.addoption("--device", action="store", default=None)
 
 
 @pytest.fixture
@@ -98,6 +102,32 @@ def token(request):
 
 def pytest_sessionstart(session):
     session.stash["baseline"] = Baseline(session)
+
+    # User command-line option takes highest priority
+    if session.config.option.device is not None:
+        device = str(session.config.option.device).lower()
+    # User GAUDI2_CI environment variable takes second priority for backwards compatibility
+    elif "GAUDI2_CI" in os.environ:
+        device = "gaudi2" if os.environ["GAUDI2_CI"] == "1" else "gaudi1"
+    # Try to automatically detect it
+    else:
+        import habana_frameworks.torch.hpu as torch_hpu
+
+        name = torch_hpu.get_device_name().strip()
+        if not name:
+            raise RuntimeError("Expected a Gaudi device but did not detect one.")
+        device = name.split()[-1].lower()
+
+    # torch_hpu.get_device_name() returns GAUDI for G1
+    if "gaudi" == device:
+        # use "gaudi1" since this is used in tests, baselines, etc.
+        device = "gaudi1"
+
+    oh_testutils.OH_DEVICE_CONTEXT = device
+
+
+def pytest_report_header():
+    return [f"device context: {oh_testutils.OH_DEVICE_CONTEXT}"]
 
 
 def pytest_sessionfinish(session):

--- a/tests/test_bnb_inference.py
+++ b/tests/test_bnb_inference.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import copy
-import os
 
 import torch
 from habana_frameworks.torch.hpu import wrap_in_hpu_graph
@@ -22,10 +21,12 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 
 from optimum.habana.transformers import modeling_utils
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 modeling_utils.adapt_transformers_to_gaudi()
 
-assert os.environ.get("GAUDI2_CI", "0") == "1", "Execution does not support on Gaudi1"
+assert OH_DEVICE_CONTEXT != "gaudi1", "Execution does not support on Gaudi1"
 
 MODEL_ID = "meta-llama/Llama-3.2-1B"
 

--- a/tests/test_bnb_qlora.py
+++ b/tests/test_bnb_qlora.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import subprocess
 
 import pytest
@@ -24,10 +23,12 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
 from optimum.habana.transformers import modeling_utils
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 modeling_utils.adapt_transformers_to_gaudi()
 
-assert os.environ.get("GAUDI2_CI", "0") == "1", "Execution does not support on Gaudi1"
+assert OH_DEVICE_CONTEXT != "gaudi1", "Execution does not support on Gaudi1"
 try:
     import sys
 

--- a/tests/test_custom_file_input.py
+++ b/tests/test_custom_file_input.py
@@ -8,10 +8,12 @@ from tempfile import TemporaryDirectory
 import pytest
 from transformers.testing_utils import slow
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 PATH_TO_RESOURCES = Path(__file__).resolve().parent.parent / "tests/resource"
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     MODEL_FILE_OPTIONS_TO_TEST = {
         "bf16": [
             (

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -125,12 +125,12 @@ from optimum.habana.diffusers.models import (
 from optimum.habana.utils import set_seed
 
 from .clip_coco_utils import calculate_clip_score, download_files
+from .utils import OH_DEVICE_CONTEXT
 
 
-IS_GAUDI2 = os.environ.get("GAUDI2_CI", "0") == "1"
+IS_GAUDI1 = bool("gaudi1" == OH_DEVICE_CONTEXT)
 
-
-if IS_GAUDI2:
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     THROUGHPUT_BASELINE_BF16 = 1.086
     THROUGHPUT_BASELINE_AUTOCAST = 0.394
     TEXTUAL_INVERSION_THROUGHPUT = 131.7606336456344
@@ -1695,7 +1695,7 @@ class GaudiStableDiffusion3PipelineTester(TestCase):
 
     @slow
     @check_gated_model_access("stabilityai/stable-diffusion-3-medium-diffusers")
-    @pytest.mark.skipif(not IS_GAUDI2, reason="does not fit into Gaudi1 memory")
+    @pytest.mark.skipif(IS_GAUDI1, reason="does not fit into Gaudi1 memory")
     def test_sd3_inference(self):
         repo_id = "stabilityai/stable-diffusion-3-medium-diffusers"
 
@@ -5985,7 +5985,7 @@ class GaudiFluxPipelineTester(TestCase):
         assert max_diff < 1e-4
 
     @slow
-    @pytest.mark.skipif(not IS_GAUDI2, reason="does not fit into Gaudi1 memory")
+    @pytest.mark.skipif(IS_GAUDI1, reason="does not fit into Gaudi1 memory")
     def test_flux_inference(self):
         prompts = [
             "A cat holding a sign that says hello world",
@@ -6154,7 +6154,7 @@ class GaudiFluxImg2ImgPipelineTester(TestCase):
 
     @slow
     @check_gated_model_access("black-forest-labs/FLUX.1-dev")
-    @pytest.mark.skipif(not IS_GAUDI2, reason="does not fit into Gaudi1 memory")
+    @pytest.mark.skipif(IS_GAUDI1, reason="does not fit into Gaudi1 memory")
     def test_flux_img2img_inference(self):
         repo_id = "black-forest-labs/FLUX.1-dev"
         image_path = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png"

--- a/tests/test_encoder_decoder.py
+++ b/tests/test_encoder_decoder.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -9,6 +8,7 @@ from typing import List
 import pytest
 
 from .test_examples import ACCURACY_PERF_FACTOR, TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
 MODELS_TO_TEST = {
@@ -88,12 +88,10 @@ class TestEncoderDecoderModels:
             with open(Path(tmp_dir) / "predict_results.json") as fp:
                 results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         self.baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             predict_samples_per_second=results["predict_samples_per_second"],
         )
 
@@ -103,7 +101,7 @@ class TestEncoderDecoderModels:
             accuracy_metric = "predict_bleu"
         self.baseline.assertRef(
             compare=lambda actual, ref: actual >= ACCURACY_PERF_FACTOR * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             **{accuracy_metric: results[accuracy_metric]},
         )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -50,6 +50,7 @@ from .utils import (
     MODELS_TO_TEST_FOR_SEQUENCE_CLASSIFICATION,
     MODELS_TO_TEST_FOR_SPEECH_RECOGNITION,
     MODELS_TO_TEST_MAPPING,
+    OH_DEVICE_CONTEXT,
 )
 
 
@@ -60,7 +61,7 @@ ACCURACY_PERF_FACTOR = 0.99
 TIME_PERF_FACTOR = 1.05
 
 
-IS_GAUDI2 = os.environ.get("GAUDI2_CI", "0") == "1"
+IS_GAUDI2 = bool("gaudi2" == OH_DEVICE_CONTEXT)
 
 
 def _get_supported_models_for_script(
@@ -439,7 +440,7 @@ class ExampleTestMeta(type):
                     # Assess accuracy
                     with open(Path(tmp_dir) / "accuracy_metrics.json") as fp:
                         results = json.load(fp)
-                        baseline = 0.43 if os.environ.get("GAUDI2_CI", "0") == "1" else 0.42
+                        baseline = 0.43 if IS_GAUDI2 else 0.42
                         self.assertGreaterEqual(results["accuracy"], baseline)
                 return
             elif self.EXAMPLE_NAME == "run_clip":

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import time
 from unittest import TestCase
 
@@ -25,10 +24,12 @@ from transformers import AutoModel, AutoTokenizer
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 adapt_transformers_to_gaudi()
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     LATENCY_GTE_SMALL_BF16_GRAPH_BASELINE = 0.6812
 else:

--- a/tests/test_fp8_examples.py
+++ b/tests/test_fp8_examples.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -8,9 +7,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from .test_examples import ACCURACY_PERF_FACTOR, TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "fp8": [
@@ -109,17 +109,15 @@ def _test_fp8_train(
         with open(Path(tmp_dir) / "all_results.json") as fp:
             results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             train_samples_per_second=results["train_samples_per_second"],
         )
         baseline.assertRef(
             compare=lambda actual, ref: actual >= ACCURACY_PERF_FACTOR * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             eval_accuracy=results["eval_accuracy"],
         )
 

--- a/tests/test_fsdp_examples.py
+++ b/tests/test_fsdp_examples.py
@@ -8,9 +8,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from .test_examples import ACCURACY_PERF_FACTOR, TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "bf16": [
@@ -145,24 +146,22 @@ def _test_fsdp(
         with open(Path(tmp_dir) / "all_results.json") as fp:
             results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             train_samples_per_second=results["train_samples_per_second"],
         )
         if model_name == "bert-base-uncased":
             baseline.assertRef(
                 compare=lambda actual, ref: actual >= ACCURACY_PERF_FACTOR * ref,
-                context=[device],
+                context=[OH_DEVICE_CONTEXT],
                 eval_f1=results["eval_f1"],
             )
         else:
             baseline.assertRef(
                 compare=lambda actual, ref: actual <= (2 - ACCURACY_PERF_FACTOR) * ref,
-                context=[device],
+                context=[OH_DEVICE_CONTEXT],
                 train_loss=results["train_loss"],
             )
 

--- a/tests/test_functional_text_generation_example.py
+++ b/tests/test_functional_text_generation_example.py
@@ -9,8 +9,10 @@ import pytest
 
 from optimum.habana.utils import set_seed
 
+from .utils import OH_DEVICE_CONTEXT
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     MODEL_OUTPUTS = {
         "bigcode/starcoder": 'def print_hello_world():\n    print("Hello World")\n\ndef print_hello_world_twice():\n    print_hello_world()\n    print_hello_world()\n\ndef print_hello_world_thrice():\n    print_hello_world()\n    print_hello_world()\n    print_hello_world()\n\ndef print_hello_world_four_times():\n    print_hello_world()\n    print_hello_world()\n    print_hello_world()\n   ',
         "bigcode/starcoder2-3b": 'def print_hello_world():\n    print("Hello World")\n\ndef print_hello_world_with_name(name):\n    print("Hello World, " + name)\n\ndef print_hello_world_with_name_and_age(name, age):\n    print("Hello World, " + name + ", " + str(age))\n\ndef print_hello_world_with_name_and_age_and_gender(name, age, gender):\n    print("Hello',

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -8,9 +8,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "bf16": [
@@ -119,12 +120,10 @@ def _test_image_to_text(
         with open(Path(tmp_dir) / "results.json") as fp:
             results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             throughput=results["throughput"],
         )
 

--- a/tests/test_object_detection.py
+++ b/tests/test_object_detection.py
@@ -27,11 +27,12 @@ from transformers import AutoProcessor, DetrForObjectDetection
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
 adapt_transformers_to_gaudi()
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     LATENCY_DETR_BF16_GRAPH_BASELINE = 7.0
 else:

--- a/tests/test_openclip_vqa.py
+++ b/tests/test_openclip_vqa.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
 MODELS_TO_TEST = {
@@ -62,12 +63,10 @@ def _test_openclip_vqa(model_name: str, baseline):
         with open(Path(tmp_dir) / "results.json") as fp:
             results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             throughput=results["throughput"],
         )
 

--- a/tests/test_sentence_transformers.py
+++ b/tests/test_sentence_transformers.py
@@ -7,6 +7,7 @@ import pytest
 from sentence_transformers import SentenceTransformer, util
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
 MODELS_TO_TEST = [
@@ -56,12 +57,10 @@ def _test_sentence_transformers(
         diff_time = end_time - start_time
         measured_throughput = len(sentences) / diff_time
 
-    device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
     # Only assert the last measured throughtput as the first iteration is used as a warmup
     baseline.assertRef(
         compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-        context=[device],
+        context=[OH_DEVICE_CONTEXT],
         measured_throughput=measured_throughput,
     )
 

--- a/tests/test_table_transformer.py
+++ b/tests/test_table_transformer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import time
 from unittest import TestCase
 
@@ -25,11 +24,13 @@ from transformers import AutoImageProcessor, TableTransformerForObjectDetection
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 adapt_transformers_to_gaudi()
 
 MODEL_NAME = "microsoft/table-transformer-detection"
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     LATENCY_TABLE_TRANSFORMER_BF16_GRAPH_BASELINE = 2.2
 else:
     LATENCY_TABLE_TRANSFORMER_BF16_GRAPH_BASELINE = 6.6

--- a/tests/test_text_generation_example.py
+++ b/tests/test_text_generation_example.py
@@ -13,13 +13,13 @@ import pytest
 from optimum.habana.utils import set_seed
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
 prev_quant_model_name = None
 prev_quant_rank = 0
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
-    # Gaudi2 CI
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     MODELS_TO_TEST = {
         "bf16_1x": [
             ("bigscience/bloomz-7b1", 1, False, False),
@@ -366,18 +366,20 @@ def _test_text_generation(
         with open(Path(tmp_dir) / "results.json") as fp:
             results = json.load(fp)
 
-        device = "gaudi2" if os.environ.get("GAUDI2_CI", "0") == "1" else "gaudi1"
-
         # Ensure performance requirements (throughput) are met
         baseline.assertRef(
             compare=lambda actual, ref: actual >= (2 - TIME_PERF_FACTOR) * ref,
-            context=[device],
+            context=[OH_DEVICE_CONTEXT],
             throughput=results["throughput"],
         )
 
         # Verify output for 1 HPU, BF16
         if check_output:
-            baseline.assertRef(compare=operator.eq, context=[device], output=results["output"][0][0])
+            baseline.assertRef(
+                compare=operator.eq,
+                context=[OH_DEVICE_CONTEXT],
+                output=results["output"][0][0],
+            )
 
 
 @pytest.mark.parametrize("model_name, batch_size, reuse_cache, check_output", MODELS_TO_TEST["bf16_1x"])
@@ -394,7 +396,7 @@ def test_text_generation_bf16_1x(
     )
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize(
     "model_name, world_size, batch_size, reuse_cache, input_len, output_len", MODELS_TO_TEST["fp8"]
 )
@@ -423,7 +425,7 @@ def test_text_generation_fp8(
     )
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize(
     "model_name, world_size, batch_size, reuse_cache, input_len, output_len",
     MODELS_TO_TEST["load_quantized_model_with_autogptq"],
@@ -454,7 +456,7 @@ def test_text_generation_gptq(
     )
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize(
     "model_name, world_size, batch_size, reuse_cache, input_len, output_len",
     MODELS_TO_TEST["load_quantized_model_with_autoawq"],
@@ -490,20 +492,20 @@ def test_text_generation_deepspeed(model_name: str, world_size: int, batch_size:
     _test_text_generation(model_name, baseline, token, deepspeed=True, world_size=world_size, batch_size=batch_size)
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize("model_name", MODELS_TO_TEST["torch_compile"])
 def test_text_generation_torch_compile(model_name: str, baseline, token):
     _test_text_generation(model_name, baseline, token, torch_compile=True)
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize("model_name", MODELS_TO_TEST["torch_compile_distributed"])
 def test_text_generation_torch_compile_distributed(model_name: str, baseline, token):
     world_size = 8
     _test_text_generation(model_name, baseline, token, deepspeed=True, world_size=world_size, torch_compile=True)
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize("model_name", MODELS_TO_TEST["distributed_tp"])
 def test_text_generation_distributed_tp(model_name: str, baseline, token):
     world_size = 8
@@ -524,7 +526,7 @@ def test_text_generation_contrastive_search(model_name: str, batch_size: int, re
     _test_text_generation(model_name, baseline, token, batch_size, reuse_cache, contrastive_search=True)
 
 
-@pytest.mark.skipif(condition=not bool(int(os.environ.get("GAUDI2_CI", "0"))), reason="Skipping test for G1")
+@pytest.mark.skipif(condition=bool("gaudi1" == OH_DEVICE_CONTEXT), reason=f"Skipping test for {OH_DEVICE_CONTEXT}")
 @pytest.mark.parametrize("model_name, batch_size, reuse_cache", MODELS_TO_TEST["beam_search"])
 def test_text_generation_beam_search(model_name: str, batch_size: int, reuse_cache: bool, baseline, token):
     _test_text_generation(model_name, baseline, token, batch_size, reuse_cache, num_beams=3)

--- a/tests/test_video_llava.py
+++ b/tests/test_video_llava.py
@@ -8,9 +8,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from .test_examples import TIME_PERF_FACTOR
+from .utils import OH_DEVICE_CONTEXT
 
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     MODELS_TO_TEST = {
         "bf16": [

--- a/tests/test_video_mae.py
+++ b/tests/test_video_mae.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import os
 import time
 from unittest import TestCase
 
@@ -24,8 +23,10 @@ import pytest
 import torch
 from transformers import VideoMAEForVideoClassification, VideoMAEImageProcessor
 
+from .utils import OH_DEVICE_CONTEXT
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     LATENCY_VIDEOMAE_BF16_GRAPH_BASELINE = 17.544198036193848
 else:

--- a/tests/test_zero_shot_object_detection.py
+++ b/tests/test_zero_shot_object_detection.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import time
 from unittest import TestCase
 
@@ -26,10 +25,12 @@ from transformers import OwlViTForObjectDetection, OwlViTProcessor
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
+from .utils import OH_DEVICE_CONTEXT
+
 
 adapt_transformers_to_gaudi()
 
-if os.environ.get("GAUDI2_CI", "0") == "1":
+if OH_DEVICE_CONTEXT in ["gaudi2"]:
     # Gaudi2 CI baselines
     LATENCY_OWLVIT_BF16_GRAPH_BASELINE = 4.2139556878198333
 else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,3 +103,6 @@ MODELS_TO_TEST_FOR_AUDIO_CLASSIFICATION = ["wav2vec2", "audio-spectrogram-transf
 MODELS_TO_TEST_FOR_SPEECH_RECOGNITION = ["wav2vec2", "whisper"]
 
 MODELS_TO_TEST_FOR_IMAGE_TEXT = ["clip"]
+
+# This will be configured by conftest.py at the start of the pytest session
+OH_DEVICE_CONTEXT = "unknown"


### PR DESCRIPTION
# What does this PR do?

Add `--device` cli option to specify which CI device is
being tested.  If the cli option is not specified, then
we fallback to the usual GAUDI2_CI environment variable.
Finally, if neither is specified, then try to get the
device name automatically from the habana frameworks
API.

This setting is to prepare for gaudi3 specific (and
future devices) test cases and baseline references.

Eventually, we can deprecate the GAUDI2_CI environment
variable once the rest of the test framework is
migrated to the new device declaration.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
