### PR TITLE
enable profiling for video-comprehension sample

### DIFF
--- a/examples/common_parser.py
+++ b/examples/common_parser.py
@@ -1,0 +1,21 @@
+from argparse import ArgumentParser
+
+
+def add_profiling_args(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "--profiling_warmup_steps",
+        default=0,
+        type=int,
+        help="Number of steps to ignore for profiling.",
+    )
+    parser.add_argument(
+        "--profiling_steps",
+        default=0,
+        type=int,
+        help="Number of steps to capture for profiling.",
+    )
+    parser.add_argument(
+        "--profiling_record_shapes",
+        action="store_true",
+        help="Record shapes when enabling profiling.",
+    )

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -23,6 +23,7 @@ import json
 import logging
 import math
 import os
+import sys
 from itertools import cycle
 from pathlib import Path
 
@@ -38,6 +39,12 @@ from utils import (
 )
 
 from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
+
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+from examples.common_parser import add_profiling_args  # noqa: E402
 
 
 logging.basicConfig(
@@ -132,23 +139,7 @@ def setup_parser(parser):
         type=int,
         help="Seed to use for random generation. Useful to reproduce your runs with `--do_sample`.",
     )
-    parser.add_argument(
-        "--profiling_warmup_steps",
-        default=0,
-        type=int,
-        help="Number of steps to ignore for profiling.",
-    )
-    parser.add_argument(
-        "--profiling_steps",
-        default=0,
-        type=int,
-        help="Number of steps to capture for profiling.",
-    )
-    parser.add_argument(
-        "--profiling_record_shapes",
-        action="store_true",
-        help="Record shapes when enabling profiling.",
-    )
+    add_profiling_args(parser)
     parser.add_argument(
         "--prompt",
         default=None,


### PR DESCRIPTION
# What does this PR do?

Enable profiling for video-comprehension sample. I needed to collect profiling results for performance degradation issue, to do it
- I've added profiling arguments as it works in text-generation/run_generation.py
- To avoid code duplication I've added common_parser.py and moved profiling options to this file.
Some command lines to test:
python examples/video-comprehension/run_example.py --help
python examples/text-generation/run_generation.py --help
python examples/video-comprehension/run_example.py --model_name_or_path LanguageBind/Video-LLaVA-7B-hf --bf16 --use_hpu_graphs --output_dir /tmp/tmpssf594uz --profiling_steps 10 --profiling_warmup_steps 3 --profiling_record_shapes

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
