### PR TITLE
fea(): Added PT_HPU_LAZY_MODE=1 for diffuser tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fast_tests:
 fast_tests_diffusers:
 	python -m pip install .[tests]
 	python -m pip install -r examples/stable-diffusion/requirements.txt
-	python -m pytest tests/test_diffusers.py
+	PT_HPU_LAZY_MODE=1 python -m pytest tests/test_diffusers.py
 
 # Run single-card non-regression tests on image classification models
 fast_tests_image_classifications:
@@ -103,10 +103,10 @@ slow_tests_diffusers: test_installs
 	python -m pip install -r examples/stable-diffusion/requirements.txt \
 	python -m pytest tests/test_diffusers.py -v -s -k "textual_inversion" || status1=$$?; \
 	python -m pip install peft==0.7.0 \
-	python -m pytest tests/test_diffusers.py -v -s -k "test_train_text_to_image_" || status2=$$?; \
-	python -m pytest tests/test_diffusers.py -v -s -k "test_train_controlnet" || status3=$$?; \
-	python -m pytest tests/test_diffusers.py -v -s -k "test_deterministic_image_generation" || status4=$$?; \
-	python -m pytest tests/test_diffusers.py -v -s -k "test_no_" || status5=$$?; \
+	PT_HPU_LAZY_MODE=1 python -m pytest tests/test_diffusers.py -v -s -k "test_train_text_to_image_" || status2=$$?; \
+	PT_HPU_LAZY_MODE=1 python -m pytest tests/test_diffusers.py -v -s -k "test_train_controlnet" || status3=$$?; \
+	PT_HPU_LAZY_MODE=1 python -m pytest tests/test_diffusers.py -v -s -k "test_deterministic_image_generation" || status4=$$?; \
+	PT_HPU_LAZY_MODE=1 python -m pytest tests/test_diffusers.py -v -s -k "test_no_" || status5=$$?; \
 	exit $$((status1 + status2 + status3 + status4 + status5))
 
 # Run all text-generation non-regression tests


### PR DESCRIPTION
# What does this PR do?

This PR is needed to enforece the lazy mode in diffuser starting on 1.21 release. 
It at least addresses the following failures on 1.21-5XX driver/container
```
RUN_SLOW=true python -m pytest --device gaudi2 -s -v tests/test_diffusers.py -k test_attention_slicing_forward_pass
```
```
FAILED tests/test_diffusers.py::StableDiffusionInpaintPipelineTests::test_attention_slicing_forward_pass - RuntimeError: HPUGraph class is available in lazy mode only.
FAILED tests/test_diffusers.py::StableDiffusionXLInpaintPipelineTests::test_attention_slicing_forward_pass - RuntimeError: HPUGraph class is available in lazy mode only.
```
with PR changes, the above-test pass. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
