### PR TITLE
Change `tokenizer` to `processing_class`

### DIFF
--- a/optimum/habana/trl/trainer/dpo_trainer.py
+++ b/optimum/habana/trl/trainer/dpo_trainer.py
@@ -477,7 +477,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             data_collator=data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/optimum/habana/trl/trainer/sft_trainer.py
+++ b/optimum/habana/trl/trainer/sft_trainer.py
@@ -420,7 +420,7 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             data_collator=data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,


### PR DESCRIPTION
# What does this PR do?
The `trl` trainers still pass `tokenizer` to the `GaudiTrainer` class. This is deprecated and causes a lot of warnings, so this commit updates the argument name to `processing_class`.