### PR TITLE
Fix unclosed Markdown code block; add `bash` language if missing

### DIFF
--- a/examples/image-to-text/README.md
+++ b/examples/image-to-text/README.md
@@ -42,7 +42,7 @@ GLM=4v python3 run_pipeline.py \
     --sdp_on_bf16 \
     --use_flash_attention \
     --use_kv_cache
-
+```
 
 ### Multi-cards inference with BF16
 

--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -109,7 +109,7 @@ The first column is assumed to be for `text` and the second is for the summary.
 
 If the csv file has multiple columns, you can then specify the names of the columns to use:
 
-```bash
+```
     --text_column text_column_name \
     --summary_column summary_column_name \
 ```
@@ -122,7 +122,7 @@ id,date,text,summary
 
 and you wanted to select only `text` and `summary`, then you'd pass these additional arguments:
 
-```bash
+```
     --text_column text \
     --summary_column summary \
 ```
@@ -142,7 +142,7 @@ Same as with the CSV files, by default the first value will be used as the text 
 
 And as with the CSV files, you can specify which values to select from the file, by explicitly specifying the corresponding key names. In our example this again would be:
 
-```bash
+```
     --text_column text \
     --summary_column summary \
 ```

--- a/examples/text-feature-extraction/README.md
+++ b/examples/text-feature-extraction/README.md
@@ -31,3 +31,9 @@ python run_feature_extraction.py \
     --sdp_on_bf16 \
     --bf16
 ```
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -72,7 +72,7 @@ python run_generation.py --help
 
 If you want to generate a sequence of text from a prompt of your choice, you should use the `--prompt` argument.
 For example:
-```
+```bash
 python run_generation.py \
 --model_name_or_path gpt2 \
 --use_hpu_graphs \
@@ -84,7 +84,7 @@ python run_generation.py \
 ```
 
 If you want to provide several prompts as inputs, here is how to do it:
-```
+```bash
 python run_generation.py \
 --model_name_or_path gpt2 \
 --use_hpu_graphs \
@@ -102,7 +102,7 @@ python run_generation.py \
 
 If you want to generate a sequence of text from a prompt of your choice using assisted decoding, you can use the following command as an example:
 
-```
+```bash
 python run_generation.py \
 --model_name_or_path gpt2 \
 --assistant_model distilgpt2 \
@@ -758,7 +758,7 @@ pip install -r requirements_lm_eval.txt
 ### Examples
 
 Evaluate Llama 7B on Gaudi on task PiQA, using the BF16 data type:
-```
+```bash
 python run_lm_eval.py \
 --model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \

--- a/examples/text-generation/text-generation-pipeline/README.md
+++ b/examples/text-generation/text-generation-pipeline/README.md
@@ -55,7 +55,7 @@ python run_pipeline.py --help
 
 If you want to generate a sequence of text from a prompt of your choice, you should use the `--prompt` argument.
 For example:
-```
+```bash
 python run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \
@@ -66,7 +66,7 @@ python run_pipeline.py \
 ```
 
 If you want to provide several prompts as inputs, here is how to do it:
-```
+```bash
 python run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \
@@ -78,7 +78,7 @@ python run_pipeline.py \
 ```
 
 If you want to perform generation on default prompts, do not pass the `--prompt` argument.
-```
+```bash
 python run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \
@@ -88,7 +88,7 @@ python run_pipeline.py \
 ```
 
 If you want to change the temperature and top_p values, make sure to include the `--do_sample` argument. Here is a sample command.
-```
+```bash
 python run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-7b-hf \
 --use_hpu_graphs \
@@ -104,7 +104,7 @@ python run_pipeline.py \
 ### Multi-card runs
 
 To run a large model such as Llama-2-70b via DeepSpeed, run the following command.
-```
+```bash
 python ../../gaudi_spawn.py --use_deepspeed --world_size 8 run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-70b-hf \
 --max_new_tokens 100 \
@@ -116,7 +116,7 @@ python ../../gaudi_spawn.py --use_deepspeed --world_size 8 run_pipeline.py \
 ```
 
 To change the temperature and top_p values, run the following command.
-```
+```bash
 python ../../gaudi_spawn.py --use_deepspeed --world_size 8 run_pipeline.py \
 --model_name_or_path meta-llama/Llama-2-70b-hf \
 --max_new_tokens 100 \
@@ -133,7 +133,7 @@ python ../../gaudi_spawn.py --use_deepspeed --world_size 8 run_pipeline.py \
 ### Usage with LangChain
 
 To run a Q&A example with LangChain, use the script `run_pipeline_langchain.py`. It supports a similar syntax to `run_pipeline.py`. For example, you can use following command:
-```
+```bash
 python run_pipeline_langchain.py \
     --model_name_or_path meta-llama/Llama-2-7b-hf \
     --bf16 \

--- a/examples/trl/README.md
+++ b/examples/trl/README.md
@@ -4,14 +4,14 @@
 ## Requirements
 
 First, you should install the requirements:
-```
-$ pip install -U -r requirements.txt
+```bash
+pip install -U -r requirements.txt
 ```
 ## Supervised Finetuning
 
 1. The following example is for the supervised Lora finetune with Qwen2 model for conversational format dataset.
 
-    ```
+    ```bash
     python sft.py \
         --model_name_or_path "Qwen/Qwen2-7B" \
         --dataset_name "philschmid/dolly-15k-oai-style" \
@@ -45,7 +45,7 @@ $ pip install -U -r requirements.txt
 
 2. Supervised fine-tuning of the mistralai/Mixtral-8x7B-Instruct-v0.1 on 4 cards:
 
-    ```
+    ```bash
     DEEPSPEED_HPU_ZERO3_SYNC_MARK_STEP_REQUIRED=1 python ../gaudi_spawn.py --world_size 4 --use_deepspeed sft.py \
         --model_name_or_path mistralai/Mixtral-8x7B-Instruct-v0.1 \
         --dataset_name "philschmid/dolly-15k-oai-style" \
@@ -87,7 +87,7 @@ For large model like Llama2-70B, we could use DeepSpeed Zero-3 to enable DPO tra
 steps like:
 1. Supervised fine-tuning of the base llama-v2-70b model to create llama-v2-70b-se:
 
-    ```
+    ```bash
     DEEPSPEED_HPU_ZERO3_SYNC_MARK_STEP_REQUIRED=1 python ../gaudi_spawn.py --world_size 8 --use_deepspeed sft.py \
         --model_name_or_path meta-llama/Llama-2-70b-hf \
         --dataset_name "lvwerra/stack-exchange-paired" \
@@ -114,12 +114,12 @@ steps like:
         --use_lazy_mode
     ```
     To merge the adaptors to get the final sft merged checkpoint, we can use the `merge_peft_adapter.py` helper script that comes with TRL:
-    ```
+    ```bash
     python merge_peft_adapter.py --base_model_name="meta-llama/Llama-2-70b-hf" --adapter_model_name="sft" --output_name="sft/final_merged_checkpoint"
     ```
 
 2. Run the DPO trainer using the model saved by the previous step:
-    ```
+    ```bash
     DEEPSPEED_HPU_ZERO3_SYNC_MARK_STEP_REQUIRED=1 python ../gaudi_spawn.py --world_size 8 --use_deepspeed dpo.py \
         --model_name_or_path="sft/final_merged_checkpoint" \
         --tokenizer_name_or_path=meta-llama/Llama-2-70b-hf \
@@ -136,7 +136,7 @@ steps like:
 
 To merge the adaptors into the base model we can use the `merge_peft_adapter.py` helper script that comes with TRL:
 
-```
+```bash
 python merge_peft_adapter.py --base_model_name="meta-llama/Llama-2-70b-hf" --adapter_model_name="dpo" --output_name="stack-llama-2"
 ```
 
@@ -146,7 +146,7 @@ which will also push the model to your HuggingFace hub account.
 
 We can load the DPO-trained LoRA adaptors which were saved by the DPO training step and run it through the [text-generation example](https://github.com/huggingface/optimum-habana/tree/main/examples/text-generation).
 
-```
+```bash
 python ../gaudi_spawn.py --world_size 8 --use_deepspeed run_generation.py \
 --model_name_or_path ../trl/stack-llama-2/ \
 --use_hpu_graphs --use_kv_cache --batch_size 1 --bf16 --max_new_tokens 100 \
@@ -162,7 +162,7 @@ python ../gaudi_spawn.py --world_size 8 --use_deepspeed run_generation.py \
 The following example is for the creation of StackLlaMa 2: a Stack exchange llama-v2-7b model.
 There are three main steps to the PPO training process:
 1. Supervised fine-tuning of the base llama-v2-7b model to create llama-v2-7b-se:
-    ```
+    ```bash
     python ../gaudi_spawn.py --world_size 8 --use_mpi sft.py \
         --model_name_or_path meta-llama/Llama-2-7b-hf \
         --dataset_name "lvwerra/stack-exchange-paired" \
@@ -188,11 +188,11 @@ There are three main steps to the PPO training process:
         --use_lazy_mode
     ```
     To merge the adaptors to get the final sft merged checkpoint, we can use the `merge_peft_adapter.py` helper script that comes with TRL:
-    ```
+    ```bash
     python merge_peft_adapter.py --base_model_name="meta-llama/Llama-2-7b-hf" --adapter_model_name="sft" --output_name="sft/final_merged_checkpoint"
     ```
 2. Reward modeling using dialog pairs from the SE dataset on the llama-v2-7b-se to create llama-v2-7b-se-rm
-    ```
+    ```bash
     python ../gaudi_spawn.py --world_size 8 --use_mpi reward_modeling.py \
         --model_name_or_path=./sft/final_merged_checkpoint \
         --tokenizer_name_or_path=meta-llama/Llama-2-7b-hf \
@@ -250,7 +250,7 @@ HPU graphs are enabled by default for better performance.
 There are two main steps to the DDPO training process:
 
 1. Fine-tuning of the base stable-diffusion model with LoRA to create ddpo-aesthetic-predictor:
-```
+```bash
 python ddpo.py \
   --num_epochs=200 \
   --train_gradient_accumulation_steps=1 \


### PR DESCRIPTION
# What does this PR do?

This PR improves the docs (usage examples of Optimum Habana).

Improve quality of automated README.md examples extraction and automated functional test.

Precisely:
- fix issue with unclosed code block in `examples/image-to-text/README.md` (causes problems with parsing README files)
- apply Markdown rule (https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md040---fenced-code-blocks-should-have-a-language-specified) to improve "correctness" 

# Impact
No new tests are required. 
No influence on performance/accuracy.