### PR TITLE
Move bitsandbytes requirements from setup.py to bnb tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ TESTS_REQUIRE = [
     "torchsde",
     "timm",
     "peft",
-    "bitsandbytes @ git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
 ]
 
 QUALITY_REQUIRES = [

--- a/tests/test_bnb_inference.py
+++ b/tests/test_bnb_inference.py
@@ -42,6 +42,22 @@ def get_model(token: str):
 
 @pytest.mark.skipif("gaudi1" == OH_DEVICE_CONTEXT, reason="execution not supported on gaudi1")
 def test_nf4_quantization_inference(token: str, baseline):
+    try:
+        import subprocess
+        import sys
+
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
+            ]
+        )
+    except subprocess.CalledProcessError:
+        pytest.fail("Failed to install bitsandbytes")
+
     os.environ["PT_HPU_LAZY_MODE"] = "0"
     from optimum.habana.transformers import modeling_utils
 

--- a/tests/test_bnb_qlora.py
+++ b/tests/test_bnb_qlora.py
@@ -83,10 +83,19 @@ def test_nf4_quantization_finetuning(token: str, baseline):
     try:
         import sys
 
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "peft==0.12.0"])
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "peft==0.12.0",
+                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
+            ]
+        )
         from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
     except subprocess.CalledProcessError:
-        pytest.fail("Failed to install peft==0.12.0")
+        pytest.fail("Failed to install peft==0.12.0 / bitsandbytes")
 
     os.environ["PT_HPU_LAZY_MODE"] = "0"
     from optimum.habana.transformers import modeling_utils


### PR DESCRIPTION
Instead of adding bitsandbytes (bnb) requirement to setup.py, move it to bnb test files (tests/test_bnb_qlora.py, tests/test_bnb_inference.py). 

Details:
1) Because for HPU, bitsandbytes loads the CPU binaries (https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/cextension.py#L73), which are not required. Failure to load these binaries throws OSError (OSError: /usr/local/lib/python3.10/dist-packages/bitsandbytes/libbitsandbytes_cpu.so: cannot open shared object file: No such file or directory) for other tests.
2) For now, we move the BNB installation to the above-specified tests. And **both of these tests passed**.
3) Later, we'll try to upstream the fix to the bitsandbytes repo.

