### PR TITLE
force model preparation on eval if torch.compile enabled

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1874,7 +1874,7 @@ class GaudiTrainer(Trainer):
 
         model = self._wrap_model(self.model, training=False, dataloader=dataloader)
 
-        if len(self.accelerator._models) == 0 and model is self.model:
+        if (len(self.accelerator._models) == 0 or self.args.torch_compile) and model is self.model:
             start_time = time.time()
             model = (
                 self.accelerator.prepare(model)


### PR DESCRIPTION
Running training example as torch.compile() mode, the evaluation step skips the model compilation reporting wrong metrics.

To fix it, we force the accelerator model preparation for both training ed evaluation steps.

