### PR TITLE
Fix passing return_dict to pre_attn() in Llama

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1000,7 +1000,6 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
                     valid_sequence_lengths=sub_valid_sequence_lengths[i],
                     cache_idx=cache_idx,
                     num_virtual_tokens=num_virtual_tokens,
-                    **kwargs,
                 )
                 self.self_attn.attention_all_reduce(split_hidden_states[i])
                 if output_attentions:
@@ -1044,7 +1043,6 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
                 valid_sequence_lengths=valid_sequence_lengths,
                 cache_idx=cache_idx,
                 num_virtual_tokens=num_virtual_tokens,
-                **kwargs,
             )
             self.self_attn.attention_all_reduce(hidden_states)
             hidden_states, residual = self.post_attn_pre_mlp(hidden_states, residual)


### PR DESCRIPTION
This pull request makes a minor adjustment to the `forward` method in the LLaMA model implementation by removing the unpacking of additional keyword arguments (`**kwargs`) in two separate calls. This change prevents passing down return_dict to pre_attn() 

Changes in `forward` method:

* [`optimum/habana/transformers/models/llama/modeling_llama.py`](diffhunk://#diff-30aeee6868dd1de34878aca0583f57bb5b0dd9a2a8511a80e9a6b2645f39ce6bL1003): Removed `**kwargs` from calls to functions handling attention and sequence lengths, ensuring a more explicit and controlled parameter list. [[1]](diffhunk://#diff-30aeee6868dd1de34878aca0583f57bb5b0dd9a2a8511a80e9a6b2645f39ce6bL1003) [[2]](diffhunk://#diff-30aeee6868dd1de34878aca0583f57bb5b0dd9a2a8511a80e9a6b2645f39ce6bL1047)


The change is necessary after introducing this: https://github.com/huggingface/transformers/pull/36794