### PR TITLE
Extra Content: remove synDeviceGaudi call

### DIFF
--- a/optimum/habana/utils.py
+++ b/optimum/habana/utils.py
@@ -412,9 +412,7 @@ def get_device_name():
 
     device_type = htexp._get_device_type()
 
-    if device_type == htexp.synDeviceType.synDeviceGaudi:
-        return "gaudi"
-    elif device_type == htexp.synDeviceType.synDeviceGaudi2:
+    if device_type == htexp.synDeviceType.synDeviceGaudi2:
         return "gaudi2"
     elif device_type == htexp.synDeviceType.synDeviceGaudi3:
         return "gaudi3"


### PR DESCRIPTION
This pull request includes a small change to the `optimum/habana/utils.py` file. The change updates the logic in the `get_device_name` function to remove the handling of the `synDeviceGaudi` device type.