### PR TITLE
Fix missing openorca dataset

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -530,7 +530,7 @@ def main():
         per_sequence_profiler = disabled_profiler
         per_token_profiler = active_profiler
 
-    if args.dataset_name == "mlcommons":
+    if args.dataset_name == "openorca" or args.dataset_name == "mlcommons":
         # Benchmark over the prompts below
         def get_ds(args):
             ds = pd.read_pickle(args.mlcommons_dataset)


### PR DESCRIPTION
This pull request updates the dataset handling logic in the `examples/text-generation/run_generation.py` script to include support for the "openorca" dataset alongside the existing "mlcommons" dataset.

Key change:

* Updated the conditional in the `main` function to allow the use of the "openorca" dataset by adding a check for `args.dataset_name == "openorca"`. This ensures that the benchmarking logic can now handle both "openorca" and "mlcommons" datasets.