### PR TITLE
Don't upcast logits to float if not necessary

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -863,7 +863,7 @@ class GaudiMixtralForCausalLM(MixtralForCausalLM):
         hidden_states = outputs[0]
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :]).float()
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
Logits only have to be converted to floats if we are computing the loss. This PR removes unnecessary conversion, resulting in some speed up.

**This PR should only be merged after upgrade to version 4.46.**