### PR TITLE
makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,12 @@ slow_tests_custom_file_input: test_installs
 
 # Run single-card non-regression tests
 slow_tests_1x: test_installs
-	python -m pytest tests/test_examples.py -v -s -k "single_card"
-	python -m pip install peft==0.10.0
-	python -m pytest tests/test_peft_inference.py
-	python -m pytest tests/test_pipeline.py
+	@status1=0; status2=0; status3=0; \
+	python -m pytest tests/test_examples.py -v -s -k "single_card" || status1=$$?; \
+	python -m pip install peft==0.10.0 \
+	python -m pytest tests/test_peft_inference.py || status2=$$?; \
+	python -m pytest tests/test_pipeline.py || status3=$$?; \
+	exit $$((status1 + status2 + status3))
 
 # Run multi-card non-regression tests
 slow_tests_8x: test_installs
@@ -97,13 +99,15 @@ slow_tests_deepspeed: test_installs
 	python -m pytest tests/test_examples.py -v -s -k "deepspeed"
 
 slow_tests_diffusers: test_installs
-	python -m pip install -r examples/stable-diffusion/requirements.txt
-	python -m pytest tests/test_diffusers.py -v -s -k "textual_inversion"
-	python -m pip install peft==0.7.0
-	python -m pytest tests/test_diffusers.py -v -s -k "test_train_text_to_image_"
-	python -m pytest tests/test_diffusers.py -v -s -k "test_train_controlnet"
-	python -m pytest tests/test_diffusers.py -v -s -k "test_deterministic_image_generation"
-	python -m pytest tests/test_diffusers.py -v -s -k "test_no_"
+	@status1=0; status2=0; status3=0; status4=0; status5=0; \
+	python -m pip install -r examples/stable-diffusion/requirements.txt \
+	python -m pytest tests/test_diffusers.py -v -s -k "textual_inversion" || status1=$$?; \
+	python -m pip install peft==0.7.0 \
+	python -m pytest tests/test_diffusers.py -v -s -k "test_train_text_to_image_" || status2=$$?; \
+	python -m pytest tests/test_diffusers.py -v -s -k "test_train_controlnet" || status3=$$?; \
+	python -m pytest tests/test_diffusers.py -v -s -k "test_deterministic_image_generation" || status4=$$?; \
+	python -m pytest tests/test_diffusers.py -v -s -k "test_no_" || status5=$$?; \
+	exit $$((status1 + status2 + status3 + status4 + status5))
 
 # Run text-generation non-regression tests
 slow_tests_text_generation_example: test_installs


### PR DESCRIPTION
# What does this PR do?

The Makefile stops test execution after the first failed pytest command.
We ensure that all tests are executed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
