### PR TITLE
Remove unused protobuf dependecy from examples

### DIFF
--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -1,6 +1,5 @@
 datasets >= 2.14.0
 sentencepiece != 0.1.92
-protobuf
 evaluate
 scikit-learn == 1.5.2
 peft == 0.12.0

--- a/examples/summarization/requirements.txt
+++ b/examples/summarization/requirements.txt
@@ -1,6 +1,5 @@
 datasets >= 2.4.0
 sentencepiece != 0.1.92
-protobuf
 rouge-score
 nltk
 py7zr

--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -2,6 +2,5 @@ datasets >= 2.4.0
 sentencepiece != 0.1.92
 scipy
 scikit-learn == 1.5.2
-protobuf
 torch >= 1.3
 evaluate

--- a/examples/translation/requirements.txt
+++ b/examples/translation/requirements.txt
@@ -1,6 +1,5 @@
 datasets >= 2.4.0
 sentencepiece != 0.1.92
-protobuf
 sacrebleu >= 1.4.12
 py7zr
 torch >= 1.3


### PR DESCRIPTION
Protobuf (3.20.3) appeared in our security scans (for known vulnerabilities).

Protobuf doesn't seem to be used in the examples, where is listed as a dependency:
- examples/language-modeling/requirements.txt
- examples/summarization/requirements.txt
- examples/text-classification/requirements.txt
- examples/translation/requirements.txt

This PR removes the unnecessary dependency.