### PR TITLE
Silence `Trainer.tokenizer` warnings

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -2676,3 +2676,13 @@ class GaudiTrainer(Trainer):
             num_items_in_batch = num_items_in_batch.to(device)
 
         return batch_samples, num_items_in_batch
+
+    @property
+    def tokenizer(self) -> Optional[PreTrainedTokenizerBase]:
+        # Removed warning about usage of Trainer.tokenizer
+        return self.processing_class
+
+    @tokenizer.setter
+    def tokenizer(self, processing_class) -> None:
+        # Removed warning about usage of Trainer.tokenizer
+        self.processing_class = processing_class

--- a/optimum/habana/trl/trainer/dpo_trainer.py
+++ b/optimum/habana/trl/trainer/dpo_trainer.py
@@ -477,7 +477,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             data_collator=data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/optimum/habana/trl/trainer/sft_trainer.py
+++ b/optimum/habana/trl/trainer/sft_trainer.py
@@ -420,7 +420,7 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             data_collator=data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,


### PR DESCRIPTION
# What does this PR do?
Recent versions of `transformers` deprecated the usage of `Trainer.tokenizer` in favor of `Trainer.processing_class`. However, the property method of the tokenizer attribute triggers a `logging.warning` each time the property is accessed. This causes the script output to be flooded with these tokenizer warnings. Until the next `transformers` upgrade, we want to silence these warnings.

