### PR TITLE
Fix FLUX fine-tuning script

### DIFF
--- a/examples/stable-diffusion/training/train_dreambooth_lora_flux.py
+++ b/examples/stable-diffusion/training/train_dreambooth_lora_flux.py
@@ -535,10 +535,16 @@ class DreamBoothDataset(Dataset):
         prompt_embeds = embeddings[0]
         pooled_prompt_embeds = embeddings[1]
         text_ids = embeddings[2]
-        prompt_embeds = prompt_embeds.reshape(self.max_sequence_length, prompt_embeds.shape[-1])
-        pooled_prompt_embeds = pooled_prompt_embeds.reshape(pooled_prompt_embeds.shape[-1])
-        text_ids = text_ids.reshape(self.max_sequence_length, 3)
-        return prompt_embeds, pooled_prompt_embeds, text_ids
+        if torch.is_tensor(prompt_embeds):
+            prompt_embeds = prompt_embeds.reshape(self.max_sequence_length, prompt_embeds.shape[-1])
+            pooled_prompt_embeds = pooled_prompt_embeds.reshape(pooled_prompt_embeds.shape[-1])
+            text_ids = text_ids.reshape(self.max_sequence_length, 3)
+            return prompt_embeds, pooled_prompt_embeds, text_ids
+        else:
+            prompt_embeds = np.array(prompt_embeds).reshape(self.max_sequence_length, prompt_embeds.shape[-1])
+            pooled_prompt_embeds = np.array(pooled_prompt_embeds).reshape(pooled_prompt_embeds.shape[-1])
+            text_ids = np.array(text_ids).reshape(self.max_sequence_length, 3)
+            return torch.from_numpy(prompt_embeds), torch.from_numpy(pooled_prompt_embeds), torch.from_numpy(text_ids)
 
     def generate_image_hash(self, image):
         return insecure_hashlib.sha256(image.tobytes()).hexdigest()

--- a/examples/stable-diffusion/training/train_dreambooth_lora_flux.py
+++ b/examples/stable-diffusion/training/train_dreambooth_lora_flux.py
@@ -535,10 +535,10 @@ class DreamBoothDataset(Dataset):
         prompt_embeds = embeddings[0]
         pooled_prompt_embeds = embeddings[1]
         text_ids = embeddings[2]
-        prompt_embeds = np.array(prompt_embeds).reshape(self.max_sequence_length, prompt_embeds.shape[-1])
-        pooled_prompt_embeds = np.array(pooled_prompt_embeds).reshape(pooled_prompt_embeds.shape[-1])
-        text_ids = np.array(text_ids).reshape(self.max_sequence_length, 3)
-        return torch.from_numpy(prompt_embeds), torch.from_numpy(pooled_prompt_embeds), torch.from_numpy(text_ids)
+        prompt_embeds = prompt_embeds.reshape(self.max_sequence_length, prompt_embeds.shape[-1])
+        pooled_prompt_embeds = pooled_prompt_embeds.reshape(pooled_prompt_embeds.shape[-1])
+        text_ids = text_ids.reshape(self.max_sequence_length, 3)
+        return prompt_embeds, pooled_prompt_embeds, text_ids
 
     def generate_image_hash(self, image):
         return insecure_hashlib.sha256(image.tobytes()).hexdigest()

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -6503,7 +6503,9 @@ class DreamBoothLoRAFLUX(TestCase):
                 self.assertTrue(os.path.isfile(os.path.join(out_dir, "pytorch_lora_weights.safetensors")))
 
                 # make sure the state_dict has the correct naming in the parameters.
-                lora_state_dict = safetensors.torch.load_file(os.path.join(out_dir, "pytorch_lora_weights.safetensors"))
+                lora_state_dict = safetensors.torch.load_file(
+                    os.path.join(out_dir, "pytorch_lora_weights.safetensors")
+                )
                 is_lora = all("lora" in k for k in lora_state_dict.keys())
                 self.assertTrue(is_lora)
 
@@ -6523,7 +6525,7 @@ class DreamBoothLoRAFLUX(TestCase):
     def test_dreambooth_lora_flux(self):
         RT_VAR = "PT_HPU_MAX_COMPOUND_OP_SIZE"
         orig_value = os.environ.get(RT_VAR)
-        os.environ[RT_VAR] = '1'
+        os.environ[RT_VAR] = "1"
         try:
             self._test_dreambooth_lora_flux(train_text_encoder=False)
         finally:


### PR DESCRIPTION
# What does this PR do?

Fixes flux training script issue caused by updated accelerator #1876 

Error before fix:
```
  File "/root/optimum-habana_main/examples/stable-diffusion/training/train_dreambooth_lora_flux.py", line 1142, in <module>
    main(args)
  File "/root/optimum-habana_main/examples/stable-diffusion/training/train_dreambooth_lora_flux.py", line 839, in main
    train_dataset = DreamBoothDataset(
  File "/root/optimum-habana_main/examples/stable-diffusion/training/train_dreambooth_lora_flux.py", line 480, in __init__
    prompt_embeds, pooled_prompt_embeds, text_ids = self.convert_to_torch_tensor(
  File "/root/optimum-habana_main/examples/stable-diffusion/training/train_dreambooth_lora_flux.py", line 538, in convert_to_torch_tensor
    prompt_embeds = np.array(prompt_embeds).reshape(self.max_sequence_length, prompt_embeds.shape[-1])
  File "/usr/local/lib/python3.10/dist-packages/torch/_tensor.py", line 1204, in __array__
    return self.numpy()
TypeError: can't convert hpu:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

After fix scripts runs without issues (tested and visual quality is good) ✅