### PR TITLE
Pin opencv version to 4.10.0.84 and remove pinned numpy version.

### DIFF
--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -1,4 +1,3 @@
-opencv-python == 4.10.0.82
+opencv-python == 4.10.0.84
 compel
 sentencepiece
-numpy==1.26.4


### PR DESCRIPTION
# What does this PR do?

Removes W/A resolving incompatibility between opencv and newer numpy versions.
Pins opencv version to a new compatible one.
