### PR TITLE
Remove unnecesary HabanaProfile.disable

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -1067,8 +1067,6 @@ def main():
             ).cpu()
             return prompt, outputs
 
-        # compilation stage disable profiling
-        HabanaProfile.disable()
         # Compilation
         logger.info("Graph compilation...")
         timer = HabanaGenerationTime()


### PR DESCRIPTION
This pull request includes a small change to the `generate_dataset` function in `examples/text-generation/run_generation.py`. The change removes the call to `HabanaProfile.disable()` during the compilation stage, simplifying the function.