### PR TITLE
Add missing test dependencies for image-to-text

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ TESTS_REQUIRE = [
     "torchsde",
     "timm",
     "peft",
+    "tiktoken",
+    "blobfile",
 ]
 
 QUALITY_REQUIRES = [

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -67,22 +67,13 @@ def _test_image_to_text(
         f"--batch_size {batch_size}",
         "--max_new_tokens 20",
         "--ignore_eos",
+        "--use_hpu_graphs",
+        "--bf16",
+        "--sdp_on_bf16",
     ]
 
     if model_name == "THUDM/glm-4v-9b":
         env_variables["GLM"] = "4v"
-
-    command += [
-        "--use_hpu_graphs",
-    ]
-
-    if "meta-llama/Llama-3.2-11B-Vision-Instruct" in model_name or "tiiuae/falcon-11B-vlm" in model_name:
-        command += [
-            "--sdp_on_bf16",
-        ]
-
-    command.append("--bf16")
-    command.append("--sdp_on_bf16")
 
     with TemporaryDirectory() as tmp_dir:
         command.append(f"--output_dir {tmp_dir}")


### PR DESCRIPTION
# What does this PR do?
The `THUDM/glm-4v-9b` model requires the `tiktoken` and `blobfile` packages. Currently, the test failed with:
```
Traceback (most recent call last):
File "/root/optimum-habana-fork/examples/image-to-text/run_pipeline.py", line 527, in <module>
  main()
File "/root/optimum-habana-fork/examples/image-to-text/run_pipeline.py", line 286, in main
  processor = AutoProcessor.from_pretrained(args.model_name_or_path, padding_side="left")
File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/processing_auto.py", line 362, in from_pretrained
  raise ValueError(

ValueError: Unrecognized processing class in THUDM/glm-4v-9b. Can't instantiate a processor, a tokenizer, an image processor or a feature extractor for this model. Make sure the repository contains the files of at least one of those processing classes.
```
Looking at the code in `processing_auto.py`: https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/models/auto/processing_auto.py#L343 the function tries to create an `AutoTokenizer` object. This call silently fails with https://github.com/huggingface/optimum-habana/blob/main/optimum/habana/transformers/models/glm4v/tokenization_chatglm.py#L57
```
"GLM-4V requires the Tiktoken library to be installed. Please install it with: `pip install tiktoken`"
```
so that finally the original ValueError is raised. This PR adds the missing packages to the `TEST_REQUIRE` section in the `setup.py` file.

Additionally, I noticed that the code for constructing commands in `test_image_to_text_example.py` could be a bit simplified. Moreover, in some cases it prevents duplicated arguments.

Summary:
- add `tiktoken` and `blobfile` to `TEST_REQUIRE` in `setup.py`
- cleanup `test_image_to_text_example.py`