### PR TITLE
Extra Content: fixed lost modules in regional compilation

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -195,8 +195,14 @@ def compile_regions(model, **kwargs):
             module = torch.compile(module, **kwargs)
             setattr(model, name, module)
     else:
-        for _, module in model.named_children():
-            compile_regions(module, **kwargs)
+        if model._modules:  # If model has submodules, recurse and reassign
+            for name, module in model.named_children():
+                compiled_module = compile_regions(module, **kwargs)
+                if compiled_module is not None:  # Only reassign if something is returned
+                    setattr(model, name, compiled_module)
+        else:  # Leaf node
+            compiled_model = torch.compile(model, **kwargs)
+            return compiled_model
     return model
 
 


### PR DESCRIPTION
This pull request refines the `compile_regions` function in `examples/text-generation/utils.py` to improve handling of models with nested submodules. The changes ensure proper recursion and reassignment of compiled submodules, while also addressing edge cases where models may lack submodules.

### Improvements to model compilation logic:

* [`examples/text-generation/utils.py`](diffhunk://#diff-5a060fceea52152d87c73775ffdedc6877a2a3d38fabfebc13a1075497a20729L198-R205): Enhanced the recursion logic in `compile_regions` to check if a model has submodules (`_modules`) before iterating over `named_children`. Added handling for leaf nodes by compiling the model directly and returning the compiled result.