### PR TITLE
Add groups to slow_tests_image_to_text_example v1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,10 @@ slow_tests_image_to_text_example: test_installs
 	python -m pytest tests/test_image_to_text_example.py -v -s --token $(TOKEN)
 
 slow_tests_image_to_text_example_1x: test_installs
-	python -m pytest tests/test_image_to_text_example.py -m "not x8" -v -s --token $(TOKEN)
+	python -m pytest tests/test_image_to_text_example.py -m "(not x2) and (not x8)" -v -s --token $(TOKEN)
+
+slow_tests_image_to_text_example_2x: test_installs
+	python -m pytest tests/test_image_to_text_example.py -m x2 -v -s --token $(TOKEN)
 
 slow_tests_image_to_text_example_8x: test_installs
 	python -m pytest tests/test_image_to_text_example.py -m x8 -v -s --token $(TOKEN)

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -32,9 +32,9 @@ if OH_DEVICE_CONTEXT not in ["gaudi1"]:
         "fp8": [
             # ("llava-hf/llava-1.5-7b-hf", 1),
             # ("llava-hf/llava-1.5-13b-hf", 1),
-            ("llava-hf/llava-v1.6-mistral-7b-hf", 1, marks=pytest.mark.x2),
-            ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, marks=pytest.mark.x2),
-            ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, marks=pytest.mark.x8),
+            pytest.param("llava-hf/llava-v1.6-mistral-7b-hf", 1, marks=pytest.mark.x2),
+            pytest.param("llava-hf/llava-v1.6-vicuna-7b-hf", 1, marks=pytest.mark.x2),
+            pytest.param("llava-hf/llava-v1.6-vicuna-13b-hf", 1, marks=pytest.mark.x8),
         ],
     }
 else:

--- a/tests/test_image_to_text_example.py
+++ b/tests/test_image_to_text_example.py
@@ -32,9 +32,9 @@ if OH_DEVICE_CONTEXT not in ["gaudi1"]:
         "fp8": [
             # ("llava-hf/llava-1.5-7b-hf", 1),
             # ("llava-hf/llava-1.5-13b-hf", 1),
-            ("llava-hf/llava-v1.6-mistral-7b-hf", 1),
-            ("llava-hf/llava-v1.6-vicuna-7b-hf", 1),
-            pytest.param("llava-hf/llava-v1.6-vicuna-13b-hf", 1, marks=pytest.mark.x8),
+            ("llava-hf/llava-v1.6-mistral-7b-hf", 1, marks=pytest.mark.x2),
+            ("llava-hf/llava-v1.6-vicuna-7b-hf", 1, marks=pytest.mark.x2),
+            ("llava-hf/llava-v1.6-vicuna-13b-hf", 1, marks=pytest.mark.x8),
         ],
     }
 else:


### PR DESCRIPTION
Add slow_tests_image_to_text_example_2x group to align tests with correct platform configuration