### PR TITLE
Bring back dynamic quantization files

### DIFF
--- a/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -1,0 +1,13 @@
+{
+    "mode": "QUANTIZE",
+    "scale_method": "ACT_MAXABS_PCS_POW2_WEIGHT_MAXABS_PTS_POW2_HW",
+    "scale_format": "CONST",
+    "allowlist": {
+        "types": [],
+        "names": [
+            "mlp"
+        ]
+    },
+    "dynamic_quantization": "True",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization_pts.json
+++ b/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization_pts.json
@@ -1,0 +1,13 @@
+{
+    "mode": "QUANTIZE",
+    "scale_method": "maxabs_pow2",
+    "scale_format": "CONST",
+    "allowlist": {
+        "types": [],
+        "names": [
+            "mlp"
+        ]
+    },
+    "dynamic_quantization": "True",
+    "dump_stats_path": "./hqt_output/measure"
+}


### PR DESCRIPTION
This pull request adds two new configuration files for dynamic quantization in the `examples/text-generation/quantization_config` directory. These configurations specify different methods for scaling and quantizing model parameters.

**New dynamic quantization configurations:**

* [`examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization.json`](diffhunk://#diff-18fb0c9fe1fdf297efb66b2574e8341e5eeed130caac00a211e401795789aab4R1-R13): Introduced a configuration file with the `ACT_MAXABS_PCS_POW2_WEIGHT_MAXABS_PTS_POW2_HW` scaling method, allowing dynamic quantization and specifying the `mlp` module in the allowlist.
* [`examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization_pts.json`](diffhunk://#diff-289160e64f718dba101055a0bb1b0e345fe44d5f0a9f08f1d13ed5a91293f594R1-R13): Added another configuration file using the `maxabs_pow2` scaling method, also enabling dynamic quantization and targeting the `mlp` module in the allowlist.