### PR TITLE
Use token_idx_cpu int instead of token_idx tensor in slicing (#157)

### DIFF
--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -1167,8 +1167,11 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
         # add cross-attn mask for new token
         if cross_attention_mask_prev is not None:
             token_idx = model_kwargs.get("token_idx", None)
+            token_idx_cpu = model_kwargs.get(
+                "token_idx_cpu", None
+            )  # returns an integer so following slicing ops happen using int instead of tensor
             if token_idx is not None:
-                mask = cross_attention_mask_prev[:, token_idx - 2 : token_idx - 1, ...]
+                mask = cross_attention_mask_prev[:, token_idx_cpu - 2 : token_idx_cpu - 1, ...]
                 cross_attention_mask_prev.index_copy_(1, token_idx - 1, mask)
                 model_kwargs["cross_attention_mask"] = cross_attention_mask_prev
             else:


### PR DESCRIPTION

Token idx is a tensor and when used within python slicing, it internally calls torch's .item() function. This is unnecessary and slows down the workload. So we replace it with token idx cpu which is already an integer and perfect for this.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
