### PR TITLE
Support compile from the 2nd iteration

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -135,7 +135,7 @@ if is_peft_available():
 if is_deepspeed_available():
     from accelerate.utils import DeepSpeedSchedulerWrapper
 
-from accelerate.utils import DataLoaderConfiguration
+from accelerate.utils import DataLoaderConfiguration, is_torch_version
 
 
 def _get_input_update_settings(model, lazy_mode: Optional[bool] = None) -> Tuple[bool, Dict]:
@@ -958,6 +958,8 @@ class GaudiTrainer(Trainer):
                 )
                 for i, inputs in enumerate(batch_samples):
                     step += 1
+                    if self.args.compile_from_sec_iteration and is_torch_version(">=", "2.6.0"):
+                        torch.compiler.set_stance("force_eager" if step == 0 else "default")
 
                     if (
                         args.throughput_warmup_steps > 0

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -107,6 +107,8 @@ class GaudiTrainingArguments(TrainingArguments):
             Whether to use HPU graphs for performing inference. It will speed up training but may not be compatible with some operations.
         use_compiled_autograd (`bool`, *optional*, defaults to `False`):
             Whether to use compiled autograd for training. Currently only for summarization models.
+        compile_from_sec_iteration (`bool`, *optional*, defaults to `False`):
+            Whether to torch.compile from the second training iteration.
         compile_dynamic (`bool|None`, *optional*, defaults to `None`):
             Set value of 'dynamic' parameter for torch.compile.
         use_regional_compilation (`bool`, *optional*, defaults to `False`):
@@ -177,6 +179,11 @@ class GaudiTrainingArguments(TrainingArguments):
     use_compiled_autograd: Optional[bool] = field(
         default=False,
         metadata={"help": ("Whether to use compiled autograd for training. Currently only for summarization models.")},
+    )
+
+    compile_from_sec_iteration: Optional[bool] = field(
+        default=False,
+        metadata={"help": ("Whether to torch.compile from the second training iteration.")},
     )
 
     compile_dynamic: Optional[bool | None] = field(


### PR DESCRIPTION
Change-Id: Ic15cd7d04b93a4674425f4752ef31eedb64afe87

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

We add an option to compile from the 2nd iteration. This can be helpful when the dynamic graph contains some opaque operators which cannot be inspect during the tracing.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
