### PR TITLE
set support static cache for qwen2

### DIFF
--- a/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -517,6 +517,7 @@ class GaudiQwen2VLModel(Qwen2VLModel):
 
 # from: https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L1420
 class GaudiQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
+    # todo: change when the following gets fixed https://github.com/huggingface/transformers/blame/66f29aaaf55c8fe0c3dbcd24beede2ca4effac56/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L390C5-L390C27 
     _supports_static_cache = True
     def forward(
         self,

--- a/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -517,6 +517,7 @@ class GaudiQwen2VLModel(Qwen2VLModel):
 
 # from: https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L1420
 class GaudiQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
+    _supports_static_cache = True
     def forward(
         self,
         input_ids: torch.LongTensor = None,


### PR DESCRIPTION
In upstream, supporting static cache for this model is temporarily set to False (https://github.com/huggingface/transformers/blame/752ef3fd4e70869626ec70657a770a85c0ad9219/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L941). We will set it to true here to allow the following test to run

`python3 /root/optimum-habana/examples/image-to-text/run_pipeline.py --model_name_or_path Qwen/Qwen2-VL-2B-Instruct --batch_size 1 --max_new_tokens 20 --ignore_eos --use_hpu_graphs --bf16 --sdp_on_bf16 --output_dir /tmp/tmp_26vvp09`

If not, we get the following value error

```   
File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/generation/utils.py", line 1033, in _prepare_cache_for_generation
    raise ValueError(
ValueError: This model does not support `cache_implementation='static'`. Please check the following issue: https://github.com/huggingface/transformers/issues/28981
```