### PR TITLE
WA: conftest do not overshadow tests/transformers/tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,10 @@
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 
 import pytest
-
-import tests.utils as oh_testutils
 
 
 BASELINE_DIRECTORY = Path(__file__).parent.resolve() / Path("tests") / Path("baselines") / Path("fixture")
@@ -123,11 +122,19 @@ def pytest_sessionstart(session):
         # use "gaudi1" since this is used in tests, baselines, etc.
         device = "gaudi1"
 
-    oh_testutils.OH_DEVICE_CONTEXT = device
+    from tests import utils
+
+    utils.OH_DEVICE_CONTEXT = device
+    session.config.stash["device-context"] = device
+
+    # WA: delete the imported top-level tests module so we don't overshadow
+    # tests/transformers/tests module.
+    # This fixes python -m pytest tests/transformers/tests/models/ -s -v
+    del sys.modules["tests"]
 
 
-def pytest_report_header():
-    return [f"device context: {oh_testutils.OH_DEVICE_CONTEXT}"]
+def pytest_report_header(config):
+    return [f"device context: {config.stash['device-context']}"]
 
 
 def pytest_sessionfinish(session):


### PR DESCRIPTION
# What does this PR do?
Fix bug introduced by #1787 that causes the follow error when running `GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/ -s -v`:

```
________________________________________________________________________________________________________________ ERROR collecting tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py _________________________________________________________________________________________________________________
ImportError while importing test module '/root/optimum-habana/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named 'tests.models'
============================================================================================================================================== short test summary info ===============================================================================================================================================
ERROR tests/transformers/tests/models/albert/test_modeling_albert.py
ERROR tests/transformers/tests/models/bert/test_modeling_bert.py
ERROR tests/transformers/tests/models/bridgetower/test_modeling_bridgetower.py
ERROR tests/transformers/tests/models/distilbert/test_modeling_distilbert.py
ERROR tests/transformers/tests/models/falcon/test_modeling_falcon.py
ERROR tests/transformers/tests/models/gpt2/test_modeling_gpt2.py
ERROR tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py
ERROR tests/transformers/tests/models/gptj/test_modeling_gptj.py
ERROR tests/transformers/tests/models/llama/test_modeling_llama.py
ERROR tests/transformers/tests/models/mistral/test_modeling_mistral.py
ERROR tests/transformers/tests/models/mixtral/test_modeling_mixtral.py
ERROR tests/transformers/tests/models/roberta/test_modeling_roberta.py
ERROR tests/transformers/tests/models/swin/test_modeling_swin.py
ERROR tests/transformers/tests/models/t5/test_modeling_t5.py
ERROR tests/transformers/tests/models/vit/test_modeling_vit.py
ERROR tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
