### PR TITLE
Use `eval_strategy` in sentence-transformers-training

### DIFF
--- a/examples/sentence-transformers-training/paraphrases/training_paraphrases.py
+++ b/examples/sentence-transformers-training/paraphrases/training_paraphrases.py
@@ -107,7 +107,7 @@ args = SentenceTransformerGaudiTrainingArguments(
     # use round robin, which samples the same amount of batches from each dataset, until one dataset is empty
     multi_dataset_batch_sampler=MultiDatasetBatchSamplers.ROUND_ROBIN,
     # Optional tracking/debugging parameters:
-    evaluation_strategy="steps",
+    eval_strategy="steps",
     eval_steps=1000,
     save_strategy="steps",
     save_steps=1000,


### PR DESCRIPTION
# What does this PR do?

The `training_paraphrases.py` script still used the deprecated `evaluation_strategy` keyword instead of `eval_strategy`.

