### PR TITLE
fea(): pytest fixes for gpt_neox (v4.49)

### DIFF
--- a/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -389,7 +389,7 @@ def gaudi_gpt_neox_model_forward(
 
 class GaudiGPTNeoXForCausalLM(GPTNeoXForCausalLM):
     """
-    Inherits from GPTNeoXForCausalLM: https://github.com/huggingface/transformers/blob/main/src/transformers/models/opt_neox/modeling_gpt_neox.py
+    Inherits from GPTNeoXForCausalLM: https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt_neox/modeling_gpt_neox.py
     The only differences are:
     - add new args token_idx
     - add token_idx into model_inputs

--- a/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/optimum/habana/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -530,6 +530,15 @@ class GaudiGPTNeoXForCausalLM(GPTNeoXForCausalLM):
 
         return model_inputs
 
+    def _reorder_cache(self, past_key_values, beam_idx):
+        reordered_past = ()
+        for layer_past in past_key_values:
+            reordered_past += (
+                tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past[:2])
+                + layer_past[2:],
+            )
+        return reordered_past
+
 
 def apply_customized_rope(q, k, cos, sin, position_ids, training=True):
     if q.device.type == "hpu" and FusedRoPE is not None:

--- a/tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py
+++ b/tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py
@@ -209,6 +209,9 @@ class GPTNeoXModelTester:
         model.to(torch_device)
         model.eval()
         # We want this for SDPA, eager works with a `None` attention mask
+        # TODO: Starting v4.49, gpt_neox _attn_implementation is set to eager: https://github.com/huggingface/optimum-habana/blob/transformers_4_49/optimum/habana/transformers/models/modeling_all_models.py
+        # here we manually set it back to sdpa for testing
+        model.config._attn_implementation = "sdpa"
         assert model.config._attn_implementation == "sdpa", (
             "This test assumes the model to have the SDPA implementation for its attention calculations."
         )


### PR DESCRIPTION
# What does this PR do?

This PR fixes the following pytest failures: 
- The `_reorder_cache` has been removed from gpt_neox in HF PR: https://github.com/huggingface/transformers/pull/35610 and causing the following `FAILED tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_beam_search_generate_dict_outputs_use_cache - NotImplementedError: Make sure that a _reorder_cache function is correctly implemented in`
- ` tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_cached_forward_with_and_without_attention_mask - AssertionError: This test assumes the model to have the SDPA implementation for its attention calculations.`

## Results without the PR changes 

```bash  
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/gpt_neox/ -s -v -k test_beam_search_generate
```
```
E       NotImplementedError: Make sure that a `_reorder_cache` function is correctly implemented in optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox to enable beam search for <class 'optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox.GaudiGPTNeoXForCausalLM'>

/usr/local/lib/python3.10/dist-packages/transformers/generation/utils.py:819: NotImplementedError
======================================================================================================================================================== warnings summary ========================================================================================================================================================
tests/transformers/tests/test_modeling_common.py:2058
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2058: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2096
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2096: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2132
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2132: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== short test summary info =====================================================================================================================================================
FAILED tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_beam_search_generate - NotImplementedError: Make sure that a `_reorder_cache` function is correctly implemented in optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox to enable beam search for <class 'optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox.GaudiGPTNeoXForCausalLM'>
FAILED tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_beam_search_generate_dict_outputs_use_cache - NotImplementedError: Make sure that a `_reorder_cache` function is correctly implemented in optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox to enable beam search for <class 'optimum.habana.transformers.models.gpt_neox.modeling_gpt_neox.GaudiGPTNeoXForCausalLM'>
==================================================================================================================================== 2 failed, 1 passed, 86 deselected, 3 warnings in 11.62s ==================================================================================================================================
```

```bash
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/gpt_neox/ -s -v -k test_cached_forward_with_and_without_attention_mask 
```
```
.
.
E       AssertionError: This test assumes the model to have the SDPA implementation for its attention calculations.
E       assert 'eager' == 'sdpa'
E         - sdpa
E         + eager

tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py:215: AssertionError
======================================================================================================================================================== warnings summary ========================================================================================================================================================
tests/transformers/tests/test_modeling_common.py:2058
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2058: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2096
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2096: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2132
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2132: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== short test summary info =====================================================================================================================================================
FAILED tests/transformers/tests/models/gpt_neox/test_modeling_gpt_neox.py::GPTNeoXModelTest::test_cached_forward_with_and_without_attention_mask - AssertionError: This test assumes the model to have the SDPA implementation for its attention calculations.
========================================================================================================================================== 1 failed, 88 deselected, 3 warnings in 9.22s ============================================================================================
```

## Results with the PR changes 
```
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/gpt_neox/ -s -v -k test_beam_search_generate
```
```
======================================================================================================================================================== warnings summary ========================================================================================================================================================
tests/transformers/tests/test_modeling_common.py:2058
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2058: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2096
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2096: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

tests/transformers/tests/test_modeling_common.py:2132
  /devops/sgohari/tests/codes/ig/optimum-habana/tests/transformers/tests/test_modeling_common.py:2132: PytestUnknownMarkWarning: Unknown pytest.mark.accelerate_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.accelerate_tests

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================================================= 3 passed, 86 deselected, 3 warnings in 15.75s ===================================================================================================================
```
```bash
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/gpt_neox/ -s -v -k test_cached_forward_with_and_without_attention_mask 
```
```
.
.
========================================================================================================================================== 1 passed, 88 deselected, 3 warnings in 9.31s ==========================================================================================================================================
```
