### PR TITLE
WA torch.compile mode blank output for SDXL pipeline

### DIFF
--- a/optimum/habana/diffusers/models/__init__.py
+++ b/optimum/habana/diffusers/models/__init__.py
@@ -2,3 +2,5 @@ from .controlnet_sdv import ControlNetSDVModel
 from .unet_2d import gaudi_unet_2d_model_forward
 from .unet_2d_condition import gaudi_unet_2d_condition_model_forward
 from .unet_spatio_temporal_condition_controlnet import UNetSpatioTemporalConditionControlNetModel
+from . import unet_2d_blocks
+

--- a/optimum/habana/diffusers/models/unet_2d_blocks.py
+++ b/optimum/habana/diffusers/models/unet_2d_blocks.py
@@ -1,5 +1,6 @@
 import torch
-from diffusers.models.unets.unet_2d_blocks import CrossAttnDownBlock2D, CrossAttnUpBlock2D
+from diffusers.models.unets.unet_2d_blocks import CrossAttnDownBlock2D, CrossAttnUpBlock2D, UpDecoderBlock2D
+from typing import Optional
 
 CrossAttnDownBlock2D_original_forward = CrossAttnDownBlock2D.forward
 @torch.compiler.disable
@@ -12,3 +13,20 @@ CrossAttnUpBlock2D_original_forward = CrossAttnUpBlock2D.forward
 def gaudi_CrossAttnUpBlock2D_forward(self, *args, **kwargs):
     return CrossAttnUpBlock2D_original_forward(self, *args, **kwargs)
 CrossAttnUpBlock2D.forward = gaudi_CrossAttnUpBlock2D_forward
+
+# WA: added graph break between self.resnets and self.upsamplers fixed blank output
+UpDecoderBlock2D_original_forward = UpDecoderBlock2D.forward
+def gaudi_UpDecoderBlock2D_forward(self, hidden_states: torch.Tensor, temb: Optional[torch.Tensor] = None) -> torch.Tensor:
+    for resnet in self.resnets:
+        hidden_states = resnet(hidden_states, temb=temb)
+
+    # add graph break
+    if torch.compiler.is_dynamo_compiling():
+        torch._dynamo.graph_break()
+
+    if self.upsamplers is not None:
+        for upsampler in self.upsamplers:
+            hidden_states = upsampler(hidden_states)
+
+    return hidden_states
+UpDecoderBlock2D.forward = gaudi_UpDecoderBlock2D_forward

--- a/optimum/habana/diffusers/models/unet_2d_blocks.py
+++ b/optimum/habana/diffusers/models/unet_2d_blocks.py
@@ -1,0 +1,14 @@
+import torch
+from diffusers.models.unets.unet_2d_blocks import CrossAttnDownBlock2D, CrossAttnUpBlock2D
+
+CrossAttnDownBlock2D_original_forward = CrossAttnDownBlock2D.forward
+@torch.compiler.disable
+def gaudi_CrossAttnDownBlock2D_forward(self, *args, **kwargs):
+    return CrossAttnDownBlock2D_original_forward(self, *args, **kwargs)
+CrossAttnDownBlock2D.forward = gaudi_CrossAttnDownBlock2D_forward
+
+CrossAttnUpBlock2D_original_forward = CrossAttnUpBlock2D.forward
+@torch.compiler.disable
+def gaudi_CrossAttnUpBlock2D_forward(self, *args, **kwargs):
+    return CrossAttnUpBlock2D_original_forward(self, *args, **kwargs)
+CrossAttnUpBlock2D.forward = gaudi_CrossAttnUpBlock2D_forward

--- a/optimum/habana/diffusers/schedulers/scheduling_euler_ancestral_discrete.py
+++ b/optimum/habana/diffusers/schedulers/scheduling_euler_ancestral_discrete.py
@@ -94,6 +94,7 @@ class GaudiEulerAncestralDiscreteScheduler(EulerAncestralDiscreteScheduler):
         self.sigma_up_t_list = []
         self.sigma_down_t_list = []
 
+    @torch.compiler.disable
     def get_params(self, timestep: Union[float, torch.FloatTensor]):
         """
         Initialize the time-dependent parameters, and retrieve the time-dependent

--- a/optimum/habana/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/optimum/habana/diffusers/schedulers/scheduling_euler_discrete.py
@@ -181,6 +181,7 @@ class GaudiEulerDiscreteScheduler(EulerDiscreteScheduler):
         self.is_scale_input_called = True
         return sample
 
+    @torch.compiler.disable
     def step(
         self,
         model_output: torch.FloatTensor,


### PR DESCRIPTION
Based on PR#1959, compiling entire SDXL pipeline with `torch.compile()` generated blank image. 

Tracking down it is happening in `VAE --> UpDecoderBlock2D`.

Added `torch._dynamo.graph_break()` in `UpDecoderBlock2D.forward()` between `self.resnets` and `self.upsamplers` to break the graph, can workaround to fixes this issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
