### PR TITLE
Add support for local dataset loading for LibriSpeech and COCO examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ slow_tests_1x: test_installs
 
 # Run multi-card non-regression tests
 slow_tests_8x: test_installs
-	DATASET_CONFIG=$(DATASET_CONFIG) python -m pytest tests/test_examples.py -v -s -k "multi_card"
+	DATASET_CONFIG='$(DATASET_CONFIG)' python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Run DeepSpeed non-regression tests
 slow_tests_deepspeed: test_installs

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ slow_tests_1x: test_installs
 
 # Run multi-card non-regression tests
 slow_tests_8x: test_installs
-	DATA_CACHE=$(DATA_CACHE) python -m pytest tests/test_examples.py -v -s -k "multi_card"
+	DATASET_CONFIG=$(DATASET_CONFIG) python -m pytest tests/test_examples.py -v -s -k "multi_card"
 
 # Run DeepSpeed non-regression tests
 slow_tests_deepspeed: test_installs

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -193,6 +193,9 @@ class DataTrainingArguments:
     dataset_name: str = field(
         metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
     )
+    dataset_dir: Optional[str] = field(
+        default=None, metadata={"help": "Optional path to a local dataset directory (e.g. extracted LibriSpeech)."},
+    )
     dataset_config_name: str = field(
         default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
     )
@@ -489,13 +492,17 @@ def main():
     # 1. First, let's load the dataset
     raw_datasets = DatasetDict()
 
-    raw_datasets["train"] = load_dataset(
-        data_args.dataset_name,
-        data_args.dataset_config_name,
-        split=data_args.train_split_name,
-        token=data_args.token,
-        trust_remote_code=data_args.trust_remote_code,
-    )
+    load_dataset_kwargs = {
+        "path": data_args.dataset_name,
+        "name": data_args.dataset_config_name,
+        "split": data_args.train_split_name,
+        "token": data_args.token,
+        "trust_remote_code": data_args.trust_remote_code,
+    }
+    if data_args.dataset_dir is not None:
+        load_dataset_kwargs["data_dir"] = data_args.dataset_dir
+
+    raw_datasets["train"] = load_dataset(**load_dataset_kwargs)
 
     if data_args.audio_column_name not in raw_datasets["train"].column_names:
         raise ValueError(
@@ -515,13 +522,8 @@ def main():
         raw_datasets["train"] = raw_datasets["train"].select(range(data_args.max_train_samples))
 
     if training_args.do_eval:
-        raw_datasets["eval"] = load_dataset(
-            data_args.dataset_name,
-            data_args.dataset_config_name,
-            split=data_args.eval_split_name,
-            token=data_args.token,
-            trust_remote_code=data_args.trust_remote_code,
-        )
+        load_dataset_kwargs["split"] = data_args.eval_split_name
+        raw_datasets["eval"] = load_dataset(**load_dataset_kwargs)
 
         if data_args.max_eval_samples is not None:
             raw_datasets["eval"] = raw_datasets["eval"].select(range(data_args.max_eval_samples))

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -500,6 +500,7 @@ def main():
         "trust_remote_code": data_args.trust_remote_code,
     }
     if data_args.dataset_dir is not None:
+        load_dataset_kwargs["path"] = os.path.join(data_args.dataset_dir, "librispeech_asr.py")
         load_dataset_kwargs["data_dir"] = data_args.dataset_dir
         logger.info(f"Loading dataset from local cache directory: {data_args.dataset_dir}")
 

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -194,7 +194,8 @@ class DataTrainingArguments:
         metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
     )
     dataset_dir: Optional[str] = field(
-        default=None, metadata={"help": "Optional path to a local dataset directory (e.g. extracted LibriSpeech)."},
+        default=None,
+        metadata={"help": "Optional path to a local dataset directory (e.g. extracted LibriSpeech)."},
     )
     dataset_config_name: str = field(
         default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -500,8 +500,7 @@ def main():
         "trust_remote_code": data_args.trust_remote_code,
     }
     if data_args.dataset_dir is not None:
-        load_dataset_kwargs["path"] = os.path.join(data_args.dataset_dir, "librispeech_asr.py")
-        load_dataset_kwargs["data_dir"] = os.path.join(data_args.dataset_dir, "LibriSpeech")
+        load_dataset_kwargs["data_dir"] = data_args.dataset_dir
         logger.info(f"Loading dataset from local cache directory: {data_args.dataset_dir}")
 
     raw_datasets["train"] = load_dataset(**load_dataset_kwargs)

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -501,6 +501,7 @@ def main():
     }
     if data_args.dataset_dir is not None:
         load_dataset_kwargs["data_dir"] = data_args.dataset_dir
+        logger.info(f"Loading dataset from local cache directory: {data_args.dataset_dir}")
 
     raw_datasets["train"] = load_dataset(**load_dataset_kwargs)
 

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -501,7 +501,7 @@ def main():
     }
     if data_args.dataset_dir is not None:
         load_dataset_kwargs["path"] = os.path.join(data_args.dataset_dir, "librispeech_asr.py")
-        load_dataset_kwargs["data_dir"] = data_args.dataset_dir
+        load_dataset_kwargs["data_dir"] = os.path.join(data_args.dataset_dir, "LibriSpeech")
         logger.info(f"Loading dataset from local cache directory: {data_args.dataset_dir}")
 
     raw_datasets["train"] = load_dataset(**load_dataset_kwargs)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -801,6 +801,9 @@ class ExampleTesterBase(TestCase):
 
     def _get_dataset_args(self) -> List[str]:
         dataset_config = self._load_dataset_config()
+        if not dataset_config:
+            return []
+
         example_paths = {
             "run_clip": "coco",
             "run_speech_recognition_ctc": "libri",
@@ -808,7 +811,7 @@ class ExampleTesterBase(TestCase):
 
         dataset_key = example_paths.get(self.EXAMPLE_NAME)
         if dataset_key is None:
-            raise RuntimeError(f"Unsupported EXAMPLE_NAME: {self.EXAMPLE_NAME}")
+            return []
 
         dataset_info = dataset_config.get(dataset_key)
         if not dataset_info:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -221,45 +221,6 @@ class ExampleTestMeta(type):
     models.
     """
 
-    def _load_dataset_config(self) -> dict:
-        config_str = os.environ.get("DATASET_CONFIG")
-        if not config_str:
-            return {}
-        try:
-            return json.loads(config_str)
-        except json.JSONDecodeError as e:
-            raise RuntimeError("Invalid JSON in DATASET_CONFIG") from e
-
-    def _get_dataset_args(self) -> List[str]:
-        dataset_config = self._load_dataset_config()
-        if not dataset_config:
-            return []
-
-        example_paths = {
-            "run_clip": "coco",
-            "run_speech_recognition_ctc": "libri",
-        }
-
-        dataset_key = example_paths.get(self.EXAMPLE_NAME)
-        dataset_info = dataset_config.get(dataset_key)
-        if not dataset_info:
-            return []
-
-        if dataset_key == "coco":
-            return self._get_clip_dataset_args(dataset_info)
-        elif dataset_key == "libri":
-            return self._get_speech_dataset_args(dataset_info)
-        return []
-
-    def _get_clip_dataset_args(self, dataset_info: dict) -> List[str]:
-        return [f"--data_dir {dataset_info['dataset_dir']}"]
-
-    def _get_speech_dataset_args(self, dataset_info: dict) -> List[str]:
-        return [
-            f"--dataset_name {os.path.join(dataset_info['dataset_dir'], dataset_info['dataset_script'])}",
-            f"--dataset_dir {os.path.join(dataset_info['dataset_dir'], dataset_info['dataset_data'])}",
-        ]
-
     @staticmethod
     def to_test(
         model_name: str,
@@ -826,6 +787,45 @@ class ExampleTesterBase(TestCase):
                 passed = False
 
         assert passed, "One or more metrics failed"
+
+    def _load_dataset_config(self) -> dict:
+        config_str = os.environ.get("DATASET_CONFIG")
+        if not config_str:
+            return {}
+        try:
+            return json.loads(config_str)
+        except json.JSONDecodeError as e:
+            raise RuntimeError("Invalid JSON in DATASET_CONFIG") from e
+
+    def _get_dataset_args(self) -> List[str]:
+        dataset_config = self._load_dataset_config()
+        if not dataset_config:
+            return []
+
+        example_paths = {
+            "run_clip": "coco",
+            "run_speech_recognition_ctc": "libri",
+        }
+
+        dataset_key = example_paths.get(self.EXAMPLE_NAME)
+        dataset_info = dataset_config.get(dataset_key)
+        if not dataset_info:
+            return []
+
+        if dataset_key == "coco":
+            return self._get_clip_dataset_args(dataset_info)
+        elif dataset_key == "libri":
+            return self._get_speech_dataset_args(dataset_info)
+        return []
+
+    def _get_clip_dataset_args(self, dataset_info: dict) -> List[str]:
+        return [f"--data_dir {dataset_info['dataset_dir']}"]
+
+    def _get_speech_dataset_args(self, dataset_info: dict) -> List[str]:
+        return [
+            f"--dataset_name {os.path.join(dataset_info['dataset_dir'], dataset_info['dataset_script'])}",
+            f"--dataset_dir {os.path.join(dataset_info['dataset_dir'], dataset_info['dataset_data'])}",
+        ]
 
 
 class TextClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_glue"):


### PR DESCRIPTION
This PR adds support for loading datasets from local paths for the following examples:
- run_speech_recognition_ctc → LibriSpeech
- run_clip → COCO

Key features:
- New mechanism for passing dataset paths via the DATASET_CONFIG environment variable (in JSON format).
- Uses per-example argument handlers to generate appropriate CLI flags.

Example usage:
Set the DATASET_CONFIG environment variable before running tests or scripts:
`DATASET_CONFIG='{
  "coco": {
    "dataset_dir": "/path/to/local/coco"
  },
  "libri": {
    "dataset_dir": "/path/to/librispeech",
    "dataset_script": "librispeech_asr.py",
    "dataset_data": "LibriSpeech"
  }
}'`
