### PR TITLE
Factor out model_initialization from pipeline constructor, and pass initialized model.

### DIFF
--- a/examples/text-generation/text-generation-pipeline/pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/pipeline.py
@@ -10,7 +10,9 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 
 class GaudiTextGenerationPipeline(TextGenerationPipeline):
-    def __init__(self, args, logger, model, tokenizer, generation_config, use_with_langchain=False, warmup_on_init=True):
+    def __init__(
+        self, args, logger, model, tokenizer, generation_config, use_with_langchain=False, warmup_on_init=True
+    ):
         self.model = model
         self.tokenizer = tokenizer
         self.generation_config = generation_config

--- a/examples/text-generation/text-generation-pipeline/run_pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline.py
@@ -3,6 +3,8 @@ import logging
 import math
 import sys
 from pathlib import Path
+
+
 sys.path.append(str(Path(__file__).parent.parent))
 
 from run_generation import setup_parser
@@ -43,9 +45,11 @@ def main():
 
     logger.info("Initializing text-generation pipeline...")
     from utils import initialize_model
+
     model, _, tokenizer, generation_config = initialize_model(args, logger)
 
     from pipeline import GaudiTextGenerationPipeline
+
     pipe = GaudiTextGenerationPipeline(args, logger, model, tokenizer, generation_config)
 
     from optimum.habana.utils import HabanaGenerationTime

--- a/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from langchain_core.prompts import PromptTemplate
 from langchain_huggingface.llms import HuggingFacePipeline
 
+
 sys.path.append(str(Path(__file__).parent.parent))
 from run_generation import setup_parser
 
@@ -43,10 +44,14 @@ def main():
 
     # Initialize the model
     from utils import initialize_model
+
     model, _, tokenizer, generation_config = initialize_model(args, logger)
     # Initialize the pipeline
     from pipeline import GaudiTextGenerationPipeline
-    pipe = GaudiTextGenerationPipeline(args, logger, model, tokenizer, generation_config, use_with_langchain=True, warmup_on_init=False)
+
+    pipe = GaudiTextGenerationPipeline(
+        args, logger, model, tokenizer, generation_config, use_with_langchain=True, warmup_on_init=False
+    )
 
     # Create LangChain object
     hf = HuggingFacePipeline(pipeline=pipe)


### PR DESCRIPTION
# What does this PR do?

Model initialization procedure sets environmental variables, which are needed prior to habanalabs .so loading. At the same time importing pipeline, in effect, loads the library.

To resolve the egg-chicken-problem, initialization of the model needed to be extracted from the constructor and performed in outside context.
