### PR TITLE
Factor out model_initialization from pipeline constructor, and pass initialized model.

### DIFF
--- a/examples/text-generation/text-generation-pipeline/pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/pipeline.py
@@ -10,10 +10,10 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 
 class GaudiTextGenerationPipeline(TextGenerationPipeline):
-    def __init__(self, args, logger, use_with_langchain=False, warmup_on_init=True):
-        from utils import initialize_model
-
-        self.model, _, self.tokenizer, self.generation_config = initialize_model(args, logger)
+    def __init__(self, args, logger, model, tokenizer, generation_config, use_with_langchain=False, warmup_on_init=True):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.generation_config = generation_config
 
         self.task = "text-generation"
         self.device = args.device

--- a/examples/text-generation/text-generation-pipeline/run_pipeline.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline.py
@@ -1,11 +1,11 @@
 import argparse
 import logging
 import math
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent.parent))
 
-from pipeline import GaudiTextGenerationPipeline
 from run_generation import setup_parser
-
-from optimum.habana.utils import HabanaGenerationTime
 
 
 logging.basicConfig(
@@ -42,7 +42,13 @@ def main():
     input_sentences = input_sentences[: args.batch_size]
 
     logger.info("Initializing text-generation pipeline...")
-    pipe = GaudiTextGenerationPipeline(args, logger)
+    from utils import initialize_model
+    model, _, tokenizer, generation_config = initialize_model(args, logger)
+
+    from pipeline import GaudiTextGenerationPipeline
+    pipe = GaudiTextGenerationPipeline(args, logger, model, tokenizer, generation_config)
+
+    from optimum.habana.utils import HabanaGenerationTime
 
     duration = 0
     for iteration in range(args.n_iterations):

--- a/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
+++ b/examples/text-generation/text-generation-pipeline/run_pipeline_langchain.py
@@ -17,10 +17,13 @@
 import argparse
 import logging
 import math
+import sys
+from pathlib import Path
 
 from langchain_core.prompts import PromptTemplate
 from langchain_huggingface.llms import HuggingFacePipeline
-from pipeline import GaudiTextGenerationPipeline
+
+sys.path.append(str(Path(__file__).parent.parent))
 from run_generation import setup_parser
 
 from optimum.habana.utils import HabanaGenerationTime
@@ -38,8 +41,12 @@ def main():
     parser = argparse.ArgumentParser()
     args = setup_parser(parser)
 
+    # Initialize the model
+    from utils import initialize_model
+    model, _, tokenizer, generation_config = initialize_model(args, logger)
     # Initialize the pipeline
-    pipe = GaudiTextGenerationPipeline(args, logger, use_with_langchain=True, warmup_on_init=False)
+    from pipeline import GaudiTextGenerationPipeline
+    pipe = GaudiTextGenerationPipeline(args, logger, model, tokenizer, generation_config, use_with_langchain=True, warmup_on_init=False)
 
     # Create LangChain object
     hf = HuggingFacePipeline(pipeline=pipe)


### PR DESCRIPTION
# What does this PR do?

Model initialization procedure sets environmental variables, which are needed prior to habanalabs .so loading. At the same time importing pipeline, in effect, loads the library.

To resolve the egg-chicken-problem, initialization of the model needed to be extracted from the constructor and performed in outside context.