### PR TITLE
[Transformers future] Loss Computation for Compatibility with Transformers 4.48.3

### DIFF
--- a/optimum/habana/distributed/contextparallel.py
+++ b/optimum/habana/distributed/contextparallel.py
@@ -7,13 +7,26 @@ from .parallel_state import (
 )
 
 
-# Gather losses across context parallel group
-class _ContextParallelLoss(torch.autograd.Function):
+class ContextParallelLossFunction(torch.autograd.Function):
+    """
+    Gather losses across context parallel group.
+
+    This custom autograd function is designed to handle the distribution of loss computation
+    across multiple parallel contexts in a distributed training setup. It ensures that the loss
+    is gathered from all devices involved in the parallel context, allowing for consistent and
+    accurate computation of the overall loss.
+
+    The forward method gathers the loss from all ranks in the context parallel group, while the
+    backward method ensures that gradients are correctly synchronized across the different parallel
+    contexts.
+    """
+
     @staticmethod
     def forward(ctx, loss):
         ctx.seqlen = loss.size(0) * get_sequence_parallel_world_size()
-
+        # Create a tensor to gather all losses from context parallel group
         loss_all = torch.empty(ctx.seqlen, dtype=loss.dtype, device=loss.device)
+        # Gather losses from all ranks in the group
         torch.distributed.all_gather_into_tensor(loss_all, loss, group=get_sequence_parallel_group())
         return loss_all
 
@@ -21,10 +34,37 @@ class _ContextParallelLoss(torch.autograd.Function):
     def backward(ctx, grad_output):
         step_seqlen = ctx.seqlen // get_sequence_parallel_world_size()
         sp_rank = get_sequence_parallel_rank()
+        # Extract the relevant part of the gradient for this rank
         grad_output_part = grad_output[step_seqlen * sp_rank : step_seqlen * (sp_rank + 1)]
-
         return grad_output_part, None
 
 
-def _get_loss_from_context_parallel(vocab_parallel_loss):
-    return _ContextParallelLoss.apply(vocab_parallel_loss)
+def fixed_cross_entropy(source, target, num_items_in_batch: int = None, ignore_index: int = -100, **kwargs):
+    loss_all = torch.nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction="none")
+    # Apply context parallel loss
+    loss_all = ContextParallelLossFunction.apply(loss_all)
+    if num_items_in_batch is None:
+        loss = torch.mean(loss_all)
+    else:
+        loss = torch.sum(loss_all) / num_items_in_batch
+    return loss
+
+
+def ForCausalLMContextParallelLoss(
+    logits, labels, vocab_size: int, num_items_in_batch: int = None, ignore_index: int = -100, **kwargs
+):
+    # Upcast to float if we need to compute the loss to avoid potential precision issues
+    logits = logits.float()
+    labels = labels.to(logits.device)
+    # Shift so that tokens < n predict n
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+
+    # Flatten the tokens
+    shift_logits = shift_logits.view(-1, vocab_size)
+    shift_labels = shift_labels.view(-1)
+    # Enable model parallelism
+    shift_labels = shift_labels.to(shift_logits.device)
+
+    loss = fixed_cross_entropy(shift_logits, shift_labels, num_items_in_batch, ignore_index, **kwargs)
+    return loss

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1418,6 +1418,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
     def __init__(self, config, parallel_strategy: DistributedStrategy = NoOpStrategy):
         config.parallel_strategy = parallel_strategy
         super().__init__(config)
+        self._is_context_parallel_active: bool = parallel_state.sequence_parallel_is_initialized() and parallel_state.get_sequence_parallel_world_size() > 1
 
     def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):
         self.model.allocate_kv_cache(batch_size, max_seq_len, inp_seq_len)
@@ -1506,30 +1507,32 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            # Shift so that tokens < n predict n
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-            # Flatten the tokens
-            loss_fct = torch.nn.CrossEntropyLoss()
-            shift_logits = shift_logits.view(-1, self.config.vocab_size)
-            shift_labels = shift_labels.view(-1)
-            # Enable model parallelism
-            shift_labels = shift_labels.to(shift_logits.device)
             # Collect losses from context parallel group
             # Each rank in group calculates loss on partial outputs
-            if (
-                parallel_state.sequence_parallel_is_initialized()
-                and parallel_state.get_sequence_parallel_world_size() > 1
-            ):
+            if self._is_context_parallel_active:
                 from ....distributed.contextparallel import _get_loss_from_context_parallel
+
+                # Upcast to float if we need to compute the loss to avoid potential precision issues
+                logits = logits.float()
+                # Shift so that tokens < n predict n
+                shift_logits = logits[..., :-1, :].contiguous()
+                shift_labels = labels[..., 1:].contiguous()
+                # Flatten the tokens
+                loss_fct = torch.nn.CrossEntropyLoss()
+                shift_logits = shift_logits.view(-1, self.config.vocab_size)
+                shift_labels = shift_labels.view(-1)
+                # Enable model parallelism
+                shift_labels = shift_labels.to(shift_logits.device)
 
                 loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
                 loss_all = _get_loss_from_context_parallel(loss_fct(shift_logits, shift_labels))
-                loss = torch.mean(loss_all)
+                num_items_in_batch = kwargs.get("num_items_in_batch", None)
+                if num_items_in_batch is None:
+                    loss = torch.mean(loss_all)
+                else:
+                    loss = torch.sum(loss_all) / num_items_in_batch
             else:
-                loss = loss_fct(shift_logits, shift_labels)
+                loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -955,6 +955,16 @@ class GaudiTrainer(Trainer):
         else:
             self.log_evaluate_save_time = None
 
+        # Calculate the number of items in each batch for all epochs
+        num_items_in_batches = self.get_num_items_in_batches(
+            args,
+            epochs_trained,
+            num_train_epochs,
+            train_dataloader,
+            len_dataloader,
+            num_examples,
+        )
+
         hb_profiler = HabanaProfile(
             warmup=self.args.profiling_warmup_steps,
             active=self.args.profiling_steps,
@@ -1008,7 +1018,8 @@ class GaudiTrainer(Trainer):
             for _ in range(total_updates):
                 update_step += 1
                 num_batches = args.gradient_accumulation_steps if update_step != (total_updates - 1) else remainder
-                batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator, num_batches)
+                batch_samples = self.get_iterator_batch_samples(epoch_iterator, num_batches)
+                num_items_in_batch = num_items_in_batches[epoch][update_step]
                 for i, inputs in enumerate(batch_samples):
                     step += 1
 
@@ -2636,3 +2647,75 @@ class GaudiTrainer(Trainer):
             except TypeError:
                 model.zero_grad()
                 model._zero_grad_kwargs = {}
+
+    def get_num_items_in_batches(
+        self, args, epochs_trained, num_train_epochs, train_dataloader, len_dataloader, num_examples
+    ):
+        """
+        Calculate the number of items in each batch for all epochs during training.
+        """
+        steps_in_epoch = (
+            len_dataloader if len_dataloader is not None else args.max_steps * args.gradient_accumulation_steps
+        )
+
+        remainder = num_examples % args.gradient_accumulation_steps
+        if remainder == 0:
+            remainder = args.gradient_accumulation_steps
+
+        total_updates = steps_in_epoch // args.gradient_accumulation_steps + 1
+        if args.gradient_accumulation_steps == 1:
+            total_updates -= 1
+
+        num_items_in_batches = []
+        for epoch in range(epochs_trained, num_train_epochs):
+            epoch_dataloader = train_dataloader
+            if hasattr(epoch_dataloader, "set_epoch"):
+                epoch_dataloader.set_epoch(epoch)
+
+            epoch_iterator = iter(epoch_dataloader)
+            try:
+                first_batch = next(epoch_iterator)
+            except StopIteration:
+                break
+            # Check if the batch contains "labels" (once per epoch)
+            if "labels" not in first_batch:
+                num_items_in_batches.append([None] * total_updates)
+                continue
+
+            device = first_batch["labels"].device
+
+            # Reset the iterator
+            epoch_iterator = iter(epoch_dataloader)
+
+            num_items_in_batches.append([])
+            for update_step in range(total_updates):
+                num_batches = args.gradient_accumulation_steps if update_step != (total_updates - 1) else remainder
+
+                num_items_in_batch = 0
+                for _ in range(num_batches):
+                    try:
+                        batch = next(epoch_iterator)
+                        num_items_in_batch += (batch["labels"].ne(-100)).sum().item()
+                    except StopIteration:
+                        break
+
+                if self.args.average_tokens_across_devices and num_items_in_batch > 0:
+                    num_items_in_batch = torch.tensor(num_items_in_batch, device=device)
+                    num_items_in_batch = self.accelerator.gather(num_items_in_batch).sum().item()
+
+                # Set to None if no items in batch
+                if num_items_in_batch == 0:
+                    num_items_in_batch = None
+
+                num_items_in_batches[epoch].append(num_items_in_batch)
+
+        return num_items_in_batches
+
+    def get_iterator_batch_samples(self, epoch_iterator, num_batches):
+        batch_samples = []
+        for _ in range(num_batches):
+            try:
+                batch_samples += [next(epoch_iterator)]
+            except StopIteration:
+                break
+        return batch_samples

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -207,8 +207,8 @@ TRAINING_ARGS_NAME = "training_args.bin"
 TRAINER_STATE_NAME = "trainer_state.json"
 OPTIMIZER_NAME = "optimizer.pt"
 OPTIMIZER_NAME_BIN = "optimizer.bin"
-SCHEDULER_NAME = "scheduler.pt"
 SCALER_NAME = "scaler.pt"
+SCHEDULER_NAME = "scheduler.pt"
 
 
 class GaudiTrainer(Trainer):
@@ -450,6 +450,9 @@ class GaudiTrainer(Trainer):
         output_dir = os.path.join(checkpoint_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}")
         self.save_model(output_dir, _internal_call=True)
         if self.args.should_save:
+            # TODO
+            # Update the `TrainerControl` state to where we are currently
+            # self.state.stateful_callbacks["TrainerControl"] = self.control.state()
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
             torch.save(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))
             torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
@@ -467,13 +470,22 @@ class GaudiTrainer(Trainer):
         if self.args.parallel_mode == ParallelMode.DISTRIBUTED and self.args.distribution_strategy == "ddp":
             kwargs = {}
 
-            kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
-            if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
-                logger.warning(
-                    "ddp_find_unused_parameters and gradient_checkpointing are both True, which may lead to an error:"
-                    " https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
-                )
-            kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
+            if self.args.ddp_find_unused_parameters is not None:
+                kwargs["find_unused_parameters"] = self.args.ddp_find_unused_parameters
+                if self.args.ddp_find_unused_parameters and self.args.gradient_checkpointing:
+                    logger.warning(
+                        "ddp_find_unused_parameters and gradient_checkpointing are both True, which may lead to an error:"
+                        " https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021"
+                    )
+            elif isinstance(model, PreTrainedModel):
+                # find_unused_parameters breaks checkpointing as per
+                # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
+                kwargs["find_unused_parameters"] = not model.is_gradient_checkpointing
+            else:
+                kwargs["find_unused_parameters"] = True
+
+            if self.args.ddp_bucket_cap_mb is not None:
+                kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 
             if self.args.use_habana:
                 kwargs["gradient_as_bucket_view"] = True
@@ -499,6 +511,7 @@ class GaudiTrainer(Trainer):
     ):
         """
         Main training entry point.
+
         Args:
             resume_from_checkpoint (`str` or `bool`, *optional*):
                 If a `str`, local path to a saved checkpoint as saved by a previous instance of [`Trainer`]. If a
@@ -541,7 +554,7 @@ class GaudiTrainer(Trainer):
                 FutureWarning,
             )
         if len(kwargs) > 0:
-            raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
+            raise TypeError(f"train() got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
         # This might change the seed so needs to run first.
         self._hp_search_setup(trial)
         self._train_batch_size = self.args.train_batch_size
@@ -826,18 +839,15 @@ class GaudiTrainer(Trainer):
         # Check if saved optimizer or scheduler states exist
         self._load_optimizer_and_scheduler(resume_from_checkpoint)
 
-        if self.gaudi_config.use_fused_clip_norm:
+        if self.gaudi_config.use_fused_clip_norm and self.args.use_habana:
             try:
                 from habana_frameworks.torch.hpex.normalization import FusedClipNorm
             except ImportError as error:
-                error.msg = (
-                    f"Could not import 'FusedClipNorm' from 'habana_frameworks.torch.hpex.normalization'. {error.msg}."
-                )
+                error.msg = f"Could not import habana_frameworks.torch.hpex.normalization. {error.msg}."
                 raise error
-            self.FusedNorm = FusedClipNorm(
-                model.parameters(),
-                args.max_grad_norm,
-            )
+            self.FusedNorm = FusedClipNorm(model.parameters(), args.max_grad_norm)
+        else:
+            self.FusedNorm = None
 
         # important: at this point:
         # self.model         is the Transformers Model
@@ -924,9 +934,10 @@ class GaudiTrainer(Trainer):
         self._total_loss_scalar = 0.0
         self._globalstep_last_logged = self.state.global_step
         self._zero_model_grad(model)
-        _grad_norm: Optional[float] = None
-        _should_compute_grad_norm: bool = not self.accelerator.distributed_type == GaudiDistributedType.DEEPSPEED and (
-            # Gradient clipping
+        grad_norm: Optional[float] = None
+
+        # Gradient clipping
+        _should_compute_grad_norm: bool = self.accelerator.distributed_type != GaudiDistributedType.DEEPSPEED and (
             args.max_grad_norm is not None and args.max_grad_norm > 0
         )
 
@@ -992,10 +1003,12 @@ class GaudiTrainer(Trainer):
                 remainder = args.gradient_accumulation_steps
             update_step = -1
             total_updates = steps_in_epoch // args.gradient_accumulation_steps + 1
+            if args.gradient_accumulation_steps == 1:
+                total_updates -= 1
             for _ in range(total_updates):
                 update_step += 1
                 num_batches = args.gradient_accumulation_steps if update_step != (total_updates - 1) else remainder
-                batch_samples, num_items_in_batch = self.get_batch_samples_transformers(epoch_iterator, num_batches)
+                batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator, num_batches)
                 for i, inputs in enumerate(batch_samples):
                     step += 1
 
@@ -1008,10 +1021,7 @@ class GaudiTrainer(Trainer):
 
                     do_sync_step = (step + 1) % args.gradient_accumulation_steps == 0 or (step + 1) == steps_in_epoch
                     # Since we perform prefetching, we need to manually set sync_gradients
-                    if not do_sync_step:
-                        self.accelerator.gradient_state._set_sync_gradients(False)
-                    else:
-                        self.accelerator.gradient_state._set_sync_gradients(True)
+                    self.accelerator.gradient_state._set_sync_gradients(do_sync_step)
 
                     if self.args.include_num_input_tokens_seen:
                         main_input_name = getattr(self.model, "main_input_name", "input_ids")
@@ -1073,15 +1083,16 @@ class GaudiTrainer(Trainer):
 
                     if args.logging_nan_inf_filter and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step)):
                         # if loss is nan or inf simply add the average of previous logged losses
-                        tr_loss += tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                        tr_loss = tr_loss + tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
                     else:
                         if tr_loss.device != tr_loss_step.device:
                             raise ValueError(
                                 f"Calculated loss must be on the original device: {tr_loss.device} but device in use is {tr_loss_step.device}"
                             )
-                        tr_loss += tr_loss_step
+                        tr_loss = tr_loss + tr_loss_step
 
                     self.current_flos += float(self.floating_point_ops(inputs))
+
                     if args.use_lazy_mode:
                         self.htcore.mark_step()
 
@@ -1089,15 +1100,15 @@ class GaudiTrainer(Trainer):
                         # Since we perform prefetching, we need to manually set sync_gradients to True
                         self.accelerator.gradient_state._set_sync_gradients(True)
 
-                        # If the condition is true, we need to compute _grad_norm
+                        # If the condition is true, we need to compute grad_norm, deepspeed does its own clipping
                         if _should_compute_grad_norm:
-                            # deepspeed does its own clipping
-                            if self.gaudi_config.use_fused_clip_norm and args.use_habana:
+                            # Gradient clipping
+                            if self.FusedNorm is not None:
                                 # TODO: to merge self.accelerator.clip_grad_norm_ when HMP is removed
-                                _grad_norm = self.FusedNorm.clip_norm(model.parameters())
+                                grad_norm = self.FusedNorm.clip_norm(model.parameters())
                             else:
                                 # Revert to normal clipping otherwise
-                                _grad_norm = self.accelerator.clip_grad_norm_(
+                                grad_norm = self.accelerator.clip_grad_norm_(
                                     model.parameters(),
                                     args.max_grad_norm,
                                 )
@@ -1121,7 +1132,7 @@ class GaudiTrainer(Trainer):
                             self.htcore.mark_step()
                         self.control = self.callback_handler.on_step_end(args, self.state, self.control)
                         self._maybe_log_save_evaluate(
-                            tr_loss, _grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time
+                            tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time
                         )
                     else:
                         self.control = self.callback_handler.on_substep_end(args, self.state, self.control)
@@ -1141,7 +1152,7 @@ class GaudiTrainer(Trainer):
                 self.control.should_training_stop = True
 
             self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
-            self._maybe_log_save_evaluate(tr_loss, _grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time)
+            self._maybe_log_save_evaluate(tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time)
 
             if self.control.should_training_stop:
                 break
@@ -1297,6 +1308,8 @@ class GaudiTrainer(Trainer):
                     )
 
                 # If the model is on the GPU, it still works!
+                # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963
+                # which takes *args instead of **kwargs
                 load_result = model.load_state_dict(state_dict, False)
 
             if has_been_loaded:
@@ -1324,6 +1337,7 @@ class GaudiTrainer(Trainer):
 
             # reset tr_loss to zero
             tr_loss -= tr_loss
+
             logs["loss"] = round(tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged), 4)
 
             # This grad_norm block was outside of _maybe_log_save_evaluate method causing perf degradation.
@@ -1351,7 +1365,7 @@ class GaudiTrainer(Trainer):
             self._globalstep_last_logged = self.state.global_step
             self.store_flos()
 
-            self.log(logs, start_time=start_time)
+            self.log(logs, start_time)
 
         metrics = None
         if self.control.should_evaluate:
@@ -1531,7 +1545,9 @@ class GaudiTrainer(Trainer):
     def log(self, logs: Dict[str, float], start_time: Optional[float] = None) -> None:
         """
         Log `logs` on the various objects watching training.
+
         Subclass and override this method to inject custom behavior.
+
         Args:
             logs (`Dict[str, float]`):
                 The values to log.
@@ -1586,7 +1602,9 @@ class GaudiTrainer(Trainer):
     def autocast_smart_context_manager(self, cache_enabled: Optional[bool] = True):
         """
         A helper wrapper that creates an appropriate context manager for `autocast` while feeding it the desired
-        arguments, depending on the situation. Modified by Habana to enable using `autocast` on Gaudi devices.
+        arguments, depending on the situation.
+
+        Modified by Habana to enable using `autocast` on Gaudi devices.
         """
         if self.use_cpu_amp:
             ctx_manager = torch.autocast(device_type="cpu", dtype=torch.bfloat16, cache_enabled=cache_enabled)
@@ -1623,6 +1641,7 @@ class GaudiTrainer(Trainer):
             `torch.Tensor`: The tensor with training loss on this batch.
         """
         model.train()
+        # TODO
         # if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
         #     self.optimizer.train()
 
@@ -1645,8 +1664,7 @@ class GaudiTrainer(Trainer):
             self.htcore.mark_step()
 
         # Finally we need to normalize the loss for reporting
-        if (not self.model_accepts_loss_kwargs and self.compute_loss_func is None) or (num_items_in_batch is None):
-            # TODO refer to todo in function get_batch_samples_transformers -
+        if not self.model_accepts_loss_kwargs and self.compute_loss_func is None:
             # temporary fix to calculate loss correctly
             loss = loss / self.args.gradient_accumulation_steps
 
@@ -2300,6 +2318,7 @@ class GaudiTrainer(Trainer):
     ) -> EvalLoopOutput:
         """
         Prediction/evaluation loop, shared by `Trainer.evaluate()` and `Trainer.predict()`.
+
         Works both with or without labels.
         """
         args = self.args
@@ -2334,6 +2353,7 @@ class GaudiTrainer(Trainer):
                 self.deepspeed = self.model_wrapped
 
         model.eval()
+        # TODO
         # if hasattr(self.optimizer, "eval") and callable(self.optimizer.eval):
         #     self.optimizer.eval()
 
@@ -2518,6 +2538,7 @@ class GaudiTrainer(Trainer):
         )
         if is_accelerate_available("1.1.0"):
             dataloader_config.data_seed = self.args.data_seed
+
         non_blocking = accelerator_config.pop("non_blocking")
         if non_blocking and not self.args.dataloader_pin_memory:
             logger.warning(
@@ -2615,31 +2636,3 @@ class GaudiTrainer(Trainer):
             except TypeError:
                 model.zero_grad()
                 model._zero_grad_kwargs = {}
-
-    def get_batch_samples_transformers(self, epoch_iterator, num_batches):
-        """
-        Added "_transformers" at the end of the method name to avoid a wrong call to a similarly named method in TRL trainers.
-        """
-        batch_samples = []
-        num_items_in_batch = None
-        for _ in range(num_batches):
-            try:
-                batch_samples += [next(epoch_iterator)]
-            except StopIteration:
-                break
-
-        # TODO: execute get_batch_samples outside of the training loop (before training) and uncomment the following lines
-        # if len(batch_samples) > 0 and "labels" in batch_samples[0]:
-        #     # For now we don't support object detection
-        #     try:
-        #         num_items_in_batch = sum([(batch["labels"].ne(-100)).sum() for batch in batch_samples])
-        #     except (TypeError, AttributeError):
-        #         pass
-
-        # if self.args.average_tokens_across_devices and num_items_in_batch is not None:
-        #     num_items_in_batch = self.accelerator.gather(num_items_in_batch).sum().item()
-
-        # if torch.is_tensor(num_items_in_batch):
-        #     num_items_in_batch = num_items_in_batch.item()
-
-        return batch_samples, num_items_in_batch


### PR DESCRIPTION
# What does this PR do?

- Update the GaudiTrainer to better match with with Transformers 4.48.3 with minor enhancement from 4.49.0
  - Remove the `get_batch_samples_transformers`
  - Implemented `get_num_items_in_batches` to calculate the number of items in each batch for all epochs during training.
  - Added `get_iterator_batch_samples` to retrieve batch samples from an iterator. 
  - Moved the calculation of `num_items_in_batches` outside the training loop to recover performance lost. This feature should be up streamed to Transformers branch.
 
- Update llama model loss computation
  - Simplified loss computation by using a configurable loss function.
  - Replaced the inline loss computation logic with a call to self.loss_function.
  - Introduced ForCausalLMContextParallelLoss for context parallel loss computation.
  - Updated the __init__ method to set the loss function based on the parallel strategy.
  - Ensured compatibility with Transformers 4.48.3 by aligning with its structure and conventions.

- Refactor loss computation in context parallel to better match with the upstream transformers
  - Replaced _ContextParallelLoss with ContextParallelLossFunction for better clarity and consistency.
  - Updated fixed_cross_entropy to use ContextParallelLossFunction for  gathering losses across context parallel groups.
  - Introduced ForCausalLMContextParallelLoss to handle loss computation  for causal language modeling with context parallelism.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
