### PR TITLE
Fix for lora finetune Llava image-to-text crash

### DIFF
--- a/examples/image-to-text/run_image2text_lora_finetune.py
+++ b/examples/image-to-text/run_image2text_lora_finetune.py
@@ -382,8 +382,8 @@ def eval(processor, model, dataset, batch_size, use_lazy_mode, use_hpu_graphs, m
                 images,
                 texts,
                 return_tensors="pt",
-                padding="max_length",
-                truncation=True,
+                padding=True,
+                truncation=False,
                 max_length=max_seq_length,
                 padding_side="left",
             )
@@ -611,15 +611,12 @@ def main():
         text = processor.apply_chat_template(messages, add_generation_prompt=True)
 
         if config.model_type == "llava":
-            # don't expand image_token_id
-            setattr(processor, "patch_size", None)
-            setattr(processor, "vision_feature_select_strategy", None)
             inputs = processor(
                 [image],
                 [text.strip()],
                 return_tensors="pt",
-                padding="max_length",
-                truncation=True,
+                padding=True,
+                truncation=False,
                 max_length=data_args.max_seq_length,
                 padding_side="left",
             )


### PR DESCRIPTION
When running image-to-text lora finetune llava1.5-7b-hf model with below command:
`python3 /root/optimum-habana/examples/gaudi_spawn.py --world_size 8 --use_mpi /root/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py --model_name_or_path llava-hf/llava-1.5-7b-hf --gaudi_config_name Habana/gpt2 - dataset_name nielsr/docvqa_1200_examples --do_train --output_dir /tmp/tmppy0jez4c --overwrite_output_dir --learning_rate 5e-05 --per_device_train_batch_size 2 --per_device_eval_batch_size 4 --num_train_epochs 1 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --bf16 --gradient_accumulation_steps 8 --eval_strategy no --save_strategy no --warmup_steps 50 --lr_scheduler_type constant --max_grad_norm 0.3 --logging_steps 1 --use_hpu_graphs_for_inference --lora_rank 8 --lora_alpha 8 --lora_dropout 0.1 --lora_target_modules '.*(language_model).*(down_proj|gate_proj|up_proj|k_proj|q_proj|v_proj|o_proj).*$' --low_cpu_mem_usage True --adam_epsilon 1e-08 --input_column_name image query --output_column_name answers --remove_unused_columns False --max_seq_length 512 --sdp_on_bf16`

We see below error:
```
71643 [rank0]: Traceback (most recent call last):
71644 [rank0]:   File "/root/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py", line 669, in <module>
71645 [rank0]:     main()
71646 [rank0]:   File "/root/optimum-habana/examples/image-to-text/run_image2text_lora_finetune.py", line 617, in main
71647 [rank0]:     inputs = processor(
71648 [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformers/models/llava/processing_llava.py", line 160, in __call__
71649 [rank0]:     num_image_tokens = (height // self.patch_size) * (
71650 [rank0]: TypeError: unsupported operand type(s) for //: 'int' and 'NoneType'
```

This happens because of a change in LlavaProcessor in Transformers.
In Transformers 4.45.2, if self.patch_size was None, the code skipped the part that caused the error. But in later versions, it no longer skips it.

Post this fix, it ran into tensor mismatch error similar to as mentioned in [PR-1674](https://github.com/huggingface/optimum-habana/pull/1674#issuecomment-2565151605) 

This happens because now even after automatic expansion of image tokens in processor(), it was still done in _pad_inputs() of modeling_llava.py. To resolve that, and use fix of PR-1674, padding and truncation values were changed so no expanded tokens were removed.


Fixes # (issue)
Resolves eval accuracy issue which failed due to above error.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
