### PR TITLE
Llama 3.2 - Fix the issue for eager mode (#260)

### DIFF
--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -1223,7 +1223,7 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
                 "token_idx_cpu", None
             )  # returns an integer so following slicing ops happen using int instead of tensor
             if token_idx is not None:
-                mask = cross_attention_mask_prev[:, token_idx_cpu - 2 : token_idx_cpu - 1, ...]
+                mask = cross_attention_mask_prev[:, token_idx_cpu - 2 : token_idx_cpu - 1, ...].clone()
                 cross_attention_mask_prev.index_copy_(1, token_idx - 1, mask)
                 model_kwargs["cross_attention_mask"] = cross_attention_mask_prev
             else:


### PR DESCRIPTION
https://github.com/habana-internal/optimum-habana-fork/pull/260





## Description of the Issue

This PR fixes a `RuntimeError` encountered during generation 

```
RuntimeError: unsupported operation: some elements of the input tensor and the written-to tensor refer to a single memory location. Please clone() the tensor before performing the operation.
```

This error originates from the `_update_model_kwargs_for_generation` method in `modeling_mllama.py`, where the following in-place operation is performed:

```python
cross_attention_mask_prev.index_copy_(1, token_idx - 1, mask)
```

In certain scenarios, the `mask` tensor and `cross_attention_mask_prev` can share overlapping memory. Performing in-place writes under such conditions is not supported by PyTorch, as it can lead to undefined behavior or memory corruption.

---

## How This PR Fixes It

This PR resolves the issue by cloning the `mask` tensor before performing the in-place `index_copy_` operation:

```python
cross_attention_mask_prev.index_copy_(1, token_idx - 1, mask.clone())
```

Cloning the tensor ensures that the source (`mask`) and the destination (`cross_attention_mask_prev`) do not share the same memory, making the operation safe and eliminating the runtime error.



