### PR TITLE
Enable dynamic quantization

### DIFF
--- a/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/examples/text-generation/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -1,0 +1,12 @@
+{
+    "mode": "QUANTIZE",
+    "scale_method": "MAXABS_POW2_DYNAMIC",
+    "scale_format": "CONST",
+    "allowlist": {
+        "types": [],
+        "names": [
+            "mlp"
+        ]
+    },
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -523,6 +523,8 @@ class GaudiLlamaAttention(LlamaAttention):
         Scales tensor gets the weight dtype."""
         if hasattr(self.k_proj, "qweight"):
             return self.k_proj.scales.dtype
+        elif isinstance(self.k_cache, KVCache) and "float8" in str(self.k_proj.weight.dtype):
+            return self.k_proj.hp_dtype
         return self.k_proj.weight.dtype
 
     def allocate_kv_cache(self, batch_size, max_seq_len, inp_seq_len):


### PR DESCRIPTION
This pull request introduces changes to support dynamic quantization and improve dtype handling in specific tensor operations. The updates include the addition of a new quantization configuration file and modifications to the `get_k_proj_weight_dtype` method to handle specific dtype scenarios.

### Quantization Configuration Updates:
* Added a new configuration file, `maxabs_quant_dynamic_quantization.json`, to enable dynamic quantization using the `MAXABS_POW2_DYNAMIC` scale method. The file specifies quantization mode, scale format, and an allowlist for quantization targets (`mlp`). It also includes a path for dumping statistics.

### Tensor Dtype Handling Improvements:
* Updated the `get_k_proj_weight_dtype` method in `optimum/habana/transformers/models/llama/modeling_llama.py` to handle cases where `k_proj.weight.dtype` includes "float8" and `k_cache` is an instance of `KVCache`. In these scenarios, the method now returns `hp_dtype` instead of the default weight dtype.