### PR TITLE
Add support for setting --junitxml output via JUNITXML_DIR environment variable v1.18

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import logging
 import operator
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,14 @@ def token(request):
 
 
 def pytest_configure(config):
+    junitxml_path = config.getoption("junitxml", None)
+    junitxml_global_dir = os.getenv("JUNITXML_DIR", None)
+
+    if not junitxml_path and junitxml_global_dir:
+        timestamp = time.strftime("%Y%m%d%H%M%S")
+        os.makedirs(junitxml_global_dir, exist_ok=True)
+        config.option.xmlpath = os.path.join(junitxml_global_dir, f"result_{timestamp}.xml")
+
     # Bitsandbytes installation for {test_bnb_qlora.py test_bnb_inference.py} tests
     # This change will be reverted shortly
     bnb_tests = any("bnb" in name for name in config.known_args_namespace.file_or_dir)


### PR DESCRIPTION
This PR adds support for automatically setting the --junitxml output path based on the environment variable JUNITXML_DIR if it is not explicitly provided via command-line options.

Behavior

If --junitxml is explicitly passed → no change in behavior.
If --junitxml is not provided but JUNITXML_DIR is set → the test result will be written to JUNITXML_DIR/result_.xml.
If neither is provided → no XML report is generated (default behavior remains unchanged).
Motivation
This change enables dynamic and automated control of test result locations in CI environments (e.g., Jenkins pipelines) without needing to explicitly pass --junitxml to pytest.