### PR TITLE
Workaround for torch.compile mode failure in Gaudi diffuser pipeline

### DIFF
--- a/optimum/habana/diffusers/schedulers/scheduling_flow_mactch_euler_discrete.py
+++ b/optimum/habana/diffusers/schedulers/scheduling_flow_mactch_euler_discrete.py
@@ -1,4 +1,5 @@
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+import torch
 
 
 class GaudiFlowMatchEulerDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
@@ -13,3 +14,7 @@ class GaudiFlowMatchEulerDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
         if masked.sum() > 1:
             pos += (tmp == 1).sum().item()
         return pos
+
+    @torch.compiler.disable
+    def step(self, *args, **kwargs):
+        return super().step(*args, **kwargs)


### PR DESCRIPTION
# What does this PR do?

Compiling entire diffusers pipeline with `torch.compile()` fails on Gaudi2/3. This works fine when we compile individual components of a diffusers pipeline (e.g. transformer, vae, text encoders). The following error is reported with the full pipeline.

```
RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_EAGER HabanaLaunchOpPT Run returned exception....
aten::IntImplicit isn't registered in KernelRegistry!
[Rank:0] Habana exception raised from GetConfiguredHabanaKernel at hpu_habana_launch_op_pt.cpp:3125
```

This error seems to be triggered from handling of constants in the stack. While we work on a permanent fix in the stack, this PR is intended to serve as a temporary workaround by disabling this function in the `torch.compile` graph.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
