### PR TITLE
Move model to device before wrapping with fsdp 

### DIFF
--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -376,7 +376,7 @@ def main():
         token=model_args.token,
         trust_remote_code=model_args.trust_remote_code,
     )
-
+    model = model.to("hpu")
     # Tokenizer check: this script requires a fast tokenizer.
     if not isinstance(tokenizer, PreTrainedTokenizerFast):
         raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Reintroducing https://github.com/huggingface/optimum-habana/pull/1830/files from @skaulintel, as having a more generic fix is causing OOM in other scenarios, but totally removing it, it will cause 
`pytest tests/test_fsdp_examples.py::test_fsdp_bf16[bert-base-uncased-Habana/bert-base-uncased-question-answering-24-8-run_qa.py-full_shard]` to fail


