### PR TITLE
Move import to local scope in run_lm_eval, to allow prior env vars initialization.

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -336,6 +336,9 @@ def main() -> None:
     args = setup_lm_eval_parser()
     model, _, tokenizer, generation_config = initialize_model(args, logger)
 
+    # Delayed import: optimum.habana.utils is imported here to ensure that
+    # environment variables and runtime configurations are properly initialized
+    # before loading modules that depend on them.
     from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
 
     with torch.no_grad():


### PR DESCRIPTION


# What does this PR do?

This PR fixes `RuntimeError: collective nonSFG is not supported during hpu graph capturing` error, by allowing for proper environment variables initialization, which is done during `initialize_model(args, logger)` call, prior to importing `optimum.habana`.
This ensures that shared object is loaded after env vars are set and functions properly.