### PR TITLE
Revert incorrect pt2e conflict resolution

### DIFF
--- a/examples/text-generation/quantization_tools/pt2e.py
+++ b/examples/text-generation/quantization_tools/pt2e.py
@@ -50,6 +50,9 @@ def pt2e_prepare(model, qdtype_key, save, path, logger):
             exported_model = exported_model.module()
         config.logger.info("[pt2e_quant] Inserting observers for measurement")
         model.model = prepare_pt2e(exported_model, quantizer)
+        return model
+    else:
+        # Load model with quantization info --> return model for inference
         load_path = (
             config.model_path + "pt2e_quant_model.pt2" if os.path.isdir(config.model_path) else config.model_path
         )


### PR DESCRIPTION
This pull request includes a small change to the `pt2e_prepare` function in `examples/text-generation/quantization_tools/pt2e.py`. The change ensures that the function returns the `model` object after inserting observers for measurement or loading the model with quantization information.