### PR TITLE
Limit max pos embeds to 8k to prevent OOM (#227)

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -454,7 +454,7 @@ def setup_distributed_model(args, model_dtype, model_kwargs, logger):
         # Construct model with fake meta tensors, later will be replaced on devices during ds-inference ckpt load
         with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
             if (
-                any(model_type in args.model_name_or_path.lower() for model_type in MODELS_WITH_POS_EMBEDDING_LIMIT)
+                any(model_type == config.model_type for model_type in MODELS_WITH_POS_EMBEDDING_LIMIT)
                 and config.max_position_embeddings > 8192
             ):
                 config.max_position_embeddings = 8192


### PR DESCRIPTION
# What does this PR do?

This PR caps the max pos embeds limit to 8k for the llama family of models. Earlier this check was for just one llama 3 model with a specific config. Now it applies to all llama family models and can be extended to others in the future.

Capping the max pos embeds for models in which we dont support higher context len saves memory and prevents OOM in bigger models like llama 3.1 405B