### PR TITLE
text-generation requirements fix for transformers upgrade 4.51

### DIFF
--- a/examples/text-generation/requirements_awq.txt
+++ b/examples/text-generation/requirements_awq.txt
@@ -1,3 +1,3 @@
 triton==3.1.0
 autoawq
-transformers>=4.48.2,<=4.49.0
+transformers>=4.51.0,<4.52.0

--- a/examples/text-generation/requirements_awq.txt
+++ b/examples/text-generation/requirements_awq.txt
@@ -1,3 +1,2 @@
 triton==3.1.0
 autoawq
-transformers>=4.51.0,<4.52.0


### PR DESCRIPTION
This PR updates the transformers version constraint in text-generation/requirements.txt:

This change is required to align with updates introduced in [#2063](https://github.com/huggingface/optimum-habana/pull/2063), which upgraded the minimum supported transformers version to 4.51. Without this fix, certain classes such as AssistantVocabTranslatorCache used in text generation are not available, leading to import errors.
