### PR TITLE
Remove old 1TL measuring

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -579,7 +579,7 @@ def main():
 
             timer = HabanaGenerationTime()
             timer.start()
-            print(f"Step4+ starting time is {timer.start_time * 1000}", flush=True)
+            print(f"Starting time is {timer.start_time * 1000}", flush=True)
             if size is not None:
                 input_tokens = adjust_batch(input_tokens, size)
 
@@ -773,7 +773,6 @@ def main():
             profiler = disabled_profiler if disable_profiling else per_token_profiler
             timer = HabanaGenerationTime()
             timer.start()
-            print(f"Step4+ starting time is {timer.start_time * 1000}", flush=True)
             # Tokenization
             if args.max_input_tokens > 0:
                 if hasattr(model.config, "type_vocab_size") and model.config.type_vocab_size > 0:

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -17,7 +17,6 @@
 import copy
 import inspect
 import math
-import time
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -2055,7 +2054,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 inc = iter(incrementor(bucket_size, cur_len))
             if bucket_size > 0:
                 assert "position_ids" not in model_kwargs, "Untested path"
-        greedy_first = True
+
         token_idx = model_kwargs.get("token_idx", None)
         top_k_ids = None
         if token_idx is not None:
@@ -2451,13 +2450,6 @@ class GaudiGenerationMixin(GenerationMixin):
                 )
                 this_peer_finished = unfinished_sequences.max() == 0
 
-            if greedy_first:
-                import habana_frameworks.torch.hpu as torch_hpu
-
-                torch_hpu.synchronize()
-                print(f"First Token time(greedy):{time.perf_counter() * 1000}")
-                greedy_first = False
-
             if (
                 not model_kwargs.get("pad_done", False)
                 and not model_kwargs.get("reuse_cache", False)
@@ -2649,7 +2641,6 @@ class GaudiGenerationMixin(GenerationMixin):
         if profiler is not None:
             profiler.start()
 
-        sample_first = True
         if not bucket_internal:
             if bucket_size >= 0:
                 inc = iter(incrementor(bucket_size, cur_len))
@@ -2855,13 +2846,6 @@ class GaudiGenerationMixin(GenerationMixin):
             # This is needed to properly delete outputs.logits which may be very large for first iteration
             # Otherwise a reference to outputs is kept which keeps the logits alive in the next iteration
             del outputs
-
-            if sample_first:
-                import habana_frameworks.torch.hpu as torch_hpu
-
-                torch_hpu.synchronize()
-                print(f"First Token time(sample):{time.perf_counter() * 1000}")
-                sample_first = False
 
         if (
             model_kwargs.get("use_hpu_graphs", False)


### PR DESCRIPTION
This pull request focuses on cleaning up redundant code and improving readability in the Habana-related text generation utilities and example scripts. The most important changes involve removing unused variables, redundant imports, and unnecessary debug prints.

### Cleanup in `examples/text-generation/run_generation.py`:

* Removed redundant debug print statements in the `generate` function to simplify logging output. (`[[1]](diffhunk://#diff-540800c202278e07e1977ad2ad4b4c7a42e59baf002f99907b728abd99f9bf1fL582-R582)`, `[[2]](diffhunk://#diff-540800c202278e07e1977ad2ad4b4c7a42e59baf002f99907b728abd99f9bf1fL776)`)

### Cleanup in `optimum/habana/transformers/generation/utils.py`:

* Removed the unused `time` import to clean up the file. (`[optimum/habana/transformers/generation/utils.pyL20](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL20)`)
* Eliminated the `greedy_first` variable and its associated logic in `_contrastive_search`, as it was no longer being used. (`[[1]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2058-R2057)`, `[[2]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2454-L2460)`)
* Removed the `sample_first` variable and its associated logic in `_sample`, streamlining the function. (`[[1]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2652)`, `[[2]](diffhunk://#diff-284d6c109e6788a4405e302113203f6b7e98be68afc7dd3d85b89c6329b9275eL2859-L2865)`)