### PR TITLE
Llama2 70 b OOM fix

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -559,6 +559,7 @@ class GaudiLlamaAttention(LlamaAttention):
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         attention_mask: Optional[torch.Tensor],
         past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
         use_cache: bool = False,
         cache_position: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
@@ -779,6 +780,8 @@ class GaudiLlamaAttention(LlamaAttention):
         attn_output = attn_output.transpose(1, 2).contiguous()
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
+        if not output_attentions:
+            attn_weights = None
 
         if not reuse_cache and token_idx is not None and cache_idx is not None and q_len == 1:
             # Return only past key value shapes and not the tensors during decode phase (q len is 1)


### PR DESCRIPTION
# Fix
Without this small fix, there is an OOM issue with multiple models.
To reproduce it:

```
cd optimum-habana &&
pip install -e . &&
cd optimum-habana/examples/text-generation &&
pip install -r requirements.txt && 
pip install -r requirements_lm_eval.txt &&
HF_DATASETS_TRUST_REMOTE_CODE=true QUANT_CONFIG=optimum-habana/examples/text-generation/quantization_config/maxabs_measure.json  TQDM_DISABLE=1 python3 ../gaudi_spawn.py --use_deepspeed --world_size 2 run_lm_eval.py --model_name_or_path meta-llama/Llama-2-70b-hf --warmup 0 --use_hpu_graphs -o test_results_measure.json --bf16 --batch_size 8 --use_kv_cache --trim_logits --attn_softmax_bf16 --bucket_size=128 --bucket_internal --trust_remote_code --tasks hellaswag lambada_openai piqa winogrande
```
Accuracy is the same