### PR TITLE
Fix deepspeed regional compilation by doing it before engine initialization

### DIFF
--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -565,10 +565,11 @@ class GaudiAccelerator(Accelerator):
             engine, optimizer, _, lr_scheduler = deepspeed.initialize(**kwargs)
 
             if self.state.dynamo_plugin.backend != DynamoBackend.NO and not self.use_regional_compilation:
+                compile_kwargs = self.state.dynamo_plugin.to_kwargs()
                 # deepspeed native compilation is done after deepspeed initialization
                 engine.compile(
                     backend=compile_kwargs.pop("backend"),
-                    compile_kwargs=self.state.dynamo_plugin.to_kwargs(),
+                    compile_kwargs=compile_kwargs,
                     compiled_autograd_enabled=self.compiled_autograd_enable,
                 )
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This avoids loosing any hooks or custom offloaded parameters added by the deepspeed engine wrapper.
@yafshar I think this makes more sense, allowing easy decompilation when saving the model, hope we can get it tested extensively !


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
