### PR TITLE
Pad the examples for QLoRa finetuning test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ TESTS_REQUIRE = [
     "torchsde",
     "timm",
     "peft",
+    "bitsandbytes @ git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
 ]
 
 QUALITY_REQUIRES = [

--- a/tests/baselines/fixture/tests/test_bnb_inference.json
+++ b/tests/baselines/fixture/tests/test_bnb_inference.json
@@ -1,5 +1,5 @@
 {
   "tests/test_bnb_inference.py::test_nf4_quantization_inference": {
-    "output": "Hello my name is Marlene and I am 36 years old. I am a very happy person, I love to"
+    "output": "Hello my name is Kelsey and I am a 16 year old girl who loves to draw and paint. I have"
   }
 }

--- a/tests/baselines/fixture/tests/test_bnb_qlora.json
+++ b/tests/baselines/fixture/tests/test_bnb_qlora.json
@@ -1,10 +1,10 @@
 {
-  "tests/test_bnb_qlora.py::test_nf4_quantization_inference": {
+  "tests/test_bnb_qlora.py::test_nf4_quantization_finetuning": {
     "gaudi2": {
-      "eval_loss": 1.638
+      "eval_loss": 1.225
     },
     "gaudi3": {
-      "eval_loss": 1.638
+      "eval_loss": 1.225
     }
   }
 }

--- a/tests/test_bnb_inference.py
+++ b/tests/test_bnb_inference.py
@@ -56,8 +56,6 @@ def test_nf4_quantization_inference(token: str, baseline):
     generation_config.use_cache = True
     generation_config.use_flash_attention = True
 
-    model.model = torch.compile(model.model, backend="hpu_backend")
-
     input_text = "Hello my name is"
     inputs = tokenizer(input_text, return_tensors="pt").to(device="hpu")
 


### PR DESCRIPTION
1. Pad the examples up to max_seq_len of 1024
2. Increase the max_steps (from 5 to 50) and eval_steps (from 3 to 10). Set throughput-related arguments (adjust_throughput, throughput_warmup_steps)
4. Update the fine-tuning test name
5. Also, adjust the reference "eval loss" value for fine-tuning test and "output" for inference test.

Additional updates
6. Enable the eager mode for the test (disable the torch.compile mode for now).
7. Add new requirement for installing the bitsandbytes (from https://github.com/bitsandbytes-foundation/bitsandbytes/tree/multi-backend-refactor)