### PR TITLE
fix broken link for GenerationConfig

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -376,6 +376,7 @@ def adapt_transformers_to_gaudi():
         GaudiGenerationMixin._prepare_cache_for_generation
     )
     transformers.generation.GenerationConfig = GaudiGenerationConfig
+    transformers.GenerationConfig = GaudiGenerationConfig
     transformers.generation.configuration_utils.GenerationConfig = GaudiGenerationConfig
     transformers.modeling_utils.GenerationConfig = GaudiGenerationConfig
     transformers.generation.MaxLengthCriteria.__call__ = gaudi_MaxLengthCriteria_call


### PR DESCRIPTION
Importing lm_eval stuffs will break the link between transformers.generation.GenerationConfig andtransformers.GenerationConfig.

You can reproduce it with code below.
```Python
from lm_eval import evaluator, utils
from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
adapt_transformers_to_gaudi()
import transformers
print('=======', transformers.GenerationConfig)
print('=======', transformers.generation.GenerationConfig)
```