### PR TITLE
Improve diffusers training download script

### DIFF
--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -23,6 +23,14 @@ This directory contains scripts that showcase how to perform training/fine-tunin
 The `textual_inversion_sdxl.py` script shows how to implement textual inversion fine-tuning on Gaudi for XL diffusion models
 such as `stabilityai/stable-diffusion-xl-base-1.0` or `cagliostrolab/animagine-xl-3.1` for example.
 
+For this example we will use a set of cat toy images from the following dataset:
+[https://huggingface.co/datasets/diffusers/cat_toy_example](https://huggingface.co/datasets/diffusers/cat_toy_example).
+
+To download this and other example training datasets locally, run:
+```bash
+python download_train_datasets.py
+```
+
 Assuming the afforemenioned cat toy dataset has been obtained, we can launch textual inversion XL training using:
 
 ```bash

--- a/examples/stable-diffusion/training/download_train_datasets.py
+++ b/examples/stable-diffusion/training/download_train_datasets.py
@@ -45,8 +45,8 @@ file_path2 = hf_hub_download(
     repo_type="dataset",
     local_dir=local_dir,
 )
-shutil.move(file_path1, local_dir)
-shutil.move(file_path2, local_dir)
+shutil.copy2(file_path1, local_dir)
+shutil.copy2(file_path2, local_dir)
 cache_dir = Path(local_dir, ".cache")
 if cache_dir.is_dir():
     shutil.rmtree(cache_dir)


### PR DESCRIPTION
# What does this PR do?

This PR improves download script for diffusers training samples.

If we already ran `./download_train_datasets.py` current script would raise error that destination patch already exists:
```bash
./download_train_datasets.py
Fetching 6 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00, 39.09it/s]
Fetching 5 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 35.63it/s]
Traceback (most recent call last):
  File "/root/optimum-habana_transformers_future/examples/stable-diffusion/training/./download_train_datasets.py", line 48, in <module>
    shutil.move(file_path1, local_dir)
  File "/usr/lib/python3.10/shutil.py", line 814, in move
    raise Error("Destination path '%s' already exists" % real_dst)
shutil.Error: Destination path './cnet/conditioning_image_1.png' already exists
```

In a more robust version, we use `copy2` instead of `move` which works OK even with multiple runs.   2nd run works without raising errors: 

```bash
./download_train_datasets.py
Fetching 6 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00, 32.20it/s]
Fetching 5 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 16.56it/s]
conditioning_image_1.png: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 26.7k/26.7k [00:00<00:00, 183MB/s]
conditioning_image_2.png: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.22k/7.22k [00:00<00:00, 79.9MB/s]
```