### PR TITLE
Use data cache in slow_tests_8x (#214)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ slow_tests_1x: test_installs
 
 # Run multi-card non-regression tests
 slow_tests_8x: test_installs
-	python -m pytest tests/test_examples.py -v -s -k "multi_card"
+	DATA_CACHE=$(DATA_CACHE) python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Run DeepSpeed non-regression tests
 slow_tests_deepspeed: test_installs

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -447,7 +447,7 @@ class ExampleTestMeta(type):
                         self.assertGreaterEqual(results["accuracy"], baseline)
                 return
             elif self.EXAMPLE_NAME == "run_clip":
-                if os.environ.get("DATA_CACHE", None) is None:
+                if os.environ.get("DATA_CACHE", "") == "":
                     from .clip_coco_utils import COCO_URLS, download_files
 
                     download_files(COCO_URLS)
@@ -515,7 +515,7 @@ class ExampleTestMeta(type):
                 env_variables["PT_HPU_LAZY_MODE"] = "0"
                 if "--use_hpu_graphs_for_inference" in extra_command_line_arguments:
                     extra_command_line_arguments.remove("--use_hpu_graphs_for_inference")
-            if os.environ.get("DATA_CACHE", None) is not None and self.EXAMPLE_NAME == "run_clip":
+            if os.environ.get("DATA_CACHE", "") != "" and self.EXAMPLE_NAME == "run_clip":
                 extra_command_line_arguments[0] = "--data_dir {}".format(os.environ["DATA_CACHE"])
 
             if torch_compile and (
@@ -870,7 +870,7 @@ class MultiCardSpeechRecognitionExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_speech_recognition_ctc", multi_card=True
 ):
     TASK_NAME = "regisss/librispeech_asr_for_optimum_habana_ci"
-    DATASET_NAME = os.environ.get("DATA_CACHE", None)
+    DATASET_NAME = os.environ.get("DATA_CACHE")
 
 
 class MultiCardSummarizationExampleTester(


### PR DESCRIPTION
Allows for using cached datasets (http://images.cocodataset.org) in slow tests.



