### PR TITLE
Fix READMEs - SD paths and LLM PEFT example

### DIFF
--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -110,7 +110,7 @@ python train_controlnet.py \
 ```
 
 You can run inference on multiple HPUs by replacing `python train_controlnet.py`
-with `python ../gaudi_spawn.py --world_size <num-HPUs> train_controlnet.py`.
+with `python ../../gaudi_spawn.py --world_size <num-HPUs> train_controlnet.py`.
 
 ### Inference
 
@@ -180,7 +180,7 @@ python train_text_to_image_sdxl.py \
 > There is a known issue that in the first 2 steps, graph compilation takes longer than 10 seconds. This will be fixed in a future release.
 
 You can run inference on multiple HPUs by replacing `python train_text_to_image_sdxl.py`
-with `PT_HPU_RECIPE_CACHE_CONFIG=/tmp/stdxl_recipe_cache,True,1024 python ../gaudi_spawn.py --world_size <num-HPUs> train_text_to_image_sdxl.py`.
+with `PT_HPU_RECIPE_CACHE_CONFIG=/tmp/stdxl_recipe_cache,True,1024 python ../../gaudi_spawn.py --world_size <num-HPUs> train_text_to_image_sdxl.py`.
 
 ### Inference
 
@@ -343,7 +343,7 @@ python train_dreambooth_lora_sdxl.py \
 > To use DeepSpeed instead of MPI, replace `--use_mpi` with `--deepspeed` in the previous example.
 
 You can run inference on multiple HPUs by replacing `python train_dreambooth_lora_sdxl.py`
-with `python ../gaudi_spawn.py --world_size <num-HPUs> train_dreambooth_lora_sdxl.py`.
+with `python ../../gaudi_spawn.py --world_size <num-HPUs> train_dreambooth_lora_sdxl.py`.
 
 After training is completed, you can directly use `text_to_image_generation.py` sample for inference, as shown below:
 ```bash
@@ -396,7 +396,7 @@ python train_dreambooth_lora_flux.py \
 > To use DeepSpeed instead of MPI, replace `--use_mpi` with `--use_deepspeed` in the previous example
 
 You can run inference on multiple HPUs by replacing `python train_dreambooth_lora_flux.py`
-with `python ../gaudi_spawn.py --world_size <num-HPUs> train_dreambooth_lora_flux.py`.
+with `python ../../gaudi_spawn.py --world_size <num-HPUs> train_dreambooth_lora_flux.py`.
 
 After training completes, you could directly use `text_to_image_generation.py` sample for inference as follows:
 ```bash

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -241,18 +241,19 @@ You can also provide the path to a PEFT model to perform generation with the arg
 For example:
 ```bash
 python run_generation.py \
---model_name_or_path meta-llama/Llama-2-7b-hf \
+--model_name_or_path TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
 --use_hpu_graphs \
 --use_kv_cache \
 --batch_size 1 \
 --bf16 \
---max_new_tokens 100 \
---prompt "Here is my prompt" \
---peft_model yard1/llama-2-7b-sql-lora-test \
+--max_new_tokens 26 \
+--prompt """Table: 2-11365528-2
+Columns: ['Team', 'Head Coach', 'President', 'Home Ground', 'Location']
+Natural Query: Who is the Head Coach of the team whose President is Mario Volarevic?
+SQL Query:""" \
+--peft_model smangrul/tinyllama_lora_sql \
 --sdp_on_bf16
 ```
-
-
 
 ### Using Beam Search
 


### PR DESCRIPTION
# What does this PR do?

Updates documentation with few fixes:

1. Fixes incomplete paths to multi card spawn script in `examples/stable-diffusion/training/README.md`
2. Fixes example of using PEFT adapter with LLM (the current example does not illustrate the lora fine tuned functionality)

Regarding PEFT LLM example, we currently have:
```bash
python run_generation.py \
  --model_name_or_path meta-llama/Llama-2-7b-hf \
  --use_hpu_graphs \
  --use_kv_cache \
  --batch_size 1 \
  --bf16 \
  --max_new_tokens 100 \
  --prompt "Here is my prompt" \
  --peft_model yard1/llama-2-7b-sql-lora-test \
  --sdp_on_bf16
```

This supposed to be showcasing SQL fine-tuned LoRA model to help generate correct SQL command given a specially formatted question.  The prompt  "Here is my prompt" does not showcase it.

We can instead adopt example from PEFT documentation (see [here](https://github.com/huggingface/peft/blob/main/examples/multi_adapter_examples/Lora_Merging.ipynb)).

**New Example**

```bash
python run_generation.py \
--model_name_or_path TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
--use_hpu_graphs \
--use_kv_cache \
--batch_size 1 \
--bf16 \
--max_new_tokens 26 \
--prompt """Table: 2-11365528-2
Columns: ['Team', 'Head Coach', 'President', 'Home Ground', 'Location']
Natural Query: Who is the Head Coach of the team whose President is Mario Volarevic?
SQL Query:""" \
--peft_model smangrul/tinyllama_lora_sql \
--sdp_on_bf16
```

Input:
```bash
Table: 2-11365528-2
Columns: ['Team', 'Head Coach', 'President', 'Home Ground', 'Location']
Natural Query: Who is the Head Coach of the team whose President is Mario Volarevic?
SQL Query:
```

Output (correct SQL command):
```bash
SELECT Head Coach FROM 2-11365528-2 WHERE President = mario volarevic
```

Output if we remove line `--peft_model smangrul/tinyllama_lora_sql` and effectively run original model:
```
SELECT Team, Head Coach, President, Home Ground, Location FROM Team WHERE Head Coach = Mario Volarevic
```
which is not quite a command we asked for.

This updated example better illustrates PEFT LoRA adapter with LLM for text-generation task.