### PR TITLE
Fix issue with in-place operation with requires grad with modeling_qwen2_vl.py

### DIFF
--- a/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -620,6 +620,7 @@ class GaudiQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
                 mbatch, mtokens = image_mask.size()
                 image_mask = image_mask.flatten(0, -1)
                 inputs_embeds = inputs_embeds.flatten(0, -2)
+                inputs_embeds = inputs_embeds.clone()                
                 inputs_embeds[image_mask] = image_embeds
                 inputs_embeds = inputs_embeds.unflatten(0, [mbatch, mtokens])
 

--- a/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -620,7 +620,7 @@ class GaudiQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
                 mbatch, mtokens = image_mask.size()
                 image_mask = image_mask.flatten(0, -1)
                 inputs_embeds = inputs_embeds.flatten(0, -2)
-                inputs_embeds = inputs_embeds.clone()                
+                inputs_embeds = inputs_embeds.clone()
                 inputs_embeds[image_mask] = image_embeds
                 inputs_embeds = inputs_embeds.unflatten(0, [mbatch, mtokens])
 


### PR DESCRIPTION
# What does this PR do?

Fixes bug:
[rank1]:   File "/usr/local/lib/python3.10/dist-packages/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py", line 623, in forward
[rank1]:     inputs_embeds[image_mask] = image_embeds
[rank1]: RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.

New tests are not required.
This test still passes.
GAUDI2_CI=1 RUN_SLOW=1 python -m pytest tests/test_image_to_text_example.py -v -s -k Qwen2-VL


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
