### PR TITLE
Skipping falcon rope scaling test (#221)

### DIFF
--- a/tests/transformers/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/transformers/tests/models/falcon/test_modeling_falcon.py
@@ -435,6 +435,7 @@ class FalconModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
         self.assertFalse(torch.allclose(original_long_output, scaled_long_output, atol=1e-5))
 
     def test_model_rope_scaling(self):
+        self.skipTest("Skip untill SW-209093 is fixed")
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         hidden_size = config.hidden_size
         num_heads = config.num_attention_heads


### PR DESCRIPTION
Unskipping revealed that SW-209093 is still not fixed.
This PR skips a test that has no chance of passing (due to known and not fixed bug).