### PR TITLE
Pin Tensorboard version

### DIFF
--- a/examples/stable-diffusion/training/requirements.txt
+++ b/examples/stable-diffusion/training/requirements.txt
@@ -4,3 +4,4 @@ imagesize == 1.4.1
 opencv-python
 peft==0.10.0
 sentencepiece
+tensorboard==2.19.0


### PR DESCRIPTION
# What does this PR do?

Due to the error ```AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead```, we need to pin the Tensorboard version to `tensorboard==2.19.0` - similarly to the fix in [1].

[1] https://github.com/huggingface/optimum-habana/pull/1295
