### PR TITLE
fea(): Diffuser upgrade to 0.32.0

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -487,7 +487,7 @@ def main():
         # workaraund for https://github.com/huggingface/transformers/issues/36258
         # TODO: remove after fix is avalible in a release version of `transformers``
         if torch_dtype is None:
-            torch_dtype = getattr(config, 'torch_dtype', None)
+            torch_dtype = getattr(config, "torch_dtype", None)
 
         model = AutoModelForCausalLM.from_pretrained(
             model_args.model_name_or_path,

--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -18,10 +18,14 @@ from math import ceil
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+from diffusers import (
+    AutoencoderKL,
+    ControlNetModel,
+    MultiControlNetModel,
+    StableDiffusionControlNetPipeline,
+    UNet2DConditionModel,
+)
 from diffusers.image_processor import PipelineImageInput
-from diffusers.models import AutoencoderKL, ControlNetModel, UNet2DConditionModel
-from diffusers.pipelines.controlnet import StableDiffusionControlNetPipeline
-from diffusers.pipelines.controlnet.multicontrolnet import MultiControlNetModel
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.schedulers import KarrasDiffusionSchedulers
 from diffusers.utils import deprecate

--- a/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
+++ b/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
@@ -26,7 +26,14 @@ from diffusers.models.autoencoders import AutoencoderKL
 from diffusers.models.transformers import FluxTransformer2DModel
 from diffusers.pipelines.flux.pipeline_flux import FluxPipeline, calculate_shift, retrieve_timesteps
 from diffusers.utils import BaseOutput, replace_example_docstring
-from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
+from transformers import (
+    CLIPImageProcessor,
+    CLIPTextModel,
+    CLIPTokenizer,
+    CLIPVisionModelWithProjection,
+    T5EncoderModel,
+    T5TokenizerFast,
+)
 
 from optimum.utils import logging
 
@@ -256,7 +263,7 @@ class GaudiFusedFluxAttnProcessor2_0:
 
 class GaudiFluxPipeline(GaudiDiffusionPipeline, FluxPipeline):
     r"""
-    Adapted from https://github.com/huggingface/diffusers/blob/v0.30.3/src/diffusers/pipelines/flux/pipeline_flux.py#L140
+    Adapted from https://github.com/huggingface/diffusers/blob/v0.32.0/src/diffusers/pipelines/flux/pipeline_flux.py#L140
         Added batch size control for inference, and support for HPU graphs and Gaudi quantization via Intel Neural Compressor
 
     The Flux pipeline for text-to-image generation.
@@ -297,7 +304,7 @@ class GaudiFluxPipeline(GaudiDiffusionPipeline, FluxPipeline):
     """
 
     model_cpu_offload_seq = "text_encoder->text_encoder_2->transformer->vae"
-    _optional_components = []
+    _optional_components = ["image_encoder", "feature_extractor"]
     _callback_tensor_inputs = ["latents", "prompt_embeds"]
 
     def __init__(
@@ -309,6 +316,8 @@ class GaudiFluxPipeline(GaudiDiffusionPipeline, FluxPipeline):
         text_encoder_2: T5EncoderModel,
         tokenizer_2: T5TokenizerFast,
         transformer: FluxTransformer2DModel,
+        image_encoder: CLIPVisionModelWithProjection = None,
+        feature_extractor: CLIPImageProcessor = None,
         use_habana: bool = False,
         use_hpu_graphs: bool = False,
         gaudi_config: Union[str, GaudiConfig] = None,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -32,8 +32,10 @@ from diffusers.utils import (
     replace_example_docstring,
 )
 from transformers import (
+    BaseImageProcessor,
     CLIPTextModelWithProjection,
     CLIPTokenizer,
+    PreTrainedModel,
     T5EncoderModel,
     T5TokenizerFast,
 )
@@ -175,7 +177,7 @@ class GaudiJointAttnProcessor2_0:
 
 class GaudiStableDiffusion3Pipeline(GaudiDiffusionPipeline, StableDiffusion3Pipeline):
     r"""
-    Adapted from: https://github.com/huggingface/diffusers/blob/v0.29.2/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py#L128
+    Adapted from: https://github.com/huggingface/diffusers/blob/v0.32.0/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py#L147
 
     Args:
         transformer ([`SD3Transformer2DModel`]):
@@ -221,6 +223,8 @@ class GaudiStableDiffusion3Pipeline(GaudiDiffusionPipeline, StableDiffusion3Pipe
             Whether to allow PyTorch to use reduced precision in the SDPA math backend.
     """
 
+    _optional_components = ["image_encoder", "feature_extractor"]
+
     def __init__(
         self,
         transformer: SD3Transformer2DModel,
@@ -232,6 +236,8 @@ class GaudiStableDiffusion3Pipeline(GaudiDiffusionPipeline, StableDiffusion3Pipe
         tokenizer_2: CLIPTokenizer,
         text_encoder_3: T5EncoderModel,
         tokenizer_3: T5TokenizerFast,
+        image_encoder: PreTrainedModel = None,
+        feature_extractor: BaseImageProcessor = None,
         use_habana: bool = False,
         use_hpu_graphs: bool = False,
         gaudi_config: Union[str, GaudiConfig] = None,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ INSTALL_REQUIRES = [
     "optimum",
     "torch",
     "accelerate >= 0.33.0, < 0.34.0",
-    "diffusers >= 0.31.0, < 0.32.0",
+    "diffusers >= 0.32.0, < 0.32.1",
     "huggingface_hub >= 0.24.7",
     "sentence-transformers == 3.3.1",
 ]

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -49,6 +49,7 @@ from diffusers import (
     FluxTransformer2DModel,
     I2VGenXLUNet,
     LCMScheduler,
+    MultiControlNetModel,
     PNDMScheduler,
     SD3Transformer2DModel,
     StableDiffusionXLPipeline,
@@ -60,7 +61,6 @@ from diffusers import (
     UniPCMultistepScheduler,
 )
 from diffusers.image_processor import VaeImageProcessor
-from diffusers.pipelines.controlnet.pipeline_controlnet import MultiControlNetModel
 from diffusers.schedulers import KarrasDiffusionSchedulers
 from diffusers.utils import logging
 from diffusers.utils.testing_utils import (


### PR DESCRIPTION
# What does this PR do?
This PR updates the diffuser version to v.32.0. 
We have adopted the changes from the HF upstream and the following tests have been conducted on both Gaudi2 and Gaudi3. 
The results are all passing/meeting the exceptions (logs are internally avail). 
- pytest diffusers (g2: CI#109, g3: CI#28)
- diffuser fast tests (g2: CI#109, g3: CI#28)
- diffusers slow tests (g2: CI#109, g3: CI#28)
- diffusers README validation, inference (g2: CI#422, g3: CI#2)
- diffusers README validation, training (g2: CI#424, g3: CI#8)

--
Co-athured by Daniel Socek, @dsocek 


Fixes # (issue)
HS-5619

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?
