### PR TITLE
Switch to Spawn in PyTorch DataLoader when num_worker>0

### DIFF
--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -682,6 +682,7 @@ class GaudiAccelerator(Accelerator):
         # To avoid training crash issue SW-207456 when num_worker > 0 in multi-node training tasks
         if data_loader.num_workers > 0:
             import multiprocessing
+
             multiprocessing_context = multiprocessing.get_context("spawn")
             data_loader.multiprocessing_context = multiprocessing_context
 

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -680,7 +680,7 @@ class GaudiAccelerator(Accelerator):
         ###############################################################################################################
 
         # To avoid training crash issue SW-207456 when num_worker > 0 in multi-node training tasks
-        if int(os.environ["WORLD_SIZE"]) > 8 and data_loader.num_workers > 0:
+        if int(os.environ.get("WORLD_SIZE", 1)) > 8 and data_loader.num_workers > 0:
             import multiprocessing
 
             multiprocessing_context = multiprocessing.get_context("spawn")

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -680,7 +680,7 @@ class GaudiAccelerator(Accelerator):
         ###############################################################################################################
 
         # To avoid training crash issue SW-207456 when num_worker > 0 in multi-node training tasks
-        if data_loader.num_workers > 0:
+        if int(os.environ["WORLD_SIZE"]) > 8 and data_loader.num_workers > 0:
             import multiprocessing
 
             multiprocessing_context = multiprocessing.get_context("spawn")

--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -679,6 +679,12 @@ class GaudiAccelerator(Accelerator):
             process_index = int(process_index / parallel_state.get_sequence_parallel_world_size())
         ###############################################################################################################
 
+        # To avoid training crash issue SW-207456 when num_worker > 0 in multi-node training tasks
+        if data_loader.num_workers > 0:
+            import multiprocessing
+            multiprocessing_context = multiprocessing.get_context("spawn")
+            data_loader.multiprocessing_context = multiprocessing_context
+
         prepared_data_loader = prepare_data_loader(
             data_loader,
             self.device,


### PR DESCRIPTION

# What does this PR do?

In [SW-207456](https://jira.habana-labs.com/browse/SW-207456) , it is found the multi-node training would crash at the begining when `dataloader_num_workers` is set to larger than 0.

According to the [official habana document](https://docs.habana.ai/en/latest/PyTorch/Getting_Started_with_PyTorch_and_Gaudi/Getting_Started_with_PyTorch.html?highlight=spawn#torch-multiprocessing-for-dataloaders), it is required to change the start method to spawn or forkserver using the PyTorch API. Thus this PR updates the API for Accelerate Dataloader.


Fixes # (issue)
[SW-207456](https://jira.habana-labs.com/browse/SW-207456) 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
