### PR TITLE
Pin opencv version to 4.10.0.84 to W/A incompatibility with newer numpy.

### DIFF
--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -1,3 +1,3 @@
-opencv-python
+opencv-python == 4.10.0.84
 compel
 sentencepiece


### PR DESCRIPTION
# What does this PR do?

Pin opencv version to newer one to W/A incompatibility with newer numpy (2.+)
