### PR TITLE
Revert QDQ config json

### DIFF
--- a/examples/text-generation/quantization_config/maxabs_quant_qdq.json
+++ b/examples/text-generation/quantization_config/maxabs_quant_qdq.json
@@ -1,0 +1,9 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "scale_format": "SCALAR",
+    "dump_stats_path": "./hqt_output/measure",
+    "use_qdq": "True"
+}


### PR DESCRIPTION
This pull request introduces a new quantization configuration file to the `examples/text-generation/quantization_config` directory. The file specifies parameters for quantization using the MaxAbs method with QDQ enabled.

Key change:

* [`examples/text-generation/quantization_config/maxabs_quant_qdq.json`](diffhunk://#diff-e888e981b24b333119caec937ae316e0f496653cbadc55112ca86ab542ff8988R1-R9): Added a new JSON configuration file for quantization using the MaxAbs method. The configuration includes details such as the observer type (`maxabs`), scale method (`maxabs_hw`), and enabling QDQ (`use_qdq: True`).