### PR TITLE
Upgrade datasets requirements in audio-classification

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 1.14.0, <= 2.19.2
+datasets >= 3.0.2
 evaluate == 0.4.3
 numba==0.60.0
 librosa == 0.10.2.post1


### PR DESCRIPTION
This pull request updates the dependency requirements for the audio classification example to ensure compatibility with the latest versions of libraries.

Dependency updates:

* [`examples/audio-classification/requirements.txt`](diffhunk://#diff-46d365f6fa6b793318393522a7406ef27f034f9bb1a04ac3516a0a2849d6598fL1-R1): Updated the `datasets` library version from `>= 1.14.0, <= 2.19.2` to `>= 3.0.2` to use newer features and maintain compatibility.