### PR TITLE
Upgrade datasets to fix utf-8 encoding problem

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets>=1.14.0
+datasets >= 3.0.2
 evaluate
 numba==0.60.0
 librosa

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,3 +1,3 @@
-datasets
+datasets>=3.0.2
 peft
 sentencepiece

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.7
-datasets==2.21.0
+datasets>=3.0.2
 tiktoken
 blobfile
 sentencepiece


### PR DESCRIPTION
This pull request updates the `datasets` library version across multiple requirements files in the repository to ensure compatibility with newer features and improvements. The changes standardize the version to `datasets >= 3.0.2`.

Version updates:

* [`examples/audio-classification/requirements.txt`](diffhunk://#diff-46d365f6fa6b793318393522a7406ef27f034f9bb1a04ac3516a0a2849d6598fL1-R1): Updated `datasets` from `>=1.14.0` to `>=3.0.2`.
* [`examples/text-generation/requirements.txt`](diffhunk://#diff-6f40227d268fdd6ec065cd354c71cf9b11c762b375e4ade0e5146b37a9cdb5e1L1-R1): Added a version constraint for `datasets`, changing it to `>=3.0.2`.
* [`examples/text-generation/requirements_lm_eval.txt`](diffhunk://#diff-31a8b5ee72c51acd69df94416def6e14afd17ee766ebee41ba3b1ac66bf4398aL2-R2): Updated `datasets` from `==2.21.0` to `>=3.0.2`.