### PR TITLE
move qa model to device to allow fsdp test to pass

### DIFF
--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -376,6 +376,8 @@ def main():
         token=model_args.token,
         trust_remote_code=model_args.trust_remote_code,
     )
+    device = torch.device("hpu")
+    model = model.to(device)
 
     # Tokenizer check: this script requires a fast tokenizer.
     if not isinstance(tokenizer, PreTrainedTokenizerFast):


### PR DESCRIPTION
allows the following pytests to run.

` RUN_SLOW=true python -m pytest tests/test_fsdp_examples.py -v -s --token=*** --device gaudi3`

solves the following error

```
[rank3]:   File "/usr/local/lib/python3.10/dist-packages/torch/_subclasses/fake_tensor.py", line 885, in merge_devices
[rank3]:     raise RuntimeError(
[rank3]: torch._dynamo.exc.BackendCompilerFailed: backend='hpu_backend' raised:
[rank3]: RuntimeError: Unhandled FakeTensor Device Propagation for aten.masked_fill.Scalar, found two different devices hpu:0, cpu
```

or the following error if running the python command directly

```
[rank3]:   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/fsdp/_init_utils.py", line 1035, in _move_states_to_device
[rank3]:     param.data = param.to(device_from_device_id)
[rank3]:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 50, in __setattr__
[rank3]:     return object.__setattr__(self_, name, value)
[rank3]:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 73, in __torch_function__
[rank3]:     new_args[0].change_device_placement(new_args[1].device)
[rank3]:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/weight_sharing.py", line 42, in __getattribute__
[rank3]:     return object.__getattribute__(self_, name)
[rank3]: AttributeError: 'HabanaParameterWrapper' object has no attribute 'change_device_placement'
```


