### PR TITLE
Prevent early deepspeed initialization

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -35,8 +35,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
 from utils import finalize_quantization, initialize_model, save_model
 
-from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
-
 
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 logger = utils.eval_logger
@@ -256,6 +254,8 @@ def main() -> None:
     # Modified based on cli_evaluate function in https://github.com/EleutherAI/lm-evaluation-harness/blob/v0.4.7/lm_eval/__main__.py/#L268
     args = setup_lm_eval_parser()
     model, _, tokenizer, generation_config = initialize_model(args, logger)
+
+    from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
 
     with torch.no_grad():
         lm = HabanaModelAdapter(tokenizer, model, args, generation_config)


### PR DESCRIPTION
# What does this PR do?
Some imports cause an early initialization of DeepSpeed, so that the environment variables are not set corretly. This commit postpones the initialization by moving these imports into the `main()` function.
