### PR TITLE
Reduce LM_Eval output size after upgrade

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -259,7 +259,7 @@ def main():
 
     eval_start = time.perf_counter()
     with torch.no_grad():
-        results = lm_eval.evaluator.evaluate(lm, lm_tasks, limit=args.limit_iters)
+        results = lm_eval.evaluator.evaluate(lm, lm_tasks, limit=args.limit_iters, log_samples=False)
     if args.device == "hpu":
         import habana_frameworks.torch.hpu as torch_hpu
 


### PR DESCRIPTION
After upgrading to lm_eval latest version samples are logged by default, we don't want that to reduce logs sizes