### PR TITLE
Add missing test dependency (bitsandbytes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ TESTS_REQUIRE = [
     "torchsde",
     "timm",
     "peft",
+    "bitsandbytes",
 ]
 
 QUALITY_REQUIRES = [


### PR DESCRIPTION
This PR adds the bitsandbytes library to the test dependencies for text generation.

Starting from Transformers 4.51, loading some quantized models (especially with AutoModelForCausalLM.from_pretrained) may trigger runtime error