### PR TITLE
Extra Content: add first token prints

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -524,7 +524,7 @@ def main():
 
             timer = HabanaGenerationTime()
             timer.start()
-            print(f"Starting time is {timer.start_time * 1000}", flush=True)
+            print(f"Step4+ starting time is {timer.start_time * 1000}", flush=True)
             if size is not None:
                 input_tokens = adjust_batch(input_tokens, size)
 
@@ -712,6 +712,7 @@ def main():
             """Generates sequences from the input sentences and returns them."""
             timer = HabanaGenerationTime()
             timer.start()
+            print(f"Step4+ starting time is {timer.start_time * 1000}", flush=True)
             # Tokenization
             if args.max_input_tokens > 0:
                 if hasattr(model.config, "type_vocab_size") and model.config.type_vocab_size > 0:

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -17,6 +17,7 @@
 import copy
 import inspect
 import math
+import time
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -2027,7 +2028,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 inc = iter(incrementor(bucket_size, cur_len))
             if bucket_size > 0:
                 assert "position_ids" not in model_kwargs, "Untested path"
-
+        greedy_first = True
         token_idx = model_kwargs.get("token_idx", None)
         top_k_ids = None
         if token_idx is not None:
@@ -2423,6 +2424,13 @@ class GaudiGenerationMixin(GenerationMixin):
                 )
                 this_peer_finished = unfinished_sequences.max() == 0
 
+            if greedy_first:
+                import habana_frameworks.torch.hpu as torch_hpu
+
+                torch_hpu.synchronize()
+                print(f"First Token time(greedy):{time.perf_counter() * 1000}")
+                greedy_first = False
+
             if (
                 not model_kwargs.get("pad_done", False)
                 and not model_kwargs.get("reuse_cache", False)
@@ -2619,6 +2627,7 @@ class GaudiGenerationMixin(GenerationMixin):
         )
         hb_profer.start()
 
+        sample_first = True
         if not bucket_internal:
             if bucket_size >= 0:
                 inc = iter(incrementor(bucket_size, cur_len))
@@ -2824,6 +2833,13 @@ class GaudiGenerationMixin(GenerationMixin):
             # This is needed to properly delete outputs.logits which may be very large for first iteration
             # Otherwise a reference to outputs is kept which keeps the logits alive in the next iteration
             del outputs
+
+            if sample_first:
+                import habana_frameworks.torch.hpu as torch_hpu
+
+                torch_hpu.synchronize()
+                print(f"First Token time(sample):{time.perf_counter() * 1000}")
+                sample_first = False
 
         if (
             model_kwargs.get("use_hpu_graphs", False)


### PR DESCRIPTION
This pull request introduces enhancements to logging and performance profiling in text generation methods across two files: `examples/text-generation/run_generation.py` and `optimum/habana/transformers/generation/utils.py`. The changes aim to improve debugging and profiling for Habana-based generation workflows by adding synchronization points and time measurements for specific steps.

### Logging Enhancements:
* [`examples/text-generation/run_generation.py`](diffhunk://#diff-540800c202278e07e1977ad2ad4b4c7a42e59baf002f99907b728abd99f9bf1fL527-R527): Updated logging messages to include "Step4+" for better contextual identification of profiling steps. [[1]](diffhunk://#diff-540800c202278e07e1977ad2ad4b4c7a42e59baf002f99907b728abd99f9bf1fL527-R527) [[2]](diffhunk://#diff-540800c202278e07e1977ad2ad4b4c7a42e59baf002f99907b728abd99f9bf1fR715)

### Performance Profiling:
* [`optimum/habana/transformers/generation/utils.py`](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eR2427-R2433): Added synchronization with Habana HPU and timing measurements for the first token generation in both `_contrastive_search` and `_sample` methods. This includes importing `habana_frameworks.torch.hpu` and using `time.perf_counter()` for precise profiling. [[1]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eR2427-R2433) [[2]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eR2837-R2843)
* [`optimum/habana/transformers/generation/utils.py`](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2030-R2031): Introduced flags (`greedy_first` and `sample_first`) to ensure profiling occurs only during the first token generation step in respective methods. [[1]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2030-R2031) [[2]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eR2630)

### Codebase Maintenance:
* [`optimum/habana/transformers/generation/utils.py`](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eR20): Added a missing import for the `time` module to support new profiling functionality.