### PR TITLE
Update train_runtime reference number for clm gpt2_xl to fix pytest failure

### DIFF
--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -102,7 +102,7 @@
     },
     "gaudi2": {
       "perplexity": 13.1786,
-      "train_runtime": 224.3465,
+      "train_runtime": 241.093,
       "train_samples_per_second": 96.789
     },
     "gaudi3": {

--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -102,7 +102,7 @@
     },
     "gaudi2": {
       "perplexity": 13.237754028004865,
-      "train_runtime": 206.5775,
+      "train_runtime": 236.53,
       "train_samples_per_second": 95.539
     },
     "gaudi3": {


### PR DESCRIPTION
With the new changes from [PR-1869](https://github.com/huggingface/optimum-habana/pull/1869) the pytest test_run_clm_gpt2-xl_deepspeed for clm gtp2_xl is failing due to train_runtime. 
`root:test_examples.py:785 train_runtime: le(236.54, 1.05 * 206.5775)`

Reference train_runtime = 216.90

The test should be updated with new reference train_runtime to avoid future failures. This is the new train_runtime results on G2 measured with PR-1869. Once PR-1869 is merged, this change should also be merged to avoid failures.

Command tested:
`RUN_SLOW=1 python -m pytest test_examples.py -v -s -k "test_run_clm_gpt2-xl_deepspeed"`

Results without PR-1869:
```
***** train metrics *****
  epoch                       =        2.0
  max_memory_allocated (GB)   =      34.83
  memory_allocated (GB)       =      15.29
  total_flos                  = 41067876GF
  total_memory_available (GB) =      94.62
  train_loss                  =     2.7694
  train_runtime               = 0:03:23.79
  train_samples               =       2318
  train_samples_per_second    =     95.496
  train_steps_per_second      =      0.786
```
Note: The old train_runtime was 3:23 (~203 sec) which was within reference value.

Results with PR-1869:
```
***** train metrics *****
  epoch                       =        2.0
  max_memory_allocated (GB)   =      37.55
  memory_allocated (GB)       =      15.29
  total_flos                  = 41067876GF
  total_memory_available (GB) =      94.62
  train_loss                  =     2.8371
  train_runtime               = 0:03:56.53
  train_samples               =       2318
  train_samples_per_second    =     95.361
  train_steps_per_second      =      0.785
```
Note: The new train_runtime is 03:56 (~236 sec) which should now be new reference value to fix the issue

Fixes # (issue)
Fixes the pytest test_run_clm_gpt2-xl_deepspeed

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
