### PR TITLE
Tokenizer config fix for dynamic mode (#144)

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -682,7 +682,7 @@ def main():
             # Tokenize the texts
             return tokenizer(
                 examples[column_name],
-                padding="max_length",
+                padding="max_length" if prompt_length > 0 else False,
                 max_length=prompt_length if prompt_length > 0 else None,
                 truncation=prompt_length > 0,
             )


### PR DESCRIPTION
Issue:
For the Llama2 7B Dynamic mode, with padding="max_length", the tokenizer produces 'input_ids' without padding and having actual tokens only in the list. This is expected and works fine.

For the Llama3.1 8B Dynamic mode, with padding="max_length", the tokenizer produces 'input_ids' with padding and having 128K tokens (which is the max model input length. This is not expected.

Fix: The tokenizer configuration has been changed to address this issue.