### PR TITLE
Fix gemma2b-it perplexity

### DIFF
--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -72,12 +72,12 @@
   },
   "tests/test_examples.py::DeepspeedCausalLanguageModelingExampleTester::test_run_clm_gemma-2b-it_deepspeed": {
     "gaudi2": {
-      "perplexity": 26.39,
+      "perplexity": 12.8,
       "train_runtime": 80.3429,
       "train_samples_per_second": 76.06
     },
     "gaudi3": {
-      "perplexity": 26.39,
+      "perplexity": 12.8,
       "train_runtime": 57.7676,
       "train_samples_per_second": 135.39
     }

--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -239,12 +239,12 @@
   },
   "tests/test_examples.py::MultiCardCausalLanguageModelingExampleTester::test_run_clm_gemma-2b-it_multi_card": {
     "gaudi2": {
-      "perplexity": 26.39,
+      "perplexity": 12.8,
       "train_runtime": 82.6617,
       "train_samples_per_second": 94.524
     },
     "gaudi3": {
-      "perplexity": 26.39,
+      "perplexity": 12.8,
       "train_runtime": 66.2529,
       "train_samples_per_second": 159.47
     }

--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -72,9 +72,9 @@
   },
   "tests/test_examples.py::DeepspeedCausalLanguageModelingExampleTester::test_run_clm_gemma-2b-it_deepspeed": {
     "gaudi2": {
-      "perplexity": 924.062,
-      "train_runtime": 75.518,
-      "train_samples_per_second": 81.097
+      "perplexity": 26.39,
+      "train_runtime": 80.3429,
+      "train_samples_per_second": 76.06
     },
     "gaudi3": {
       "perplexity": 980.9833890324784,

--- a/tests/baselines/fixture/tests/test_examples.json
+++ b/tests/baselines/fixture/tests/test_examples.json
@@ -77,7 +77,7 @@
       "train_samples_per_second": 76.06
     },
     "gaudi3": {
-      "perplexity": 980.9833890324784,
+      "perplexity": 26.39,
       "train_runtime": 57.7676,
       "train_samples_per_second": 135.39
     }
@@ -239,12 +239,12 @@
   },
   "tests/test_examples.py::MultiCardCausalLanguageModelingExampleTester::test_run_clm_gemma-2b-it_multi_card": {
     "gaudi2": {
-      "perplexity": 954.5995,
+      "perplexity": 26.39,
       "train_runtime": 82.6617,
       "train_samples_per_second": 94.524
     },
     "gaudi3": {
-      "perplexity": 902.0585179806482,
+      "perplexity": 26.39,
       "train_runtime": 66.2529,
       "train_samples_per_second": 159.47
     }

--- a/tests/configs/examples/gemma_2b_it.json
+++ b/tests/configs/examples/gemma_2b_it.json
@@ -18,7 +18,7 @@
                     ]
                 },
                 "multi_card": {
-                    "learning_rate": 0.0008,
+                    "learning_rate": 0.0002,
                     "train_batch_size": 4,
                     "metrics": [
                         "perplexity",
@@ -31,7 +31,7 @@
                     ]
                 },
                 "deepspeed": {
-                    "learning_rate": 0.0008,
+                    "learning_rate": 0.0002,
                     "train_batch_size": 4,
                     "metrics": [
                         "perplexity",
@@ -66,7 +66,7 @@
                     ]
                 },
                 "multi_card": {
-                    "learning_rate": 0.0008,
+                    "learning_rate": 0.0002,
                     "train_batch_size": 4,
                     "metrics": [
                         "perplexity",
@@ -79,7 +79,7 @@
                     ]
                 },
                 "deepspeed": {
-                    "learning_rate": 0.0008,
+                    "learning_rate": 0.0002,
                     "train_batch_size": 4,
                     "metrics": [
                         "perplexity",


### PR DESCRIPTION
The learning rate for gemma2b mpi and deepspeed should be replaced to be more consistent with one card version and have good perplexity.

8x G2: 

```
epoch                       =        2.0
max_memory_allocated (GB)   =      64.53
memory_allocated (GB)       =      22.22
total_flos                  = 54434080GF
total_memory_available (GB) =      94.62
train_loss                  =     5.0075
train_runtime               = 0:01:23.76
train_samples               =       2395
train_samples_per_second    =     76.627
train_steps_per_second      =        2.4
***** eval metrics *****
epoch                           =        2.0
eval_accuracy                   =      0.482
eval_graph_compliation_duration =      1.493
eval_loss                       =     2.5507
eval_runtime                    = 0:00:08.25
eval_samples                    =        250
eval_samples_per_second         =     22.786
eval_steps_per_second           =       0.74
max_memory_allocated (GB)       =      64.53
memory_allocated (GB)           =      26.32
perplexity                      =    12.8156
```
  
8x G3:
```
***** train metrics *****
  epoch                       =        2.0
  max_memory_allocated (GB)   =      46.91
  memory_allocated (GB)       =      22.33
  total_flos                  = 54434080GF
  total_memory_available (GB) =     126.54
  train_loss                  =     5.2182
  train_runtime               = 0:00:51.54
  train_samples               =       2395
  train_samples_per_second    =    147.408
  train_steps_per_second      =      4.616
  ***** eval metrics *****
  epoch                           =        2.0
  eval_accuracy                   =     0.4838
  eval_graph_compliation_duration =     3.6164
  eval_loss                       =     2.5381
  eval_runtime                    = 0:00:05.84
  eval_samples                    =        250
  eval_samples_per_second         =     69.084
  eval_steps_per_second           =      2.243
  max_memory_allocated (GB)       =      46.91
  memory_allocated (GB)           =      26.42
  perplexity                      =    12.6551
  total_memory_available (GB)     =     126.54
```


