### PR TITLE
Extra Content: enable_running_lm_eval_with_log_samples

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -90,6 +90,11 @@ def setup_lm_eval_parser():
         default=False,
         help="If True, shows the full config of all tasks at the end of the evaluation.",
     )
+    parser.add_argument(
+        "--log_samples",
+        action="store_true",
+        help="If True, prints extra-logs for all tasks",
+    )
     parser.add_argument("--max_graphs", type=int, help="Maximum number of HPU graphs", default=None)
     args = setup_parser(parser)
 
@@ -262,7 +267,8 @@ def main() -> None:
 
     with HabanaGenerationTime() as timer:
         with torch.no_grad():
-            results = evaluator.simple_evaluate(lm, tasks=args.tasks, limit=args.limit_iters, log_samples=False)
+            log_samples = args.log_samples
+            results = evaluator.simple_evaluate(lm, tasks=args.tasks, limit=args.limit_iters, log_samples=log_samples)
         if args.device == "hpu":
             import habana_frameworks.torch.hpu as torch_hpu
 


### PR DESCRIPTION
This pull request introduces a new feature to the `examples/text-generation/run_lm_eval.py` script, allowing users to enable extra logging for all tasks during evaluation. The most important changes involve adding a new command-line argument and modifying the evaluation logic to utilize this argument.

### Feature Addition: Extra Logging for Tasks

* [`examples/text-generation/run_lm_eval.py`](diffhunk://#diff-f1cc242d23dabd24c924359e72d7eba31a9edc5c6a589ca3ab8438d7fad8589bR93-R97): Added a new command-line argument `--log_samples` to the `setup_lm_eval_parser` function, enabling users to toggle extra logging for all tasks during evaluation.
* [`examples/text-generation/run_lm_eval.py`](diffhunk://#diff-f1cc242d23dabd24c924359e72d7eba31a9edc5c6a589ca3ab8438d7fad8589bL265-R271): Updated the `main` function to pass the value of the new `--log_samples` argument to the `simple_evaluate` method of the `evaluator`, ensuring the extra logging behavior is applied when the argument is set.