### PR TITLE
Optimize memory utilization by keeping logits in BF16.

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -200,6 +200,11 @@ def main():
         type=int,
         help="Seed to use for random generation. Useful to reproduce your runs with `--do_sample`.",
     )
+    parser.add_argument(
+        "--logits_bf16",
+        action="store_true",
+        help="Compute logits in bf16",
+    )
 
     args = parser.parse_args()
 
@@ -338,6 +343,7 @@ def main():
         "flash_attention_recompute": args.flash_attention_recompute,
         "limit_hpu_graphs": args.limit_hpu_graphs,
         "do_sample": args.do_sample,
+        "logits_bf16": args.logits_bf16,
     }
 
     if args.sdp_on_bf16:

--- a/optimum/habana/transformers/generation/configuration_utils.py
+++ b/optimum/habana/transformers/generation/configuration_utils.py
@@ -41,6 +41,8 @@ class GaudiGenerationConfig(GenerationConfig):
         Whether to use fast softmax with reduced precision if use Habana flash attention.
     attn_batch_split (`int`, *optional*):
         Specify the batch size split for attention and mlp layers. 1 for no split. This is enabled only for prompt.
+    logits_bf16 (`bool`, *optional*):
+        Keep logits in bf16.
     """
 
     def __init__(self, **kwargs):
@@ -62,3 +64,4 @@ class GaudiGenerationConfig(GenerationConfig):
         self.use_fused_rope = kwargs.get("use_fused_rope", None)
         self.valid_sequence_lengths = kwargs.get("valid_sequence_lengths", None)
         self.attn_batch_split = kwargs.get("attn_batch_split", 1)
+        self.logits_bf16 = kwargs.get("logits_bf16", None)

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1477,6 +1477,9 @@ class GaudiGenerationMixin(GenerationMixin):
         # prepare for attention batch splitting
         model_kwargs["attn_batch_split"] = generation_config.attn_batch_split
 
+        # Keep logits in bf16
+        model_kwargs["logits_bf16"] = kwargs.get("logits_bf16")
+
         # determine whether flash attention needs to be used
         model_kwargs["use_flash_attention"] = generation_config.use_flash_attention
         model_kwargs["flash_attention_recompute"] = True if generation_config.flash_attention_recompute else False

--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -869,6 +869,7 @@ class GaudiMllamaForCausalLM(MllamaForCausalLM):
         token_idx: Optional[torch.Tensor] = None,
         use_flash_attention: Optional[bool] = False,
         flash_attention_recompute: Optional[bool] = False,
+        logits_bf16: Optional[bool] = False,
         **loss_kwargs,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         """
@@ -908,9 +909,12 @@ class GaudiMllamaForCausalLM(MllamaForCausalLM):
 
         if token_idx is None and logits_to_keep != 0:
             slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-            logits = self.lm_head(hidden_states[:, slice_indices, :]).float()
+            logits = self.lm_head(hidden_states[:, slice_indices, :])
         else:
-            logits = self.lm_head(hidden_states).float()
+            logits = self.lm_head(hidden_states)
+
+        if not logits_bf16:
+            logits = logits.float()
 
         loss = None
         if labels is not None:
@@ -957,6 +961,7 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
         token_idx: Optional[torch.Tensor] = None,
         use_flash_attention: Optional[bool] = False,
         flash_attention_recompute: Optional[bool] = False,
+        logits_bf16: Optional[bool] = False,
         **kwargs,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         """
@@ -1042,6 +1047,7 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
             token_idx=token_idx,
             use_flash_attention=use_flash_attention,
             flash_attention_recompute=flash_attention_recompute,
+            logits_bf16=logits_bf16,
         )
 
         return outputs
@@ -1123,6 +1129,7 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
                 "token_idx": token_idx,
                 "use_flash_attention": kwargs.get("use_flash_attention"),
                 "flash_attention_recompute": kwargs.get("flash_attention_recompute"),
+                "logits_bf16": kwargs.get("logits_bf16"),
             }
         )
 


### PR DESCRIPTION
Use the `--logits_bf16` parameter to keep logits in BF16; otherwise, fall back to the default path.