### PR TITLE
Add support for local dataset loading for LibriSpeech and COCO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ slow_tests_1x: test_installs
 # Run multi-card non-regression tests
 slow_tests_8x: test_installs
 	@status1=0; status2=0; \
-	DATA_CACHE=$(DATA_CACHE) python -m pytest tests/test_examples.py -v -s -k "multi_card" || status1=$$?; \
+	DATASET_CONFIG='$(DATASET_CONFIG)' python -m pytest tests/test_examples.py -v -s -k "multi_card" || status1=$$?; \
 	python -m pytest tests/test_habana_profiler_integration.py -v -s -m x8 || status2=$$?; \
 	exit $$((status1 + status2))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -447,10 +447,13 @@ class ExampleTestMeta(type):
                         self.assertGreaterEqual(results["accuracy"], baseline)
                 return
             elif self.EXAMPLE_NAME == "run_clip":
-                if os.environ.get("DATA_CACHE", "") == "":
+                coco_config = self._load_dataset_config().get("coco", {})
+
+                if not coco_config.get("dataset_dir"):
                     from .clip_coco_utils import COCO_URLS, download_files
 
                     download_files(COCO_URLS)
+
                 from .clip_coco_utils import create_clip_roberta_model
 
                 create_clip_roberta_model()
@@ -515,8 +518,8 @@ class ExampleTestMeta(type):
                 env_variables["PT_HPU_LAZY_MODE"] = "0"
                 if "--use_hpu_graphs_for_inference" in extra_command_line_arguments:
                     extra_command_line_arguments.remove("--use_hpu_graphs_for_inference")
-            if os.environ.get("DATA_CACHE", "") != "" and self.EXAMPLE_NAME == "run_clip":
-                extra_command_line_arguments[0] = "--data_dir {}".format(os.environ["DATA_CACHE"])
+
+            extra_command_line_arguments += self._get_dataset_args()
 
             if torch_compile and (
                 model_name == "bert-large-uncased-whole-word-masking"
@@ -787,6 +790,56 @@ class ExampleTesterBase(TestCase):
 
         assert passed, "One or more metrics failed"
 
+    def _load_dataset_config(self) -> dict:
+        config_str = os.environ.get("DATASET_CONFIG")
+        if not config_str:
+            return {}
+        try:
+            return json.loads(config_str)
+        except json.JSONDecodeError as e:
+            raise RuntimeError("Invalid JSON in DATASET_CONFIG") from e
+
+    def _get_dataset_args(self) -> List[str]:
+        dataset_config = self._load_dataset_config()
+        if not dataset_config:
+            return []
+
+        example_paths = {
+            "run_clip": "coco",
+            "run_speech_recognition_ctc": "libri",
+        }
+
+        dataset_key = example_paths.get(self.EXAMPLE_NAME)
+        if dataset_key is None:
+            return []
+
+        dataset_info = dataset_config.get(dataset_key)
+        if not dataset_info:
+            raise RuntimeError(f"No dataset_info found for EXAMPLE_NAME: {self.EXAMPLE_NAME}")
+
+        handler_map = {
+            "coco": self._get_clip_dataset_args,
+            "libri": self._get_speech_dataset_args,
+        }
+
+        return handler_map[dataset_key](dataset_info)
+
+    def _get_clip_dataset_args(self, dataset_info: dict) -> List[str]:
+        try:
+            return [f"--data_dir {dataset_info['dataset_dir']}"]
+        except KeyError as e:
+            raise RuntimeError(f"Missing key in dataset_info: {e}")
+
+    def _get_speech_dataset_args(self, dataset_info: dict) -> List[str]:
+        try:
+            base_dir = dataset_info["dataset_dir"]
+            return [
+                f"--dataset_name {os.path.join(base_dir, dataset_info['dataset_script'])}",
+                f"--dataset_dir {os.path.join(base_dir, dataset_info['dataset_data'])}",
+            ]
+        except KeyError as e:
+            raise RuntimeError(f"Missing key in dataset_info: {e}")
+
 
 class TextClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_glue"):
     TASK_NAME = "mrpc"
@@ -870,7 +923,6 @@ class MultiCardSpeechRecognitionExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_speech_recognition_ctc", multi_card=True
 ):
     TASK_NAME = "regisss/librispeech_asr_for_optimum_habana_ci"
-    DATASET_NAME = os.environ.get("DATA_CACHE")
 
 
 class MultiCardSummarizationExampleTester(


### PR DESCRIPTION
This PR adds support for loading datasets from local paths for the following examples:

run_speech_recognition_ctc → LibriSpeech
run_clip → COCO
Key features:

New mechanism for passing dataset paths via the DATASET_CONFIG environment variable (in JSON format).
Uses per-example argument handlers to generate appropriate CLI flags.
Example usage:
Set the DATASET_CONFIG environment variable before running tests or scripts:
DATASET_CONFIG='{ "coco": { "dataset_dir": "/path/to/local/coco" }, "libri": { "dataset_dir": "/path/to/librispeech", "dataset_script": "librispeech_asr.py", "dataset_data": "LibriSpeech" } }'