### PR TITLE
Fix HabanaGenerationTime usage in tests

### DIFF
--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -134,9 +134,9 @@ class GaudiFeatureExtractionTester(TestCase):
                     outputs = self.model_hpu_graph(**batch_dict)
                     embeddings(outputs, batch_dict)
             torch.hpu.synchronize()
-            time_per_iter = elapsed_time.last_duration * 1000 / test_iters  # time in ms
-            self.baseline.assertRef(
-                compare=lambda actual, ref: actual < (1.05 * ref),
-                context=[OH_DEVICE_CONTEXT],
-                time_per_iter=time_per_iter,
-            )
+        time_per_iter = elapsed_time.last_duration * 1000 / test_iters  # time in ms
+        self.baseline.assertRef(
+            compare=lambda actual, ref: actual < (1.05 * ref),
+            context=[OH_DEVICE_CONTEXT],
+            time_per_iter=time_per_iter,
+        )

--- a/tests/test_video_mae.py
+++ b/tests/test_video_mae.py
@@ -133,9 +133,9 @@ class GaudiVideoMAETester(TestCase):
                 for _ in range(test_iters):
                     self.model_hpu_graph(**self.inputs_hpu)
                     torch.hpu.synchronize()
-            time_per_iter = timer.last_duration * 1000 / test_iters  # Time in ms
-            self.baseline.assertRef(
-                compare=lambda latency, expect: latency < (1.05 * expect),
-                context=[OH_DEVICE_CONTEXT],
-                latency=time_per_iter,
-            )
+        time_per_iter = timer.last_duration * 1000 / test_iters  # Time in ms
+        self.baseline.assertRef(
+            compare=lambda latency, expect: latency < (1.05 * expect),
+            context=[OH_DEVICE_CONTEXT],
+            latency=time_per_iter,
+        )


### PR DESCRIPTION
# What does this PR do?
For two test cases: `test_feature_extraction` and `test_video_mae` the line that accessed the measured time (`HabanaGenerationTime`) was still within the scope of the context manager, so that `last_duration` was still set to `None`. This commit fixes the indentation of those lines.