### PR TITLE
Fix --save_last_ckpt if --save_strategy no is set

### DIFF
--- a/examples/image-to-text/run_image2text_lora_finetune.py
+++ b/examples/image-to-text/run_image2text_lora_finetune.py
@@ -585,6 +585,8 @@ def main():
         metrics = train_result.metrics
         trainer.log_metrics("train", metrics)
         trainer.save_metrics("train", metrics)
+        if data_args.save_last_ckpt:
+            trainer._save_checkpoint(trainer.model, None)
 
     if is_main_process(training_args.local_rank):
         processor.tokenizer.padding_side = "left"

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -685,7 +685,7 @@ def main():
             checkpoint = last_checkpoint
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         if data_args.save_last_ckpt:
-            trainer.save_model()  # Saves the tokenizer too for easy upload
+            trainer._save_checkpoint(trainer.model, None)  # Saves the tokenizer too for easy upload
 
         metrics = train_result.metrics
 

--- a/examples/language-modeling/run_lora_clm.py
+++ b/examples/language-modeling/run_lora_clm.py
@@ -962,7 +962,7 @@ def main():
     if training_args.do_train:
         train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
         if data_args.save_last_ckpt:
-            trainer.save_model()
+            trainer._save_checkpoint(trainer.model, None)
 
         metrics = train_result.metrics
         trainer.log_metrics("train", metrics)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #1930 

1. Fix `--save_last_ckpt` to work always even when --save_strategy "no".
2. Call trainer._save_checkpoint() for `run_image2text_lora_finetune.py` when `--save_last_ckpt` is set

### Tested `--save_last_ckpt` + `--save_strategy no` :

```
python3 run_image2text_lora_finetune.py     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct     \
 --dataset_name nielsr/docvqa_1200_examples     \
 --bf16 True     \
 --output_dir ./model_lora_llama     \
 --num_train_epochs 1     \
 --per_device_train_batch_size 2     \
 --per_device_eval_batch_size 2     \
 --gradient_accumulation_steps 8     \
 --weight_decay 0.01     \
 --logging_steps 25     \
 --eval_strategy "no"     \
 --save_strategy "no"     \
 --learning_rate 5e-5     \
 --warmup_steps  50     \
 --lr_scheduler_type "constant"     \
 --input_column_names 'image' 'query'     \
 --output_column_names 'answers'     \
 --remove_unused_columns False     \
 --do_train     \
 --do_eval     \
 --use_habana     \
 --use_lazy_mode     \
 --lora_rank=8     \
 --lora_alpha=8     \
 --lora_dropout=0.1     \
 --low_cpu_mem_usage True     \
 --max_seq_length=512     \
 --use_hpu_graphs_for_inference True     \
 --lora_target_modules ".*(language_model).*(down_proj|gate_proj|up_proj|k_proj|q_proj|v_proj|o_proj).*$" \
 --save_last_ckpt --max_train_samples 10
```

Output
```
***** train metrics *****
  epoch                       =      0.992
  max_memory_allocated (GB)   =      94.49
  memory_allocated (GB)       =      48.09
  total_flos                  = 28657213GF
  total_memory_available (GB) =      94.62
  train_loss                  =     6.6874
  train_runtime               = 0:14:46.26
  train_samples_per_second    =      1.128
  train_steps_per_second      =       0.07
[INFO|trainer.py:1690] 2025-04-18 17:41:14,358 >> Saving model checkpoint to ./model_lora_llama/checkpoint-62
[INFO|configuration_utils.py:125] 2025-04-18 17:41:17,526 >> Configuration saved in ./model_lora_llama/checkpoint-62/gaudi_config.json
04/18/2025 17:41:24 - INFO - __main__ -   generated: ['\n\nBengaluru']
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [03:07<00:00,  1.88s/it]
***** eval metrics *****
  eval_accuracy = 0.9184

```

Saved checkpoint
<img src="https://github.com/user-attachments/assets/3dbc18ff-557e-460b-a75a-ddfcce34f1ef" alt="Alt Text" width="250" height="550">


### Testing --save_last_ckpt (without save_strategy no):

```
 python3 run_image2text_lora_finetune.py     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct     \
 --dataset_name nielsr/docvqa_1200_examples     \
 --bf16 True     \
 --output_dir ./model_lora_llama_1    \
 --num_train_epochs 1     \
 --per_device_train_batch_size 2     \
 --per_device_eval_batch_size 2     \
 --gradient_accumulation_steps 8     \
 --weight_decay 0.01     \
 --logging_steps 25     \
 --eval_strategy "no"     \
 --learning_rate 5e-5     \
 --warmup_steps  50     \
 --lr_scheduler_type "constant"     \
 --input_column_names 'image' 'query'     \
 --output_column_names 'answers'     \
 --remove_unused_columns False     \
 --do_train     \
 --do_eval     \
 --use_habana     \
 --use_lazy_mode     \
 --lora_rank=8     \
 --lora_alpha=8     \
 --lora_dropout=0.1     \
 --low_cpu_mem_usage True     \
 --max_seq_length=512     \
 --use_hpu_graphs_for_inference True     \
 --lora_target_modules ".*(language_model).*(down_proj|gate_proj|up_proj|k_proj|q_proj|v_proj|o_proj).*$" \
 --save_last_ckpt \
 --max_train_samples 10
```

#### Output:
```
***** train metrics *****
  epoch                       =      0.992
  max_memory_allocated (GB)   =      94.51
  memory_allocated (GB)       =       47.9
  total_flos                  = 28657213GF
  total_memory_available (GB) =      94.62
  train_loss                  =     6.6846
  train_runtime               = 0:14:56.84
  train_samples_per_second    =      1.115
  train_steps_per_second      =      0.069
[INFO|trainer.py:1690] 2025-04-18 18:04:21,920 >> Saving model checkpoint to ./model_lora_llama_1/checkpoint-62
[INFO|configuration_utils.py:125] 2025-04-18 18:04:24,727 >> Configuration saved in ./model_lora_llama_1/checkpoint-62/gaudi_config.json
04/18/2025 18:04:30 - INFO - __main__ -   generated: ['\n\nBengaluru']
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [03:10<00:00,  1.90s/it]
***** eval metrics *****
  eval_accuracy = 0.8881
```

#### Saved checkpoint:

<img src="https://github.com/user-attachments/assets/29911f10-51e5-46e5-bd3f-96a8a57e658d" alt="Alt Text" width="250" height="475">


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
