### PR TITLE
Disable HPU migration (future add-on to HF diffusers) for OH diffusers

### DIFF
--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -344,6 +344,16 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
                 create_pr=create_pr,
             )
 
+    def to(self, *args, **kwargs):
+        """
+        Intercept to() method and disable gpu-hpu migration before sending to diffusers
+        """
+        kwargs["hpu_migration"] = False
+        return super().to(
+            *args,
+            **kwargs,
+        )
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], **kwargs):
         """

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
@@ -260,6 +260,16 @@ class StableDiffusionXLPipeline_HPU(StableDiffusionXLPipeline):
 
         return latents
 
+    def to(self, *args, **kwargs):
+        """
+        Intercept to() method and disable gpu-hpu migration before sending to diffusers
+        """
+        kwargs["hpu_migration"] = False
+        return super().to(
+            *args,
+            **kwargs,
+        )
+
     @classmethod
     def _split_inputs_into_batches(
         cls,


### PR DESCRIPTION
# What does this PR do?

We are planning to add generic support for HPUs inside HF Diffusers. This support will rely on GPU-HPU migration toolkit under the hood.

When added, one can run any diffusers pipeline out-of-the-box directly from HF diffusers (it will not be particularly optimized but it would be functional and HPU accelerated), even if this pipeline is not ported to OH.

For example, when this support is added, one can run Sana pipeline (which is NOT in OH) on HPU directly via diffusers like this:
```python
import torch
from diffusers import SanaPipeline
pipe = SanaPipeline.from_pretrained("Efficient-Large-Model/Sana_1600M_1024px_BF16_diffusers", torch_dtype=torch.bfloat16)
pipe.to("hpu")
image = pipe(prompt='a cyberpunk cat with a neon sign that says "Sana"')[0]
image.save("sana.png")
```

Since overriding `.to("hpu")` in HF Diffusers will perform migration and could clash with assigning HPU device from Gaudi diffusers pipelines from OH, we should explicitly disable the migration in OH by overriding `.to()` in OH/diffusers.
