### PR TITLE
Fix dataset_version for ST example requirement.txt

### DIFF
--- a/examples/sentence-transformers-training/nli/requirements.txt
+++ b/examples/sentence-transformers-training/nli/requirements.txt
@@ -1,2 +1,2 @@
-datasets
+datasets <= 2.19.2
 peft

--- a/examples/sentence-transformers-training/paraphrases/requirements.txt
+++ b/examples/sentence-transformers-training/paraphrases/requirements.txt
@@ -1,1 +1,1 @@
-datasets
+datasets <= 2.19.2

--- a/examples/sentence-transformers-training/sts/requirements.txt
+++ b/examples/sentence-transformers-training/sts/requirements.txt
@@ -1,2 +1,2 @@
-datasets
+datasets <= 2.19.2
 peft


### PR DESCRIPTION
# What does this PR do?

This PR will determine the datasets version for sentence transformer example with 2.19.2 and the latest version of datasets will cause critical issue for restart. Thanks. 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
