### PR TITLE
Add `sentencepiece` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ INSTALL_REQUIRES = [
     "diffusers >= 0.33.1, < 0.33.2",
     "huggingface_hub[hf_xet] >= 0.24.7",
     "sentence-transformers == 3.3.1",
+    "sentencepiece",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
# What does this PR do?
With the merge of [1], the patching in `modeling_utils.py` causes a series of imports which eventually tries to import `sentencepiece`. Hence, now `sentencepiece` is now a required package.

[1] https://github.com/huggingface/optimum-habana/pull/1719


