### PR TITLE
Fix utils package #2141

### DIFF
--- a/optimum/habana/utils/__init__.py
+++ b/optimum/habana/utils/__init__.py
@@ -1,0 +1,1 @@
+from .misc import *  # NOTE(pbielak): mimic previous imports from `utils.py`

--- a/optimum/habana/utils/misc.py
+++ b/optimum/habana/utils/misc.py
@@ -26,7 +26,7 @@ from transformers.utils import is_torch_available
 
 from optimum.utils import logging
 
-from .version import __version__
+from ..version import __version__
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
# What does this PR do?
A previous PR [1] introduced a new package `optimum.habana.utils` which created a conflict with the `optimum/habana/utils.py` file. This commit adds the missing `utils/__init__.py` file and moves the `utils.py` file into the `utils/` module (renamed as `misc.py`).

[1] https://github.com/huggingface/optimum-habana/pull/1926