### PR TITLE
This PR fixes too early deepspeed initialization

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -39,6 +39,7 @@ from utils import (
     save_model,
 )
 
+
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
     datefmt="%m/%d/%Y %H:%M:%S",

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -39,9 +39,6 @@ from utils import (
     save_model,
 )
 
-from optimum.habana.utils import HabanaGenerationTime, HabanaProfile, get_hpu_memory_stats
-
-
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
     datefmt="%m/%d/%Y %H:%M:%S",
@@ -527,6 +524,8 @@ def main():
     parser = argparse.ArgumentParser()
     args = setup_parser(parser)
     model, assistant_model, tokenizer, generation_config = initialize_model(args, logger)
+
+    from optimum.habana.utils import HabanaGenerationTime, HabanaProfile, get_hpu_memory_stats
 
     use_lazy_mode = True
     if args.torch_compile or args.pt2e_path:


### PR DESCRIPTION
TF==4.51 introduced a bug:
https://github.com/huggingface/transformers/pull/37281
deepspeed is imported too early - this causes accelerator libraries (hpu/nvidia) load too early and that blocks our environment variables to be effective (they must be set before loading habanalabs). 

it was later fixed with TF==4.52:
https://github.com/huggingface/transformers/pull/37755

so next release will not be affected. Meanwhile we must move-away all libs loading transformers.trainer from global scope.