### PR TITLE
Upgrade datasets to fix utf-8 encoding problem

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 1.14.0, <= 2.19.2
+datasets >= 3.0.2
 evaluate == 0.4.3
 numba==0.60.0
 librosa == 0.10.2.post1

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,3 +1,3 @@
-datasets==2.19.2
+datasets>=3.0.2
 peft == 0.11.1
 sentencepiece

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.8
-datasets==2.21.0
+datasets>=3.0.2
 evaluate == 0.4.3
 rouge_score == 0.1.2
 accelerate


### PR DESCRIPTION
This pull request updates the `datasets` library version in multiple requirement files across the project to ensure compatibility with version `>= 3.0.2`. The changes standardize the version used across different examples and remove upper version constraints where applicable.

Library version updates:

* [`examples/audio-classification/requirements.txt`](diffhunk://#diff-46d365f6fa6b793318393522a7406ef27f034f9bb1a04ac3516a0a2849d6598fL1-R1): Updated `datasets` version from `>= 1.14.0, <= 2.19.2` to `>= 3.0.2`.
* [`examples/text-generation/requirements.txt`](diffhunk://#diff-6f40227d268fdd6ec065cd354c71cf9b11c762b375e4ade0e5146b37a9cdb5e1L1-R1): Updated `datasets` version from `== 2.19.2` to `>= 3.0.2`.
* [`examples/text-generation/requirements_lm_eval.txt`](diffhunk://#diff-31a8b5ee72c51acd69df94416def6e14afd17ee766ebee41ba3b1ac66bf4398aL2-R2): Updated `datasets` version from `== 2.21.0` to `>= 3.0.2`.