### PR TITLE
Fix for GaudiLlamaAttention' object has no attribute 'max_position_embeddings' 

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -532,11 +532,11 @@ class GaudiLlamaAttention(LlamaAttention):
         self.v_cache.allocate(inp_seq_len, dtype, device, cache_shape)
 
     def update_sincos_cache(self, seq_len):
-        # Call rotary emb forward() to update cos/sin cache when infering more than self.max_position_embeddings
+        # Call rotary emb forward() to update cos/sin cache when infering more than self.rotary_emb.original_max_seq_len
         # This helps in avoiding creation of these caches during actual model forward pass and
         # reduce memory consumption and improve performance.
-        if seq_len > self.max_position_embeddings:
-            self.max_position_embeddings = seq_len
+        if seq_len > self.rotary_emb.original_max_seq_len:
+            self.rotary_emb.original_max_seq_len = seq_len
             _, _ = self.rotary_emb(self.get_k_proj_weight(), seq_len=seq_len)
 
     def reorder(self, tensor, beam_idx, dim_a, dim_b):


### PR DESCRIPTION
# What does this PR do?

Provide a fix for the error:
`AttributeError: 'GaudiLlamaAttention' object has no attribute 'max_position_embeddings'`

When running:

```
python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py --model_name_or_path meta-llama/Llama-2-70b-hf --use_hpu_graphs --limit_hpu_graphs --use_kv_cache --bf16 --trim_logits --attn_softmax_bf16 --bucket_size=128 --bucket_internal --batch_size 8 --max_input_tokens 40960 --max_new_tokens 5120 --use_flash_attention --flash_attention_recompute --flash_attention_causal_mask --book_source
```

Tested on G3

In `main` we get:

```
Stats:
-----------------------------------------------------------------------------------
Input tokens
Throughput (including tokenization) = 281.69667986175455 tokens/second
Memory allocated                    = 22.66 GB
Max memory allocated                = 72.98 GB
Total memory available              = 126.54 GB
Graph compilation duration          = 596.9977102539851 seconds
-----------------------------------------------------------------------------------
```

With this fix on `transformers_future` we get:

```
Stats:
-----------------------------------------------------------------------------------
Input tokens
Throughput (including tokenization) = 281.71737572938207 tokens/second
Memory allocated                    = 22.66 GB
Max memory allocated                = 72.98 GB
Total memory available              = 126.54 GB
Graph compilation duration          = 592.9270469929907 seconds
-----------------------------------------------------------------------------------

```

The generated text makes also sense