### PR TITLE
Bitsandbytes installation for qlora tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -113,6 +113,22 @@ def token(request):
 
 
 def pytest_configure(config):
+    # Bitsandbytes installation for {test_bnb_qlora.py test_bnb_inference.py} tests
+    # This change will be reverted shortly
+    bnb_tests = any("bnb" in name for name in config.known_args_namespace.file_or_dir)
+    if bnb_tests:
+        import subprocess
+        import sys
+
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
+            ]
+        )
     name = ""
     try:
         from optimum.habana.utils import get_device_name

--- a/tests/test_bnb_inference.py
+++ b/tests/test_bnb_inference.py
@@ -42,22 +42,6 @@ def get_model(token: str):
 
 @pytest.mark.skipif("gaudi1" == OH_DEVICE_CONTEXT, reason="execution not supported on gaudi1")
 def test_nf4_quantization_inference(token: str, baseline):
-    try:
-        import subprocess
-        import sys
-
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
-            ]
-        )
-    except subprocess.CalledProcessError:
-        pytest.fail("Failed to install bitsandbytes")
-
     os.environ["PT_HPU_LAZY_MODE"] = "0"
     from optimum.habana.transformers import modeling_utils
 

--- a/tests/test_bnb_qlora.py
+++ b/tests/test_bnb_qlora.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 import os
-import subprocess
 
 import pytest
 import torch
 from datasets import load_dataset
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, DataCollatorForLanguageModeling
 
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
@@ -80,23 +80,6 @@ def get_model(token: str):
 
 @pytest.mark.skipif("gaudi1" == OH_DEVICE_CONTEXT, reason="execution not supported on gaudi1")
 def test_nf4_quantization_finetuning(token: str, baseline):
-    try:
-        import sys
-
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "peft==0.12.0",
-                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@multi-backend-refactor",
-            ]
-        )
-        from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
-    except subprocess.CalledProcessError:
-        pytest.fail("Failed to install peft==0.12.0 / bitsandbytes")
-
     os.environ["PT_HPU_LAZY_MODE"] = "0"
     from optimum.habana.transformers import modeling_utils
 


### PR DESCRIPTION
Move bitsandbytes installation (required for qlora tests: tests/test_bnb_qlora.py, tests/test_bnb_inference.py) to conftest.py

Details:
1) pytest runs the pytest_configure function before executing the test itself (https://github.com/huggingface/optimum-habana/blob/main/conftest.py#L118)
2) Now, this function imports optimum.habana, which imports transformers.utils, which checks whether specific packages (for example: torch, peft, bitsandbytes) are installed (and transformers saves this state). 
3) Bitsandbytes is installed later (during the test execution) because the transformer has not updated its state, and the QLORA tests fail for the above reason. 
4) This issue does not occur in internal (OH-fork) repo because of the absence of the pytest_configure function from conftest.py file

5) Currently, we cannot add bitsandbytes to the requirements of tests in setup.py as discussed earlier.(https://github.com/huggingface/optimum-habana/pull/1941#issuecomment-2823330870). Once we upstream the a proper fix to bitsandbytes repo, we'll revert this change in conftest.py 