### PR TITLE
Revert "Move model to device before wrapping with FSDP (#1801)"

### DIFF
--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -476,9 +476,6 @@ class GaudiAccelerator(Accelerator):
                         "limit_all_gathers": fsdp_plugin.limit_all_gathers,
                         "device_id": torch.device("hpu", torch.hpu.current_device()),
                     }
-                    # There's issue with moving view tensors to device within FSDP class [See: https://github.com/pytorch/pytorch/issues/147321]
-                    # Due to above issue, view tensor's may lead to silent incorrent behavior, while pretending to be view they're really not
-                    model = model.to(kwargs["device_id"])
                     model = FSDP(model, **kwargs)
                     if fsdp_plugin.activation_checkpointing:
                         from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (


### PR DESCRIPTION
This reverts commit 379524c1c77a66cdfbd0d68606aa8a5def15bda0.

Unfortunately, this commit is causing OOM issues when running:

```
PT_HPU_AUTOCAST_LOWER_PRECISION_OPS_LIST=ops_bf16.txt PT_HPU_LAZY_MODE=0 \
python3 ../gaudi_spawn.py --world_size 8 --use_mpi run_lora_clm.py \
  --model_name_or_path meta-llama/Llama-2-70b-hf \
  --dataset_name tatsu-lab/alpaca \
  --bf16 True \
  --output_dir ./lora_out \
  --max_seq_len 2048 \
  --gradient_checkpointing \
  --per_device_train_batch_size 5 \
  --save_strategy no \
  --learning_rate 0.0004 \
  --warmup_ratio 0.03 \
  --lr_scheduler_type "constant" \
  --logging_steps 1 \
  --dataset_concatenation \
  --do_train \
  --use_habana \
  --throughput_warmup_steps 3 \
  --lora_rank 4 \
  --lora_target_modules "q_proj" "v_proj" "k_proj" "o_proj" \
  --attn_softmax_bf16 True \
  --validation_split_percentage 4 \
  --use_lazy_mode False \
  --fsdp_config fsdp_config.json \
  --fsdp auto_wrap \
  --num_train_epochs 2 \
  --eval_strategy epoch \
  --per_device_eval_batch_size 1 \
  --eval_delay 2 \
  --do_eval \
  --pipelining_fwd_bwd False \
  --use_fused_rope False \
  --torch_compile_backend hpu_backend \
  --torch_compile \
  --gradient_accumulation_steps 2 \
  --use_flash_attention True \
  --flash_attention_causal_mask True
```
command from https://github.com/huggingface/optimum-habana/tree/transformers_future/examples/language-modeling
