### PR TITLE
Use AutoAWQ version right before introduction of qwen3

### DIFF
--- a/examples/text-generation/requirements_awq.txt
+++ b/examples/text-generation/requirements_awq.txt
@@ -1,3 +1,3 @@
 triton==3.1.0
-autoawq==0.2.8
-transformers>=4.48.2,<=4.49.0
+autoawq==0.2.7
+intel_extension_for_pytorch==2.6.0


### PR DESCRIPTION
# What does this PR do?

2 out of the 5 failures in text generation nightly CI are from an attempt to import Qwen3 in AutoAWQ https://github.com/huggingface/optimum-habana/actions/runs/15570273690/job/43863687725

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
