### PR TITLE
Fix device OOM caused by buffers not being deallocated fast enough

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -2898,7 +2898,7 @@ class GaudiGenerationMixin(GenerationMixin):
 
         # Trigger the garbage collector to make sure that unnecessary buffers are deallocated
         gc.collect()
-        
+
         if return_dict_in_generate:
             if self.config.is_encoder_decoder:
                 return GenerateEncoderDecoderOutput(

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import copy
+import gc
 import inspect
 import math
 import time
@@ -2895,6 +2896,9 @@ class GaudiGenerationMixin(GenerationMixin):
             # Apply the mask to set positions greater than the first eos_token_id to pad_token_id
             input_ids[mask] = pad_token_id
 
+        # Trigger the garbage collector to make sure that unnecessary buffers are deallocated
+        gc.collect()
+        
         if return_dict_in_generate:
             if self.config.is_encoder_decoder:
                 return GenerateEncoderDecoderOutput(


### PR DESCRIPTION
This PR is a fix for a reported Device OOM in Granite 8B model. The issue was caused by a big amount of ~1GB unnecessary buffers not being deallocated at the end of GaudiGenerationMixin._sample() calls, which made these buffers stay alive between GaudiGenerationMixin.generate() calls, further causing the OOM.

The solution turned out to be explicitly calling gc.collect() just before the return statements in the _sample() method, so that python's garbage collector frees the objects holding the buffers.
