### PR TITLE
[transformers_4_49] Fix for AutoModelForCausalLM.from_pretrained()

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -459,7 +459,7 @@ def main():
 
     # Note that chatglm2/3 has float16 dtype from config.json, and on Gaudi we need to use bfloat16.
     if config.model_type == "chatglm":
-        config.dtype = "torch.bfloat16"
+        config.torch_dtype = torch.bfloat16
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,
@@ -484,6 +484,11 @@ def main():
             if model_args.torch_dtype in ["auto", None]
             else getattr(torch, model_args.torch_dtype)
         )
+        # workaraund for https://github.com/huggingface/transformers/issues/36258
+        # TODO: remove after fix is avalible in a release version of `transformers``
+        if torch_dtype is None:
+            torch_dtype = getattr(config, 'torch_dtype', None)
+
         model = AutoModelForCausalLM.from_pretrained(
             model_args.model_name_or_path,
             from_tf=bool(".ckpt" in model_args.model_name_or_path),


### PR DESCRIPTION
# What does this PR do?
Workaround for issue: https://github.com/huggingface/transformers/issues/36258
Reproducing with chatglm3 model:
`pytest tests/test_examples.py -v -s -k test_run_clm_chatglm3-6b_deepspeed`

If `torch_dtype is None`, then we check if this value can be loaded from a model's config. So it replicates behavior of `auto`.
Maybe it's better to modify the test itself to directly pass `torch_dtype=bfloat16` to the models' args.
