### PR TITLE
Extra Content: enable QDQ

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -522,6 +522,8 @@ class GaudiLlamaAttention(LlamaAttention):
         Scales tensor gets the weight dtype."""
         if hasattr(self.k_proj, "qweight"):
             return self.k_proj.scales.dtype
+        elif hasattr(self.k_proj, "use_qdq") and self.k_proj.use_qdq:
+            return self.k_proj.dequant_weights.hp_dtype
         return self.k_proj.weight.dtype
 
     def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):


### PR DESCRIPTION
This pull request introduces a small enhancement to the `get_k_proj_weight_dtype` method in the `optimum/habana/transformers/models/llama/modeling_llama.py` file. The change adds a conditional check for the `use_qdq` attribute and returns the `hp_dtype` of `dequant_weights` when `use_qdq` is enabled. 

This ensures compatibility with quantization-dequantization workflows.