### PR TITLE
fea(): updated test_tied_weights_keys pytest for 4.49

### DIFF
--- a/tests/transformers/tests/test_modeling_common.py
+++ b/tests/transformers/tests/test_modeling_common.py
@@ -1637,7 +1637,7 @@ class ModelTesterMixin:
 
     def test_tied_weights_keys(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        config.tie_word_embeddings = True
+        config.get_text_config().tie_word_embeddings = True
         for model_class in self.all_model_classes:
             model_tied = model_class(config)
 
@@ -1651,8 +1651,8 @@ class ModelTesterMixin:
             tied_weight_keys = model_tied._tied_weights_keys if model_tied._tied_weights_keys is not None else []
             # Detect we get a hit for each key
             for key in tied_weight_keys:
-                if not any(re.search(key, p) for group in tied_params for p in group):
-                    raise ValueError(f"{key} is not a tied weight key for {model_class}.")
+                is_tied_key = any(re.search(key, p) for group in tied_params for p in group)
+                self.assertTrue(is_tied_key, f"{key} is not a tied weight key for {model_class}.")
 
             # Removed tied weights found from tied params -> there should only be one left after
             for key in tied_weight_keys:


### PR DESCRIPTION
# What does this PR do?
Miroring the HF 4.49 changes [here ](https://github.com/huggingface/transformers/blob/v4.49-release/tests/test_modeling_common.py#L2326)for this test. 
# Tests 
```
GAUDI2_CI=1 RUN_SLOW=true python -m pytest tests/transformers/tests/models/ -s -v -k test_tied_weights_keys
```
## Results without this PR
```
=================================================================================================================================== 1 failed, 17 passed, 1417 deselected, 15 warnings in 2.06s ===================================================================================================================================
```
## Results with this PR
```
======================================================================================================================================== 18 passed, 1417 deselected, 15 warnings in 2.00s ========================================================================================================================================
```
--
co-authored by  Camilo Moreno, camilo.a.moreno@intel.com
