### PR TITLE
Extra Content: Ifeval and MMLU now better supported

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -28,6 +28,7 @@ import torch
 import torch.nn.functional as F
 from lm_eval import evaluator, utils
 from lm_eval.models.huggingface import HFLM, TemplateLM
+from lm_eval.models.utils import stop_sequences_criteria
 
 # Local imports
 from run_generation import setup_parser
@@ -70,7 +71,7 @@ def setup_lm_eval_parser():
         type=int,
         nargs="+",
         help="Input length buckets to use with static_shapes",
-        default=[16, 32, 64, 128, 189, 284, 384],
+        default=[16, 32, 64, 128, 189, 284, 384, 985],
     )
 
     parser.add_argument(
@@ -104,7 +105,9 @@ class HabanaModelAdapter(HFLM):
         args: argparse.Namespace,
         options: GenerationConfig,
         backend: Literal["default", "causal", "seq2seq"] = "default",
+        truncation: Optional[bool] = False,
         logits_cache: bool = True,
+        max_length: Optional[int] = None,
         add_bos_token: Optional[bool] = True,
         prefix_token_id: Optional[int] = None,
         delta: Optional[str] = None,
@@ -125,9 +128,20 @@ class HabanaModelAdapter(HFLM):
         self.custom_prefix_token_id = prefix_token_id
         # determine which of 'causal' and 'seq2seq' backends to use for HF models
         self._get_backend(config=self._config, backend=backend, trust_remote_code=args.trust_remote_code)
+        self.truncation = truncation
         self.logits_cache = logits_cache
         self.add_bos_token = add_bos_token
-        self._max_length = options.max_length
+        self._max_length = max_length
+        self.hpu_graphs = args.use_hpu_graphs
+        self.use_lazy_mode = True
+        if args.torch_compile:
+            self.use_lazy_mode = False
+        self.vocab_size = self._model.config.vocab_size
+        if "gemma" in getattr(self._config, "model_type", ""):
+            self.add_bos_token = True
+            logger.info(
+                f"Model type is '{self._config.model_type}', part of the Gemma family--a BOS token will be used as Gemma underperforms without it."
+            )
         self.batch_size_per_gpu = int(args.batch_size)
         self.revision = args.model_revision
         self.model_inputs = {"use_cache": self.options.use_cache}
@@ -187,10 +201,6 @@ class HabanaModelAdapter(HFLM):
         return self._model.config.eos_token_id
 
     @property
-    def max_length(self) -> int:
-        return self.buckets[-1]
-
-    @property
     def device(self):
         # We need to do padding ourselves, otherwise we'll end up with recompilations
         # Returning 'cpu' to keep tensors on CPU in lm_eval code
@@ -214,6 +224,49 @@ class HabanaModelAdapter(HFLM):
             logits = logits[:, :-padding_length, :]
         logits = logits.to(torch.float32)
         return logits
+
+    def _model_generate(self, context, max_length, stop, **generation_kwargs):
+        """
+        Patched method
+        source: https://github.com/EleutherAI/lm-evaluation-harness/blob/v0.4.7/lm_eval/models/huggingface.py/#L858
+        """
+
+        # temperature = 0.0 if not set
+        # if do_sample is false and temp==0.0:
+        # remove temperature, as do_sample=False takes care of this
+        # and we don't want a warning from HF
+        generation_kwargs["temperature"] = generation_kwargs.get("temperature", 0.0)
+        do_sample = generation_kwargs.get("do_sample", None)
+
+        # The temperature has to be a strictly positive float -- if it is 0.0, use greedy decoding strategies
+        if generation_kwargs.get("temperature") == 0.0 and do_sample is None:
+            generation_kwargs["do_sample"] = do_sample = False
+
+        if do_sample is False and generation_kwargs.get("temperature") == 0.0:
+            generation_kwargs.pop("temperature")
+        # build stopping criteria
+        stopping_criteria = stop_sequences_criteria(self.tokenizer, stop, context.shape[1], context.shape[0])
+        # to avoid graph recompilation
+        if self.options.static_shapes:
+            # Filter buckets greater than or equal to the given number
+            greater_or_equal = [x for x in self.buckets if x >= context.shape[1]]
+            # Return the smallest value from the filtered list, or the context shape, if no such value exists
+            bucket = min(greater_or_equal, default=context.shape[1])
+            max_gen_toks = max_length - context.shape[1]
+            max_length = max(max_length, max_gen_toks + bucket)
+        # move context & attention_mask to hpu
+        context = context.to("hpu")
+        generation_kwargs["attention_mask"] = generation_kwargs["attention_mask"].to("hpu")
+        return self.model.generate(
+            input_ids=context,
+            max_length=max_length,
+            stopping_criteria=stopping_criteria,
+            pad_token_id=self.tokenizer.pad_token_id,
+            use_cache=True,
+            hpu_graphs=self.hpu_graphs,
+            lazy_mode=self.use_lazy_mode,
+            **generation_kwargs,
+        )
 
     def get_model_info(self) -> dict:
         """


### PR DESCRIPTION
This pull request introduces enhancements to the `examples/text-generation/run_lm_eval.py` script, focusing on expanding configuration options, improving generation logic, and optimizing backend behavior for specific model families. The most important changes include adding new parameters for truncation and maximum length, introducing a patched `_model_generate` method, and refining backend behavior for Gemma models.

### Configuration Enhancements:
* Added new optional parameters `truncation` and `max_length` to the `__init__` method to provide more control over text generation behavior. [[1]](diffhunk://#diff-f1cc242d23dabd24c924359e72d7eba31a9edc5c6a589ca3ab8438d7fad8589bR108-R110) [[2]](diffhunk://#diff-f1cc242d23dabd24c924359e72d7eba31a9edc5c6a589ca3ab8438d7fad8589bR131-R144)
* Expanded the default input length buckets in `setup_lm_eval_parser` to include a new bucket size of 985.

### Generation Logic Improvements:
* Introduced a patched `_model_generate` method to handle generation with stopping criteria, dynamic bucket adjustment for static shapes, and optimized handling for HPU devices.
* Removed the `max_length` property from the class, as it is now handled dynamically within the `_model_generate` method.

### Backend Optimization:
* Added logic to ensure Gemma models use a BOS token for improved performance, with logging to notify users of this behavior.