### PR TITLE
Fix llama internal bucketing issue

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1600,6 +1600,10 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
         if num_logits_to_keep is not None:
             model_inputs["num_logits_to_keep"] = num_logits_to_keep
 
+        if bucket_internal and reuse_cache is not True:
+            # update input with kv cache len to capture padding changes during internal bucketing without cache reuse
+            model_inputs["kv_cache_len"] = kwargs.get("kv_cache_len")
+
         model_inputs.update(
             {
                 "position_ids": position_ids,


### PR DESCRIPTION
# What does this PR do?

Fixes bug in Llama model when internal bucketing is enabled without reuse cache option. 

When these options are enabled in Lazy HPU graph mode, HPU graph logic will fail to capture changes in the input padding on the fly (e.g. by changing `max new tokens`) and will try to replay old graph (with old padding), causing error.

Here is an example which will reproduce the issue:
```python
#!/usr/bin/env python
import torch
import transformers
from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
from habana_frameworks.torch.hpu import wrap_in_hpu_graph
adapt_transformers_to_gaudi()

model_id = "meta-llama/Llama-3.1-8B-Instruct"

model_kwargs = {
    "torch_dtype": torch.bfloat16,
    "use_cache": True,
}

generation_config = transformers.AutoConfig.from_pretrained(model_id, **model_kwargs)
generation_config.update({
    "pad_token_id": 50256,
    "use_flash_attention": True,
})

# Tokenize
tokenizer = transformers.AutoTokenizer.from_pretrained(model_id,generation_config=generation_config, **model_kwargs)
tokenizer.pad_token_id = 50256
input_sentences = ["Planet Earth, our cosmic home, is a unique and vibrant oasis in the vastness of the universe."]
max_input_tokens = 10
input_tokens = tokenizer.batch_encode_plus(input_sentences, max_length=max_input_tokens, truncation=True, return_tensors="pt", padding="max_length").to("hpu")
print(tokenizer.batch_decode(input_tokens["input_ids"], skip_special_tokens=True))

# Run inference
model = transformers.AutoModelForCausalLM.from_pretrained(model_id, generation_config=generation_config, **model_kwargs).to("hpu")
model = wrap_in_hpu_graph(model)

run_generation_args = {}
run_generation_args.update({
    "bucket_internal": True,
    "bucket_size": 512,
})

out = model.generate(**input_tokens, max_new_tokens=1, **run_generation_args).cpu()
print(tokenizer.batch_decode(out, skip_special_tokens=True))

out = model.generate(**input_tokens, max_new_tokens=5, **run_generation_args).cpu()
print(tokenizer.batch_decode(out, skip_special_tokens=True))
```

Output before fix:
```bash
['Planet Earth, our cosmic home, is a']
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  5.90it/s]
['Planet Earth, our cosmic home, is a beautiful']
Traceback (most recent call last):
  File "/home/dsocek/./test.py", line 42, in <module>
    out = model.generate(**input_tokens, max_new_tokens=5, **run_generation_args).cpu()
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/dsocek/optimum-habana_dsocek/optimum/habana/transformers/generation/utils.py", line 1686, in generate
    result = self._sample(
  File "/home/dsocek/optimum-habana_dsocek/optimum/habana/transformers/generation/utils.py", line 2658, in _sample
    outputs = self(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1753, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 745, in forward
    return wrapped_hpugraph_forward(
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 611, in wrapped_hpugraph_forward
    graph.capture_end()
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 64, in capture_end
    _hpu_C.capture_end(self.hpu_graph)
RuntimeError: Graph compile failed. synStatus=synStatus 26 [Generic failure].
```

Output after fix:
```bash
['Planet Earth, our cosmic home, is a']
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  6.08it/s]
['Planet Earth, our cosmic home, is a beautiful']
['Planet Earth, our cosmic home, is a beautiful and diverse place.']
```