### PR TITLE
Update t5-small samples_per_second value

### DIFF
--- a/tests/baselines/fixture/tests/test_encoder_decoder.json
+++ b/tests/baselines/fixture/tests/test_encoder_decoder.json
@@ -38,7 +38,7 @@
     },
     "gaudi3": {
       "predict_bleu": 11.7168,
-      "predict_samples_per_second": 18.174
+      "predict_samples_per_second": 13.581
     }
   }
 }


### PR DESCRIPTION
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

### Adjust ref value for t5-small model 

Feel free to replicate the value on Gaudi3, running:
```
git clone -b v1.17.0 https://github.com/huggingface/optimum-habana.git
cd optimum-habana/
pip install -e .
python -m pip install .[tests]
pip install pytest
export RUN_SLOW=1
```
```
python -m pytest tests/test_encoder_decoder.py::TestEncoderDecoderModels::test_text_translation_bf16[t5-small-Habana/t5-2-1] --device gaudi3 --log-cli-level 20 -v -s
```
for tag **v1.17.0**

The previous reference number was never achieved on the previous release (v1.16.0), at least on the machines I run the test.

On **v1.16.0** the equivalent command is:
```
export GAUDI2_CI=1
python -m pytest tests/test_encoder_decoder.py::TestEncoderDecoderModels::test_text_translation_bf16[t5-small-Habana/t5-2-1] --log-cli-level 20 -v -s
```

Test is for Lazy only