### PR TITLE
Fixes pytest runtime error - Incompatible input shapes, broadcast not possible

### DIFF
--- a/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
+++ b/optimum/habana/transformers/models/gpt2/modeling_gpt2.py
@@ -70,6 +70,7 @@ class GaudiGPT2Attention(GPT2Attention):
             attn_weights = attn_weights * head_mask
 
         attn_output = torch.matmul(attn_weights, value)
+        attn_output = attn_output.transpose(1, 2)
 
         return attn_output, attn_weights
 


### PR DESCRIPTION
This PR fixes pytest failure that causes runtime error - Incompatible input shapes, broadcast not possible in test_gpt2_reorder_and_upcast_attn

GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/gpt2/ -s -v -k test_gpt2_reorder_and_upcast_attn

FAILED tests/transformers/tests/models/gpt2/test_modeling_gpt2.py::GPT2ModelTest::test_gpt2_reorder_and_upcast_attn - RuntimeError: Incompatible input shapes, broadcast not possible. Tensor1 Size: 32 4 14 Tensor2 Size: 32 7 14

