### PR TITLE
Use HabanaGenerationTime

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -17,7 +17,6 @@ import argparse
 import json
 import logging
 import os
-import time
 from pathlib import Path
 
 import PIL.Image
@@ -25,13 +24,10 @@ import requests
 import torch
 from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor, pipeline
 
-<<<<<<< HEAD
 from optimum.habana.utils import (
+    HabanaGenerationTime,
     set_seed,
 )
-=======
-from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats, set_seed
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 
 logging.basicConfig(

--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -25,9 +25,13 @@ import requests
 import torch
 from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor, pipeline
 
+<<<<<<< HEAD
 from optimum.habana.utils import (
     set_seed,
 )
+=======
+from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats, set_seed
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 
 logging.basicConfig(
@@ -377,11 +381,9 @@ def main():
     if args.quant_config:
         finalize_quantization(generator.model)
 
-    start = time.perf_counter()
-    for i in range(args.n_iterations):
-        result = generator(images, prompt=args.prompt, batch_size=args.batch_size, generate_kwargs=generate_kwargs)
-    end = time.perf_counter()
-    duration = end - start
+    with HabanaGenerationTime() as timer:
+        for i in range(args.n_iterations):
+            result = generator(images, prompt=args.prompt, batch_size=args.batch_size, generate_kwargs=generate_kwargs)
 
     # Let's calculate the number of generated tokens
     n_input_tokens = len(generator.tokenizer(args.prompt).input_ids) if args.prompt is not None else 0
@@ -396,10 +398,10 @@ def main():
             n_output_tokens += args.max_new_tokens
 
     total_new_tokens_generated = args.n_iterations * n_output_tokens
-    throughput = total_new_tokens_generated / duration
+    throughput = total_new_tokens_generated / timer.last_duration
     logger.info(f"result = {result}")
     logger.info(
-        f"time = {(end - start) * 1000 / args.n_iterations}ms, Throughput (including tokenization) = {throughput} tokens/second"
+        f"time = {timer.last_duration * 1000 / args.n_iterations}ms, Throughput (including tokenization) = {throughput} tokens/second"
     )
 
     # Store results if necessary

--- a/examples/object-segementation/run_example_sam.py
+++ b/examples/object-segementation/run_example_sam.py
@@ -16,7 +16,6 @@
 # Copied from https://huggingface.co/facebook/sam-vit-base
 
 import argparse
-import time
 
 import habana_frameworks.torch as ht
 import requests
@@ -25,6 +24,7 @@ from PIL import Image
 from transformers import AutoModel, AutoProcessor
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 
 if __name__ == "__main__":
@@ -94,11 +94,10 @@ if __name__ == "__main__":
         total_model_time = 0
         for i in range(args.n_iterations):
             inputs = processor(image, input_points=points, return_tensors="pt").to("hpu")
-            model_start_time = time.time()
-            outputs = model(**inputs)
-            torch.hpu.synchronize()
-            model_end_time = time.time()
-            total_model_time = total_model_time + (model_end_time - model_start_time)
+            with HabanaGenerationTime() as timer:
+                outputs = model(**inputs)
+                torch.hpu.synchronize()
+            total_model_time += timer.last_duration
 
             if args.print_result:
                 if i == 0:  # generate/output once only

--- a/examples/protein-folding/run_esmfold.py
+++ b/examples/protein-folding/run_esmfold.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 # This script is based on https://colab.research.google.com/github/huggingface/notebooks/blob/main/examples/protein_folding.ipynb
 import os
-import time
 
 import habana_frameworks.torch.core as htcore
 import torch
@@ -25,6 +24,7 @@ from transformers.models.esm.openfold_utils.protein import Protein as OFProtein
 from transformers.models.esm.openfold_utils.protein import to_pdb
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 
 os.environ["PT_HPU_ENABLE_H2D_DYNAMIC_SLICE"] = "0"
@@ -99,10 +99,10 @@ with torch.no_grad():
 
     for batch in range(steps):
         print(f"ESMFOLD: step {batch} start ...")
-        start = time.time()
-        output = model(tokenized_input)
-        htcore.mark_step()
-        print(f"ESMFOLD: step {batch} duration: {time.time() - start:.03f} seconds")
+        with HabanaGenerationTime() as timer:
+            output = model(tokenized_input)
+            htcore.mark_step()
+        print(f"ESMFOLD: step {batch} duration: {timer.last_duration:.03f} seconds")
 
 pdb = convert_outputs_to_pdb(output)
 pdb_file = "save-hpu.pdb"

--- a/examples/stable-diffusion/training/textual_inversion.py
+++ b/examples/stable-diffusion/training/textual_inversion.py
@@ -20,7 +20,6 @@ import math
 import os
 import random
 import shutil
-import time
 import warnings
 from pathlib import Path
 
@@ -53,7 +52,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from optimum.habana import GaudiConfig
 from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiDDIMScheduler, GaudiStableDiffusionPipeline
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import HabanaGenerationTime, set_seed
 
 
 if is_wandb_available():
@@ -838,13 +837,12 @@ def main():
     # keep original embeddings as reference
     orig_embeds_params = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight.data.clone()
 
-    t0 = None
-
+    timer = HabanaGenerationTime()
     for epoch in range(first_epoch, args.num_train_epochs):
         text_encoder.train()
         for step, batch in enumerate(train_dataloader):
-            if t0 is None and global_step == args.throughput_warmup_steps:
-                t0 = time.perf_counter()
+            if not timer.is_running() and global_step == args.throughput_warmup_steps:
+                timer.start()
 
             with accelerator.accumulate(text_encoder):
                 # Convert images to latent space
@@ -954,7 +952,8 @@ def main():
             if global_step >= args.max_train_steps:
                 break
 
-    duration = time.perf_counter() - t0
+    timer.step()
+    duration = timer.last_duration
     throughput = (args.max_train_steps - args.throughput_warmup_steps) * total_batch_size / duration
 
     # Create the pipeline using the trained modules and save it.

--- a/examples/stable-diffusion/training/train_controlnet.py
+++ b/examples/stable-diffusion/training/train_controlnet.py
@@ -25,7 +25,6 @@ import math
 import os
 import random
 import shutil
-import time
 from pathlib import Path
 
 import diffusers
@@ -56,7 +55,7 @@ from transformers import AutoTokenizer, PretrainedConfig
 from optimum.habana import GaudiConfig
 from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiDDIMScheduler, GaudiStableDiffusionControlNetPipeline
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import HabanaGenerationTime, set_seed
 
 
 try:
@@ -1032,11 +1031,11 @@ def main(args):
     )
 
     image_logs = None
-    t0 = None
+    timer = HabanaGenerationTime()
     for epoch in range(first_epoch, args.num_train_epochs):
         for step, batch in enumerate(train_dataloader):
-            if t0 is None and global_step == args.throughput_warmup_steps:
-                t0 = time.perf_counter()
+            if not timer.is_running() and global_step == args.throughput_warmup_steps:
+                timer.start()
             with accelerator.accumulate(controlnet):
                 # Convert images to latent space
                 latents = vae.encode(batch["pixel_values"].to(dtype=weight_dtype)).latent_dist.sample()
@@ -1150,7 +1149,8 @@ def main(args):
             if global_step >= args.max_train_steps:
                 break
 
-    duration = time.perf_counter() - t0
+    timer.step()
+    duration = timer.last_duration
     throughput = (args.max_train_steps - args.throughput_warmup_steps) * total_batch_size / duration
 
     # Create the pipeline using using the trained modules and save it.

--- a/examples/stable-diffusion/training/train_text_to_image_sdxl.py
+++ b/examples/stable-diffusion/training/train_text_to_image_sdxl.py
@@ -28,7 +28,6 @@ import math
 import os
 import random
 import shutil
-import time
 from pathlib import Path
 
 import accelerate
@@ -69,7 +68,7 @@ from optimum.habana.diffusers import (
     GaudiEulerDiscreteScheduler,
     GaudiStableDiffusionXLPipeline,
 )
-from optimum.habana.utils import HabanaProfile, set_seed, to_gb_rounded
+from optimum.habana.utils import HabanaGenerationTime, HabanaProfile, set_seed, to_gb_rounded
 
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.
@@ -1208,17 +1207,16 @@ def main(args):
         disable=not accelerator.is_local_main_process,
     )
 
-    t0 = None
-    t_start = time.perf_counter()
+    timer = HabanaGenerationTime()
+    timer.start()
     train_loss = torch.tensor(0, dtype=torch.float, device="hpu")
-    checkpoint_time = 0
     for epoch in range(first_epoch, args.num_train_epochs):
         train_loss.zero_()
         if hb_profiler:
             hb_profiler.start()
         for step, batch in enumerate(train_dataloader):
-            if t0 is None and global_step == args.throughput_warmup_steps:
-                t0 = time.perf_counter()
+            if not timer.is_running() and global_step == args.throughput_warmup_steps:
+                timer.step()
             with accelerator.accumulate(unet):
                 # Move compute_vae_encoding here to reflect the transformed image input
                 model_input = compute_vae_encodings(batch["pixel_values"], vae)
@@ -1355,32 +1353,30 @@ def main(args):
 
                 if accelerator.is_main_process:
                     if args.checkpointing_steps is not None and global_step % args.checkpointing_steps == 0:
-                        t_chkpt_start = time.perf_counter()
-                        # _before_ saving state, check if this save would set us over the `checkpoints_total_limit`
-                        if args.checkpoints_total_limit is not None:
-                            checkpoints = os.listdir(args.output_dir)
-                            checkpoints = [d for d in checkpoints if d.startswith("checkpoint")]
-                            checkpoints = sorted(checkpoints, key=lambda x: int(x.split("-")[1]))
+                        with HabanaGenerationTime() as timer_checkpoint:
+                            # _before_ saving state, check if this save would set us over the `checkpoints_total_limit`
+                            if args.checkpoints_total_limit is not None:
+                                checkpoints = os.listdir(args.output_dir)
+                                checkpoints = [d for d in checkpoints if d.startswith("checkpoint")]
+                                checkpoints = sorted(checkpoints, key=lambda x: int(x.split("-")[1]))
 
-                            # before we save the new checkpoint, we need to have at _most_ `checkpoints_total_limit - 1` checkpoints
-                            if len(checkpoints) >= args.checkpoints_total_limit:
-                                num_to_remove = len(checkpoints) - args.checkpoints_total_limit + 1
-                                removing_checkpoints = checkpoints[0:num_to_remove]
+                                # before we save the new checkpoint, we need to have at _most_ `checkpoints_total_limit - 1` checkpoints
+                                if len(checkpoints) >= args.checkpoints_total_limit:
+                                    num_to_remove = len(checkpoints) - args.checkpoints_total_limit + 1
+                                    removing_checkpoints = checkpoints[0:num_to_remove]
 
-                                logger.info(
-                                    f"{len(checkpoints)} checkpoints already exist, removing {len(removing_checkpoints)} checkpoints"
-                                )
-                                logger.info(f"removing checkpoints: {', '.join(removing_checkpoints)}")
+                                    logger.info(
+                                        f"{len(checkpoints)} checkpoints already exist, removing {len(removing_checkpoints)} checkpoints"
+                                    )
+                                    logger.info(f"removing checkpoints: {', '.join(removing_checkpoints)}")
 
-                                for removing_checkpoint in removing_checkpoints:
-                                    removing_checkpoint = os.path.join(args.output_dir, removing_checkpoint)
-                                    shutil.rmtree(removing_checkpoint)
+                                    for removing_checkpoint in removing_checkpoints:
+                                        removing_checkpoint = os.path.join(args.output_dir, removing_checkpoint)
+                                        shutil.rmtree(removing_checkpoint)
 
-                        save_path = os.path.join(args.output_dir, f"checkpoint-{global_step}")
-                        accelerator.save_state(save_path)
-                        logger.info(f"Saved state to {save_path}")
-                        t_chkpt_end = time.perf_counter()
-                        checkpoint_time += t_chkpt_end - t_chkpt_start
+                            save_path = os.path.join(args.output_dir, f"checkpoint-{global_step}")
+                            accelerator.save_state(save_path)
+                            logger.info(f"Saved state to {save_path}")
 
                 if (global_step - 1) % args.logging_step == 0 or global_step == args.max_train_steps:
                     train_loss_scalar = train_loss.item()
@@ -1468,9 +1464,10 @@ def main(args):
                             }
                         )
 
-    if t0 is not None:
-        duration = time.perf_counter() - t0 - (checkpoint_time if args.adjust_throughput else 0)
-        ttt = time.perf_counter() - t_start
+    if timer.is_running():
+        timer.step()
+        duration = timer.last_duration - (timer_checkpoint.last_duration if args.adjust_throughput else 0)
+        ttt = timer.total_time()
         throughput = (args.max_train_steps - args.throughput_warmup_steps) * total_batch_size / duration
 
         accelerator.wait_for_everyone()

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -22,11 +22,6 @@ import json
 import logging
 import multiprocessing as mp
 import os
-<<<<<<< HEAD
-import time
-=======
-from typing import Literal, Optional
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 import lm_eval.evaluator
 import lm_eval.tasks
@@ -38,12 +33,7 @@ import torch.nn.functional as F
 from run_generation import setup_parser
 from utils import finalize_quantization, initialize_model, save_model
 
-<<<<<<< HEAD
-from optimum.habana.utils import get_hpu_memory_stats
-=======
-from optimum.habana.transformers.generation import GaudiGenerationConfig
 from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
@@ -266,19 +256,11 @@ def main():
     with torch.no_grad():
         lm = HabanaModelAdapter(tokenizer, model, args, generation_config)
 
-<<<<<<< HEAD
-    eval_start = time.perf_counter()
-    with torch.no_grad():
-        results = lm_eval.evaluator.evaluate(lm, lm_tasks, limit=args.limit_iters)
-    if args.device == "hpu":
-        import habana_frameworks.torch.hpu as torch_hpu
-=======
     with HabanaGenerationTime() as timer:
         with torch.no_grad():
-            results = evaluator.simple_evaluate(lm, tasks=args.tasks, limit=args.limit_iters)
+            results = lm_eval.evaluator.evaluate(lm, lm_tasks, limit=args.limit_iters)
         if args.device == "hpu":
             import habana_frameworks.torch.hpu as torch_hpu
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
             torch_hpu.synchronize()
 

--- a/examples/text-generation/text-generation-pipeline/run_pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline.py
@@ -1,10 +1,11 @@
 import argparse
 import logging
 import math
-import time
 
 from pipeline import GaudiTextGenerationPipeline
 from run_generation import setup_parser
+
+from optimum.habana.utils import HabanaGenerationTime
 
 
 logging.basicConfig(
@@ -46,9 +47,9 @@ def main():
     duration = 0
     for iteration in range(args.n_iterations):
         logger.info(f"Running inference iteration {iteration + 1}...")
-        t0 = time.perf_counter()
-        output = pipe(input_sentences)
-        duration += time.perf_counter() - t0
+        with HabanaGenerationTime() as timer:
+            output = pipe(input_sentences)
+        duration += timer.last_duration
 
         for i, (input_sentence, generated_text) in enumerate(zip(input_sentences, output)):
             print(f"Prompt[{iteration + 1}][{i + 1}]: {input_sentence}")

--- a/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
@@ -17,12 +17,13 @@
 import argparse
 import logging
 import math
-import time
 
 from langchain_core.prompts import PromptTemplate
 from langchain_huggingface.llms import HuggingFacePipeline
 from pipeline import GaudiTextGenerationPipeline
 from run_generation import setup_parser
+
+from optimum.habana.utils import HabanaGenerationTime
 
 
 logging.basicConfig(
@@ -82,9 +83,9 @@ def main():
 
     duration = 0
     for iteration in range(args.n_iterations):
-        t0 = time.perf_counter()
-        responses = chain.batch(input_questions)
-        duration += time.perf_counter() - t0
+        with HabanaGenerationTime() as timer:
+            responses = chain.batch(input_questions)
+        duration += timer.last_duration
 
         for i, (question, answer) in enumerate(zip(input_questions, responses)):
             print(f"Question[{iteration + 1}][{i + 1}]: {question['question']}")

--- a/examples/zero-shot-object-detection/run_example.py
+++ b/examples/zero-shot-object-detection/run_example.py
@@ -16,7 +16,6 @@
 # Copied from https://huggingface.co/docs/transformers/model_doc/owlvit
 
 import argparse
-import time
 
 import habana_frameworks.torch as ht
 import requests
@@ -25,6 +24,7 @@ from PIL import Image
 from transformers import AutoProcessor, OwlViTForObjectDetection
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 
 if __name__ == "__main__":
@@ -93,11 +93,10 @@ if __name__ == "__main__":
         total_model_time = 0
         for i in range(args.n_iterations):
             inputs = processor(text=texts, images=image, return_tensors="pt").to("hpu")
-            model_start_time = time.time()
-            outputs = model(**inputs)
-            torch.hpu.synchronize()
-            model_end_time = time.time()
-            total_model_time = total_model_time + (model_end_time - model_start_time)
+            with HabanaGenerationTime() as timer:
+                outputs = model(**inputs)
+                torch.hpu.synchronize()
+            total_model_time += timer.last_duration
 
             if args.print_result:
                 # Target image sizes (height, width) to rescale box predictions [batch_size, 2]

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -62,7 +62,7 @@ from transformers.utils import ModelOutput, is_hqq_available, is_quanto_availabl
 
 from optimum.utils import logging
 
-from ...utils import HabanaGenerationtime, HabanaProfile
+from ...utils import HabanaGenerationTime, HabanaProfile
 from ..integrations.deepspeed import unwrap_deepspeed_model
 from .candidate_generator import GaudiAssistedCandidateGenerator
 from .configuration_utils import GaudiGenerationConfig
@@ -978,7 +978,7 @@ class GaudiGenerationMixin(GenerationMixin):
         """
 
         if iteration_times is not None:
-            hb_gen_time = HabanaGenerationtime(iteration_times=iteration_times)
+            hb_gen_time = HabanaGenerationTime(iteration_times=iteration_times)
             hb_gen_time.start()
         else:
             hb_gen_time = None
@@ -1733,7 +1733,7 @@ class GaudiGenerationMixin(GenerationMixin):
         ignore_eos: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GenerateNonBeamOutput, torch.LongTensor]:
@@ -2329,7 +2329,7 @@ class GaudiGenerationMixin(GenerationMixin):
         ignore_eos: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GenerateNonBeamOutput, torch.LongTensor]:
@@ -2689,7 +2689,7 @@ class GaudiGenerationMixin(GenerationMixin):
         lazy_mode: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GenerateBeamOutput, torch.LongTensor]:
@@ -3269,7 +3269,7 @@ class GaudiGenerationMixin(GenerationMixin):
         lazy_mode: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ):
@@ -3326,7 +3326,7 @@ class GaudiGenerationMixin(GenerationMixin):
         lazy_mode: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GenerateBeamOutput, torch.LongTensor]:
@@ -3629,7 +3629,7 @@ class GaudiGenerationMixin(GenerationMixin):
         ignore_eos: Optional[bool] = False,
         profiling_warmup_steps: Optional[int] = 0,
         profiling_steps: Optional[int] = 0,
-        hb_gen_time: Optional[HabanaGenerationtime] = None,
+        hb_gen_time: Optional[HabanaGenerationTime] = None,
         profiling_record_shapes: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GenerateNonBeamOutput, torch.LongTensor]:

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -109,6 +109,7 @@ from optimum.utils import logging
 from ..accelerate import GaudiAccelerator
 from ..accelerate.utils import FP8ContextWrapper, GaudiDistributedType
 from ..utils import (
+    HabanaGenerationTime,
     HabanaProfile,
     get_hpu_memory_stats,
     set_seed,
@@ -1265,8 +1266,10 @@ class GaudiTrainer(Trainer):
             )
 
     def _maybe_log_save_evaluate(self, tr_loss, _grad_norm, model, trial, epoch, ignore_keys_for_eval):
+        timer = HabanaGenerationTime()
+        timer.start()
         if self.args.adjust_throughput:
-            save_start = time.perf_counter()
+            timer.step()
 
         if self.control.should_log and self.state.global_step > self._globalstep_last_logged:
             logs: Dict[str, float] = {}
@@ -1314,7 +1317,8 @@ class GaudiTrainer(Trainer):
             self.control = self.callback_handler.on_save(self.args, self.state, self.control)
 
         if self.args.adjust_throughput:
-            self.log_evaluate_save_time += time.perf_counter() - save_start
+            timer.step()
+            self.log_evaluate_save_time += timer.last_duration
 
     def _load_rng_state(self, checkpoint):
         # Load RNG states from `checkpoint`

--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -16,7 +16,7 @@
 import random
 import subprocess
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -258,19 +258,36 @@ def get_driver_version():
     return None
 
 
-class HabanaGenerationtime(object):
-    def __init__(self, iteration_times: List[float] = None):
-        self.iteration_times = iteration_times
-        self.start_time = 0
-        self.end_time = 0
+class HabanaGenerationTime(object):
+    def __init__(self, iteration_times: Optional[List[float]] = None):
+        self.iteration_times = iteration_times if iteration_times is not None else []
+        self.start_time = None
+        self.last_duration = None
 
     def start(self):
         self.start_time = time.perf_counter()
 
+    def is_running(self):
+        return self.start_time is not None
+
     def step(self):
-        self.end_time = time.perf_counter()
-        self.iteration_times.append(self.end_time - self.start_time)
-        self.start_time = self.end_time
+        if not self.is_running():
+            raise ValueError("start() must be call before step()")
+        end_time = time.perf_counter()
+        duration = end_time - self.start_time
+        self.iteration_times.append(duration)
+        self.last_duration = duration
+        self.start_time = end_time
+
+    def total_time(self):
+        return sum(self.iteration_times)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.step()
 
 
 class HabanaProfile(object):

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<<<<<<< HEAD
-import time
-=======
-import os
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -133,21 +128,6 @@ class GaudiFeatureExtractionTester(TestCase):
             for _ in range(warm_up_iters):
                 self.model_hpu_graph(**batch_dict)
         torch.hpu.synchronize()
-<<<<<<< HEAD
-        start_time = time.time()
-        with torch.autocast(device_type="hpu", dtype=torch.bfloat16), torch.no_grad():
-            for _ in range(test_iters):
-                outputs = self.model_hpu_graph(**batch_dict)
-                embeddings(outputs, batch_dict)
-        torch.hpu.synchronize()
-        end_time = time.time()
-        time_per_iter = (end_time - start_time) * 1000 / test_iters  # time in ms
-        self.baseline.assertRef(
-            compare=lambda actual, ref: actual < (1.05 * ref),
-            context=[OH_DEVICE_CONTEXT],
-            time_per_iter=time_per_iter,
-        )
-=======
 
         with HabanaGenerationTime() as elapsed_time:
             with torch.autocast(device_type="hpu", dtype=torch.bfloat16), torch.no_grad():
@@ -156,5 +136,8 @@ class GaudiFeatureExtractionTester(TestCase):
                     embeddings(outputs, batch_dict)
             torch.hpu.synchronize()
         time_per_iter = elapsed_time.last_duration * 1000 / test_iters  # time in ms
-        self.assertLess(time_per_iter, 1.05 * LATENCY_GTE_SMALL_BF16_GRAPH_BASELINE)
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
+        self.baseline.assertRef(
+            compare=lambda actual, ref: actual < (1.05 * ref),
+            context=[OH_DEVICE_CONTEXT],
+            time_per_iter=time_per_iter,
+        )

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+<<<<<<< HEAD
 import time
+=======
+import os
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -23,6 +27,7 @@ import torch.nn.functional as F
 from transformers import AutoModel, AutoTokenizer
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 from .utils import OH_DEVICE_CONTEXT
 
@@ -128,6 +133,7 @@ class GaudiFeatureExtractionTester(TestCase):
             for _ in range(warm_up_iters):
                 self.model_hpu_graph(**batch_dict)
         torch.hpu.synchronize()
+<<<<<<< HEAD
         start_time = time.time()
         with torch.autocast(device_type="hpu", dtype=torch.bfloat16), torch.no_grad():
             for _ in range(test_iters):
@@ -141,3 +147,14 @@ class GaudiFeatureExtractionTester(TestCase):
             context=[OH_DEVICE_CONTEXT],
             time_per_iter=time_per_iter,
         )
+=======
+
+        with HabanaGenerationTime() as elapsed_time:
+            with torch.autocast(device_type="hpu", dtype=torch.bfloat16), torch.no_grad():
+                for _ in range(test_iters):
+                    outputs = self.model_hpu_graph(**batch_dict)
+                    embeddings(outputs, batch_dict)
+            torch.hpu.synchronize()
+        time_per_iter = elapsed_time.last_duration * 1000 / test_iters  # time in ms
+        self.assertLess(time_per_iter, 1.05 * LATENCY_GTE_SMALL_BF16_GRAPH_BASELINE)
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))

--- a/tests/test_image_segmentation.py
+++ b/tests/test_image_segmentation.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -25,6 +24,7 @@ from PIL import Image
 from transformers import AutoModel, AutoProcessor
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 from .utils import OH_DEVICE_CONTEXT
 
@@ -115,11 +115,11 @@ class GaudiSAMTester(TestCase):
             total_model_time = 0
             for i in range(iterations):
                 inputs = processor(image, input_points=input_points, return_tensors="pt").to("hpu")
-                model_start_time = time.time()
-                _ = model(**inputs)
-                torch.hpu.synchronize()
-                model_end_time = time.time()
-                total_model_time = total_model_time + (model_end_time - model_start_time)
+                with HabanaGenerationTime() as timer:
+                    _ = model(**inputs)
+                    torch.hpu.synchronize()
+
+                total_model_time += timer.last_duration
 
         self.baseline.assertRef(
             compare=lambda latency, expect: latency <= (1.05 * expect),

--- a/tests/test_object_segmentation.py
+++ b/tests/test_object_segmentation.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -23,6 +22,7 @@ from PIL import Image
 from transformers import AutoModel, AutoProcessor
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 from .utils import OH_DEVICE_CONTEXT
 
@@ -111,11 +111,11 @@ class GaudiClipSegTester(TestCase):
                 inputs = processor(text=texts, images=[image] * len(texts), padding=True, return_tensors="pt").to(
                     "hpu"
                 )
-                model_start_time = time.time()
-                _ = model(**inputs)
-                torch.hpu.synchronize()
-                model_end_time = time.time()
-                total_model_time = total_model_time + (model_end_time - model_start_time)
+                with HabanaGenerationTime() as timer:
+                    _ = model(**inputs)
+                    torch.hpu.synchronize()
+
+                total_model_time += timer.last_duration
 
         self.baseline.assertRef(
             compare=lambda latency, expect: latency <= (1.05 * expect),

--- a/tests/test_sentence_transformers.py
+++ b/tests/test_sentence_transformers.py
@@ -1,10 +1,11 @@
 import csv
 import gzip
 import os
-import time
 
 import pytest
 from sentence_transformers import SentenceTransformer, util
+
+from optimum.habana.utils import HabanaGenerationTime
 
 from .test_examples import TIME_PERF_FACTOR
 from .utils import OH_DEVICE_CONTEXT
@@ -51,10 +52,9 @@ def _test_sentence_transformers(
     sentences = list(sentences)
 
     for i in range(2):
-        start_time = time.perf_counter()
-        _ = model.encode(sentences, batch_size=32)
-        end_time = time.perf_counter()
-        diff_time = end_time - start_time
+        with HabanaGenerationTime() as timer:
+            _ = model.encode(sentences, batch_size=32)
+        diff_time = timer.last_duration
         measured_throughput = len(sentences) / diff_time
 
     # Only assert the last measured throughtput as the first iteration is used as a warmup

--- a/tests/test_table_transformer.py
+++ b/tests/test_table_transformer.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+<<<<<<< HEAD
 import time
+=======
+import os
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -23,6 +27,7 @@ from PIL import Image
 from transformers import AutoImageProcessor, TableTransformerForObjectDetection
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 from .utils import OH_DEVICE_CONTEXT
 
@@ -141,12 +146,12 @@ class GaudiTableTransformerTester(TestCase):
             for _ in range(warm_up_iters):
                 self.model_hpu_graph(**self.inputs_hpu)
         torch.hpu.synchronize()
-        start_time = time.time()
-        with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
-            for _ in range(test_iters):
-                self.model_hpu_graph(**self.inputs_hpu)
-        torch.hpu.synchronize()
-        time_per_iter = (time.time() - start_time) * 1000 / test_iters  # Time in ms
+        with HabanaGenerationTime() as timer:
+            with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
+                for _ in range(test_iters):
+                    self.model_hpu_graph(**self.inputs_hpu)
+            torch.hpu.synchronize()
+        time_per_iter = timer.last_duration * 1000 / test_iters  # Time in ms
         print(time_per_iter)
 
         self.baseline.assertRef(

--- a/tests/test_table_transformer.py
+++ b/tests/test_table_transformer.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<<<<<<< HEAD
-import time
-=======
-import os
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht

--- a/tests/test_video_mae.py
+++ b/tests/test_video_mae.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 
-<<<<<<< HEAD
-import time
-=======
-import os
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -27,11 +22,8 @@ import pytest
 import torch
 from transformers import VideoMAEForVideoClassification, VideoMAEImageProcessor
 
-<<<<<<< HEAD
 from .utils import OH_DEVICE_CONTEXT
-=======
 from optimum.habana.utils import HabanaGenerationTime
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 
 MODEL_NAME = "MCG-NJU/videomae-base-finetuned-kinetics"
@@ -136,24 +128,14 @@ class GaudiVideoMAETester(TestCase):
             for _ in range(warm_up_iters):
                 self.model_hpu_graph(**self.inputs_hpu)
         torch.hpu.synchronize()
-<<<<<<< HEAD
-        start_time = time.time()
-        with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
-            for _ in range(test_iters):
-                self.model_hpu_graph(**self.inputs_hpu)
-                torch.hpu.synchronize()
-        time_per_iter = (time.time() - start_time) * 1000 / test_iters  # Time in ms
-        self.baseline.assertRef(
-            compare=lambda latency, expect: latency < (1.05 * expect),
-            context=[OH_DEVICE_CONTEXT],
-            latency=time_per_iter,
-        )
-=======
         with HabanaGenerationTime() as timer:
             with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
                 for _ in range(test_iters):
                     self.model_hpu_graph(**self.inputs_hpu)
             torch.hpu.synchronize()
         time_per_iter = timer.last_duration * 1000 / test_iters  # Time in ms
-        self.assertLess(time_per_iter, 1.05 * LATENCY_VIDEOMAE_BF16_GRAPH_BASELINE)
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
+        self.baseline.assertRef(
+            compare=lambda latency, expect: latency < (1.05 * expect),
+            context=[OH_DEVICE_CONTEXT],
+            latency=time_per_iter,
+        )

--- a/tests/test_video_mae.py
+++ b/tests/test_video_mae.py
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 
+<<<<<<< HEAD
 import time
+=======
+import os
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -23,7 +27,11 @@ import pytest
 import torch
 from transformers import VideoMAEForVideoClassification, VideoMAEImageProcessor
 
+<<<<<<< HEAD
 from .utils import OH_DEVICE_CONTEXT
+=======
+from optimum.habana.utils import HabanaGenerationTime
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 
 
 MODEL_NAME = "MCG-NJU/videomae-base-finetuned-kinetics"
@@ -128,6 +136,7 @@ class GaudiVideoMAETester(TestCase):
             for _ in range(warm_up_iters):
                 self.model_hpu_graph(**self.inputs_hpu)
         torch.hpu.synchronize()
+<<<<<<< HEAD
         start_time = time.time()
         with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
             for _ in range(test_iters):
@@ -139,3 +148,12 @@ class GaudiVideoMAETester(TestCase):
             context=[OH_DEVICE_CONTEXT],
             latency=time_per_iter,
         )
+=======
+        with HabanaGenerationTime() as timer:
+            with torch.no_grad(), torch.autocast(device_type="hpu", dtype=torch.bfloat16):
+                for _ in range(test_iters):
+                    self.model_hpu_graph(**self.inputs_hpu)
+            torch.hpu.synchronize()
+        time_per_iter = timer.last_duration * 1000 / test_iters  # Time in ms
+        self.assertLess(time_per_iter, 1.05 * LATENCY_VIDEOMAE_BF16_GRAPH_BASELINE)
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))

--- a/tests/test_zero_shot_object_detection.py
+++ b/tests/test_zero_shot_object_detection.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+<<<<<<< HEAD
 import time
+=======
+import os
+>>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht
@@ -25,6 +29,7 @@ from PIL import Image
 from transformers import OwlViTForObjectDetection, OwlViTProcessor
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+from optimum.habana.utils import HabanaGenerationTime
 
 from .utils import OH_DEVICE_CONTEXT
 
@@ -115,11 +120,10 @@ class GaudiOWlVITTester(TestCase):
             total_model_time = 0
             for i in range(iterations):
                 inputs = processor(text=texts, images=image, return_tensors="pt").to("hpu")
-                model_start_time = time.time()
-                _ = model(**inputs)
-                torch.hpu.synchronize()
-                model_end_time = time.time()
-                total_model_time = total_model_time + (model_end_time - model_start_time)
+                with HabanaGenerationTime() as timer:
+                    _ = model(**inputs)
+                    torch.hpu.synchronize()
+                total_model_time += timer.last_duration
 
         self.baseline.assertRef(
             compare=lambda latency, expect: latency <= (1.05 * expect),

--- a/tests/test_zero_shot_object_detection.py
+++ b/tests/test_zero_shot_object_detection.py
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<<<<<<< HEAD
-import time
-=======
-import os
->>>>>>> b43a1771 (Dev/gplutop7/use habana generation time (#199))
 from unittest import TestCase
 
 import habana_frameworks.torch as ht


### PR DESCRIPTION
This PR changes how time is measured in examples and tests.
Instead of manual `end_time - start_time`, utility class `HabanaGenerationTime` is used for better readability.