### PR TITLE
Enable distributed CFG for SD3 pipeline

### DIFF
--- a/examples/stable-diffusion/text_to_image_generation.py
+++ b/examples/stable-diffusion/text_to_image_generation.py
@@ -300,6 +300,11 @@ def main():
         help="Quantization mode 'measure', 'quantize', 'quantize-mixed' or 'disable'",
     )
     parser.add_argument(
+        "--use_distributed_cfg",
+        action="store_true",
+        help="Use distributed CFG (classifier-free guidance) across 2 devices for SD3 pipeline. Requires even world size.",
+    )
+    parser.add_argument(
         "--prompts_file",
         type=str,
         default=None,
@@ -422,6 +427,8 @@ def main():
                 negative_prompts_3 = negative_prompt_3
         kwargs_call["prompt_3"] = prompts_3
         kwargs_call["negative_prompt_3"] = negative_prompts_3
+        if args.use_distributed_cfg:
+            kwargs_call["use_distributed_cfg"] = True
 
     if inpainting:
         from diffusers.utils import load_image
@@ -613,7 +620,11 @@ def main():
     logger.setLevel(logging.INFO)
 
     # Set RNG seed
-    set_seed(args.seed)
+    seed_dist_offset = int(os.getenv("RANK", "0"))
+    if args.use_distributed_cfg:
+        # Same seed needed for a pair of workers with distributed CFG for SD3
+        seed_dist_offset = seed_dist_offset // 2
+    set_seed(args.seed + seed_dist_offset)
     if args.use_compel:
         tokenizer = [pipeline.tokenizer]
         text_encoder = [pipeline.text_encoder]
@@ -693,14 +704,15 @@ def main():
 
             image_save_dir.mkdir(parents=True, exist_ok=True)
             logger.info(f"Saving images in {image_save_dir.resolve()}...")
+            rank_ext = f"_rank{os.getenv('RANK')}" if int(os.getenv("WORLD_SIZE", "1")) > 1 else ""
             if args.ldm3d:
                 for i, rgb in enumerate(outputs.rgb):
-                    rgb.save(image_save_dir / f"rgb_{i + 1}.png")
+                    rgb.save(image_save_dir / f"rgb_{i + 1}{rank_ext}.png")
                 for i, depth in enumerate(outputs.depth):
-                    depth.save(image_save_dir / f"depth_{i + 1}.png")
+                    depth.save(image_save_dir / f"depth_{i + 1}{rank_ext}.png")
             else:
                 for i, image in enumerate(outputs.images):
-                    image.save(image_save_dir / f"image_{i + 1}.png")
+                    image.save(image_save_dir / f"image_{i + 1}{rank_ext}.png")
         else:
             logger.warning("--output_type should be equal to 'pil' to save images in --image_save_dir.")
 


### PR DESCRIPTION
# What does this PR do?

🚀 Adds distributed CFG inference support for SD3 models and updates documentation
⚡ Replaces standard RMSNorm with Gaudi-optimized RMSNorm in SD3 attention, improving performance
🛠️ Fixes text-to-image sample script to correctly output generated images during multi-card inference

# Distributed CFG Inference

In Optimum-Habana Diffusers, multi-card inference currently spawns independent image generations on each worker, which does not improve performance per device. However, the SD3 pipeline architecture allows for a performance optimization: by leveraging classifier-free guidance (CFG) mode, we can parallelize the conditional and unconditional branches across two devices, yielding up to ~2× speedup per image. This approach is not yet supported in the main Hugging Face Diffusers library (for general GPU usage), making this an original implementation.

**SD3 Inference**

In SD3x family of models Diffusion Transformer (DiT) is used in the denoising loop for image generation.  When we have prompt (and optionally negative prompt) and guidance scale > 1 (default recommended setting is 7.5), then SD3 pipeline runs in a so-called classifier-free guidance (CFG) mode.  In this mode (which is default), we process 2 latents during denoising loop:

1. Prompt-guided latents
2. Non-guided latents (negative prompt guided if negative prompt is supplied)

This means that we need 2 forward passes, one for guided latents and the other for non-guided latents. In Diffusers, the latents and embeddings are packed into tensors with a batch of size 2. Effectively, we do not perform 2 forward passes, but we run 1 forward pass with batch size 2. This process is illustrated with the following figure:

![image](https://github.com/user-attachments/assets/ba003f8b-2204-4ca5-a94a-2c6985460205)

**Distributed 2-Card CFG SD3 Inference**

The core idea behind distributed classifier-free guidance (CFG) inference across two devices is to parallelize the conditional and unconditional branches of the denoising process. We start by running the model inference independently on each device. However, at the denoising stage, the latent batch is split into guided and unguided components:

* Rank 0 (device 0) handles the guided (conditional) batch.
* Rank 1 (device 1) handles the unguided (unconditional) batch.

Each device performs denoising independently on its respective half of the batch. Once complete, the predicted noise tensors are exchanged between devices using an HCCL send/receive operation to reassemble the full batch and apply CFG. To ensure consistency between devices, both workers must use the same random seed during sampling, guaranteeing identical noise initialization and timestep behavior.

![image](https://github.com/user-attachments/assets/a081c308-e09a-493a-994b-2773bb1e52ed)

## Example

An example of performance boost and quality of generated images can be checked with the following example under `optimum-habana/examples/stable-diffusion` folder.

An example showing the performance boost and quality of generated images with distributed CFG inference mode can be ran in `optimum-habana/examples/stable-diffusion` .

Running 4 inferences for SD3.5-Large on 1xGaudi2 card:

```bash
PT_HPU_LAZY_MODE=1 python text_to_image_generation.py \
    --model_name_or_path stabilityai/stable-diffusion-3.5-large \
    --prompts "Sailing ship painting by Van Gogh" \
    --num_images_per_prompt 4 \
    --batch_size 1 \
    --num_inference_steps 28 \
    --image_save_dir /tmp/stable_diffusion_3_images_1x \
    --scheduler default \
    --use_habana \
    --use_hpu_graphs \
    --gaudi_config Habana/stable-diffusion \
    --sdp_on_bf16 \
    --bf16
```

Output:
```bash
...
[INFO|pipeline_stable_diffusion_3.py:546] 2025-06-04 22:58:26,110 >> 1 prompt(s) received, 4 generation(s) per prompt, 1 sample(s) per batch, 4 total batch(es).
100%|██████████| 28/28 [00:29<00:00,  1.05s/it]
100%|██████████| 28/28 [00:28<00:00,  1.03s/it]
100%|██████████| 28/28 [00:09<00:00,  2.90it/s]
100%|██████████| 28/28 [00:09<00:00,  2.90it/s]
[INFO|pipeline_stable_diffusion_3.py:715] 2025-06-04 22:59:58,336 >> Speed metrics: {'generation_runtime': 79.8969, 'generation_samples_per_second': 0.099, 'generation_steps_per_second': 2.768}
```
=> performance of **~2.9** steps/sec after warmup.

Generated images:
![image](https://github.com/user-attachments/assets/a0ac6222-b665-4435-be9c-cd0e8c4c5d7d)

Running 4 inferences for SD3.5-Large on 2xGaudi2 cards in Distributed CFG mode:
```bash
PT_HPU_LAZY_MODE=1 \
python ../gaudi_spawn.py --world_size 2 text_to_image_generation.py \
    --model_name_or_path stabilityai/stable-diffusion-3.5-large \
    --prompts "Sailing ship painting by Van Gogh" \
    --num_images_per_prompt 4 \
    --batch_size 1 \
    --num_inference_steps 28 \
    --image_save_dir /tmp/stable_diffusion_3_images \
    --scheduler default \
    --use_habana \
    --use_hpu_graphs \
    --use_distributed_cfg \
    --gaudi_config Habana/stable-diffusion \
    --sdp_on_bf16 \
    --bf16
```

Output:
```bash
06/04/2025 22:41:32 - INFO - __main__ - Generating images using pipeline GaudiStableDiffusion3Pipeline with scheduler GaudiFlowMatchEulerDiscreteScheduler
[INFO|pipeline_stable_diffusion_3.py:544] 2025-06-04 22:41:32,486 >> 1 prompt(s) received, 4 generation(s) per prompt, 1 sample(s) per batch, 4 total batch(es).
06/04/2025 22:41:42 - INFO - __main__ - Generating images using pipeline GaudiStableDiffusion3Pipeline with scheduler GaudiFlowMatchEulerDiscreteScheduler
[INFO|pipeline_stable_diffusion_3.py:544] 2025-06-04 22:41:42,959 >> 1 prompt(s) received, 4 generation(s) per prompt, 1 sample(s) per batch, 4 total batch(es).
100%|██████████| 28/28 [00:29<00:00,  1.04s/it]
100%|██████████| 28/28 [00:19<00:00,  1.46it/s]
100%|██████████| 28/28 [00:18<00:00,  1.49it/s]
100%|██████████| 28/28 [00:18<00:00,  1.49it/s]
100%|██████████| 28/28 [00:04<00:00,  5.62it/s]
100%|██████████| 28/28 [00:04<00:00,  5.62it/s]
100%|██████████| 28/28 [00:04<00:00,  5.63it/s]
100%|██████████| 28/28 [00:04<00:00,  5.63it/s]
[INFO|pipeline_stable_diffusion_3.py:713] 2025-06-04 22:42:44,120 >> Speed metrics: {'generation_runtime': 49.5514, 'generation_samples_per_second': 0.191, 'generation_steps_per_second': 5.343}
[INFO|pipeline_stable_diffusion_3.py:713] 2025-06-04 22:42:44,120 >> Speed metrics: {'generation_runtime': 59.5632, 'generation_samples_per_second': 0.191, 'generation_steps_per_second': 5.341}
```
=> performance of **~5.6** steps/sec after warmup.

Generated images:
![image](https://github.com/user-attachments/assets/13b114aa-b83c-4403-af27-16e5d5975e63)

Note that generated images for rank 0 and rank 1 devices are identical (as expected).  They are also identical to 1 card run example since randomization seed was the same.