### PR TITLE
Fix to limit inputs_embeds.clone() to training only as it affects inference

### DIFF
--- a/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/optimum/habana/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -620,7 +620,8 @@ class GaudiQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
                 mbatch, mtokens = image_mask.size()
                 image_mask = image_mask.flatten(0, -1)
                 inputs_embeds = inputs_embeds.flatten(0, -2)
-                inputs_embeds = inputs_embeds.clone()
+                if self.training:
+                    inputs_embeds = inputs_embeds.clone()
                 inputs_embeds[image_mask] = image_embeds
                 inputs_embeds = inputs_embeds.unflatten(0, [mbatch, mtokens])
 


### PR DESCRIPTION
This is followup to PR #1970 to limit the change to training only as it affects the inference side introduced by PR #1884.

# What does this PR do?



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes? - no changes needed
- [ ] Did you write any new necessary tests? - not needed, existing tests suffice
