### PR TITLE
[llama-vision] Remove token_idx_cpu parameter

### DIFF
--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -113,7 +113,7 @@ def _prepare_cross_attention_mask(
     cross_attention_mask: torch.Tensor,
     num_vision_tokens: int,
     dtype: str,
-    token_idx: Optional[int] = None,
+    token_idx: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Copied from _prepare_cross_attention_mask: https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/models/mllama/modeling_mllama.py#L99
@@ -1017,7 +1017,6 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
         use_flash_attention: Optional[bool] = False,
         flash_attention_recompute: Optional[bool] = False,
         logits_bf16: Optional[bool] = False,
-        token_idx_cpu: Optional[int] = None,
         **kwargs,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         """
@@ -1066,7 +1065,7 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
                 cross_attention_mask,
                 num_vision_tokens=self.vision_model.num_patches,
                 dtype=self.dtype,
-                token_idx=token_idx_cpu,
+                token_idx=token_idx,
             )
         else:
             full_text_row_masked_out_mask = None
@@ -1133,7 +1132,6 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
             - add use_flash_attention and flash_attention_recompute
         """
         token_idx = kwargs.get("token_idx", None)
-        token_idx_cpu = kwargs.get("token_idx_cpu", None)
         bucket_internal = kwargs.get("bucket_internal", None)
         if past_key_values is not None:
             if token_idx is not None:
@@ -1185,7 +1183,6 @@ class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
                 "attention_mask": attention_mask,
                 "cross_attention_mask": cross_attention_mask,
                 "token_idx": token_idx,
-                "token_idx_cpu": token_idx_cpu,
                 "trim_logits": kwargs.get("trim_logits"),
                 "use_flash_attention": kwargs.get("use_flash_attention"),
                 "flash_attention_recompute": kwargs.get("flash_attention_recompute"),


### PR DESCRIPTION
It turns out that in the configuration with hpu_graphs, an int-type parameter `token_idx_cpu` passed to mllama's forward() method causes cache misses in https://github.com/habana-internal/pytorch-integration/blob/GAUDI_v1.21.0_555/python_packages/habana_frameworks/torch/hpu/graphs.py#L618. It's due to the fact that the integer's value changes at each forward call, and the hashing function returns different hash. This leads to the graph not being reused from cache and, in consequence, a performance drop.

Example command:
```
PT_HPU_LAZY_MODE=1  python3  examples/image-to-text/run_pipeline.py --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct --use_hpu_graphs --limit_hpu_graphs --use_kv_cache --max_new_tokens 2048 --bf16 --batch_size 28  --use_flash_attention --flash_attention_recompute    --sdp_on_bf16 --logits_bf16  --max_input_tokens 128    --ignore_eos --trim_logits
```

@kalyanjk 
