### PR TITLE
Extra Content: enable accuracy benchmark using torch compile

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -2855,7 +2855,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 + start_token_idx
             )
             # Create a mask for positions greater than the first eos_token_id
-            mask = torch.arange(max_length).expand(batch_size, max_length) > eos_positions.unsqueeze(1)
+            mask = torch.arange(max_length, device="hpu").expand(batch_size, max_length) > eos_positions.unsqueeze(1)
             # Apply the mask to set positions greater than the first eos_token_id to pad_token_id
             input_ids[mask] = pad_token_id
 


### PR DESCRIPTION
This pull request includes a minor update to the `_sample` method in the `optimum/habana/transformers/generation/utils.py` file. The change ensures that the `torch.arange` function specifies the `device` as `"hpu"` for compatibility with Habana hardware.

* [`optimum/habana/transformers/generation/utils.py`](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2858-R2858): Updated the `mask` creation line in `_sample` method to use `torch.arange` with the `device="hpu"` argument for improved compatibility with Habana hardware.