### PR TITLE
Add missing test dependency (bitsandbytes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ TESTS_REQUIRE = [
     "torchsde",
     "timm",
     "peft",
+    "bitsandbytes",
 ]
 
 QUALITY_REQUIRES = [


### PR DESCRIPTION
This PR adds the bitsandbytes library to the test dependencies for text generation.

Starting from Transformers 4.51, loading some quantized models (especially with AutoModelForCausalLM.from_pretrained) may trigger runtime error

The issue can be reproduced in the slow test:
tests/test_text_generation_example.py::test_text_generation_bnb[unsloth/Meta-Llama-3.1-70B-bnb-4bit-1-20-False-True]