### PR TITLE
Support allow_unspec_int_on_nn_module

### DIFF
--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -107,6 +107,8 @@ class GaudiTrainingArguments(TrainingArguments):
             Set value of 'inline_inbuilt_nn_modules' parameter for torch._dynamo.config. Currently, disabling this parameter improves the performance of the ALBERT model.
         cache_size_limit(`int`, *optional*, defaults to 'None'):
             Set value of 'cache_size_limit' parameter for torch._dynamo.config
+        allow_unspec_int_on_nn_module (`bool`, *optional*, defaults to `None`):
+            Set value of 'allow_unspec_int_on_nn_module' parameter for torch._dynamo.config.
         disable_tensor_cache_hpu_graphs (`bool`, *optional*, defaults to `False`):
             Whether to disable tensor cache when using hpu graphs. If True, tensors won't be cached in hpu graph and memory can be saved.
         max_hpu_graphs (`int`, *optional*):
@@ -189,6 +191,13 @@ class GaudiTrainingArguments(TrainingArguments):
     inline_inbuilt_nn_modules: Optional[bool] = field(
         default=None,
         metadata={"help": ("Set value of 'inline_inbuilt_nn_modules' parameter for torch._dynamo.config.")},
+    )
+
+    # This works only if compile kwarg "dynamic = None" or "dynamic = True" is
+    # set and has no effect when "dynamic = False"
+    allow_unspec_int_on_nn_module: Optional[bool] = field(
+        default=None,
+        metadata={"help": ("Set value of 'allow_unspec_int_on_nn_module' parameter for torch._dynamo.config.")},
     )
 
     disable_tensor_cache_hpu_graphs: Optional[bool] = field(
@@ -900,6 +909,9 @@ class GaudiTrainingArguments(TrainingArguments):
 
         if self.torch_compile and self.cache_size_limit is not None:
             torch._dynamo.config.cache_size_limit = self.cache_size_limit
+
+        if self.allow_unspec_int_on_nn_module is not None:
+            torch._dynamo.config.allow_unspec_int_on_nn_module = self.allow_unspec_int_on_nn_module
 
         logger.info("PyTorch: setting up devices")
         if not is_accelerate_available():


### PR DESCRIPTION
Change-Id: Id7a21c0c1e014e9dc8c503c645a252ad4da136fb

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This is an option from https://github.com/pytorch/pytorch/pull/142829 to not specialize int from nn.Modules under torch.compile mode


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
