### PR TITLE
Fix Mllama model placement

### DIFF
--- a/examples/image-to-text/run_pipeline.py
+++ b/examples/image-to-text/run_pipeline.py
@@ -358,6 +358,7 @@ def main():
             model = AutoModelForVision2Seq.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype)
         if model_type == "mllama":
             model.language_model = initialize_distributed_model(args, model.language_model, logger, model_dtype)
+            model.to("hpu")
         else:
             model = initialize_distributed_model(args, model, logger, model_dtype)
         generator = pipeline(


### PR DESCRIPTION
# What does this PR do?
With Llama 4 support in Transformers 4.51, there was a change in the `Pipeline` class [1], which causes the pipeline device to be set to `self.model.device`. In the case of Mllama, DeepSpeed is used to create the `.language_model` on HPU, whereas the rest of the model stays on CPU [2]. Hence, always `self.model.device = CPU`, which causes the whole model to be placed back on CPU. This commit explicitly moves the model to HPU, so the pipeline will be also placed on HPU.

[1] https://github.com/huggingface/transformers/pull/37307/files#diff-441f558737166b045444da9c4be81f566b3d69054e8f20e288aed746a691fa61
[2] https://github.com/huggingface/optimum-habana/blob/v1.18.0/examples/image-to-text/run_pipeline.py#L360
