### PR TITLE
Move model to device before wrapping with FSDP

### DIFF
--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -476,6 +476,7 @@ class GaudiAccelerator(Accelerator):
                         "limit_all_gathers": fsdp_plugin.limit_all_gathers,
                         "device_id": torch.device("hpu", torch.hpu.current_device()),
                     }
+                    model = model.to(kwargs["device_id"])
                     model = FSDP(model, **kwargs)
                     if fsdp_plugin.activation_checkpointing:
                         from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -476,6 +476,8 @@ class GaudiAccelerator(Accelerator):
                         "limit_all_gathers": fsdp_plugin.limit_all_gathers,
                         "device_id": torch.device("hpu", torch.hpu.current_device()),
                     }
+                    # There's issue with moving view tensors to device within FSDP class [See: https://github.com/pytorch/pytorch/issues/147321]
+                    # Due to above issue, view tensor's may lead to silent incorrent behavior, while pretending to be view they're really not
                     model = model.to(kwargs["device_id"])
                     model = FSDP(model, **kwargs)
                     if fsdp_plugin.activation_checkpointing:


### PR DESCRIPTION
Seems to be a better approach due to known issue with moving view tensors to device within FSDP: https://github.com/pytorch/pytorch/issues/147321

Also PyTorch recommendation in FSDP tutorial does it like that:
https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html

```
model = Net().to(rank)
model = FSDP(model)
```