### PR TITLE
Pin numpy version to 1.26.4 for fast diffuser tests

### DIFF
--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python == 4.10.0.82
 compel
 sentencepiece
+numpy==1.26.4


### PR DESCRIPTION
Temporary workaround to mitigate NumPy upgrade to 2.2 in PyTorch Bridge for Intel Gaudi (HPU) until support for the new NumPy is provided.