### PR TITLE
Add warn0 utility to emit warnings only on main process

### DIFF
--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -21,7 +21,6 @@ Fine-tuning the library models for question answering using a slightly adapted v
 import logging
 import os
 import sys
-import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -46,7 +45,7 @@ from transformers.utils.versions import require_version
 from utils_qa import postprocess_qa_predictions
 
 from optimum.habana import GaudiConfig, GaudiTrainingArguments
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import set_seed, warn0
 
 
 try:
@@ -646,7 +645,7 @@ def main():
         accepted_best_metrics = ("exact_match", "f1")
 
     if training_args.load_best_model_at_end and training_args.metric_for_best_model not in accepted_best_metrics:
-        warnings.warn(f"--metric_for_best_model should be set to one of {accepted_best_metrics}")
+        warn0(f"--metric_for_best_model should be set to one of {accepted_best_metrics}")
 
     metric = evaluate.load(
         "squad_v2" if data_args.version_2_with_negative else "squad", cache_dir=model_args.cache_dir

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -22,7 +22,6 @@ import logging
 import os
 import re
 import sys
-import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
@@ -45,7 +44,7 @@ from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import set_seed, warn0
 
 
 try:
@@ -775,7 +774,7 @@ def main():
     try:
         processor = AutoProcessor.from_pretrained(training_args.output_dir)
     except (OSError, KeyError):
-        warnings.warn(
+        warn0(
             "Loading a processor from a feature extractor config that does not"
             " include a `processor_class` attribute is deprecated and will be removed in v5. Please add the following "
             " attribute to your `preprocessor_config.json` file to suppress this warning: "

--- a/examples/stable-diffusion/training/textual_inversion.py
+++ b/examples/stable-diffusion/training/textual_inversion.py
@@ -20,7 +20,6 @@ import math
 import os
 import random
 import shutil
-import warnings
 from pathlib import Path
 
 import diffusers
@@ -53,7 +52,7 @@ from optimum.habana import GaudiConfig
 from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiDDIMScheduler, GaudiStableDiffusionPipeline
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
-from optimum.habana.utils import HabanaGenerationTime, set_seed
+from optimum.habana.utils import HabanaGenerationTime, set_seed, warn0
 
 
 if is_wandb_available():
@@ -737,12 +736,11 @@ def main():
         train_dataset, batch_size=args.train_batch_size, shuffle=True, num_workers=args.dataloader_num_workers
     )
     if args.validation_epochs is not None:
-        warnings.warn(
+        warn0(
             f"FutureWarning: You are doing logging with validation_epochs={args.validation_epochs}."
             " Deprecated validation_epochs in favor of `validation_steps`"
             f"Setting `args.validation_steps` to {args.validation_epochs * len(train_dataset)}",
             FutureWarning,
-            stacklevel=2,
         )
         args.validation_steps = args.validation_epochs * len(train_dataset)
 

--- a/examples/stable-diffusion/training/train_dreambooth.py
+++ b/examples/stable-diffusion/training/train_dreambooth.py
@@ -26,7 +26,6 @@ import logging
 import math
 import os
 import threading
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -64,7 +63,7 @@ from optimum.habana import GaudiConfig
 from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiStableDiffusionPipeline
 from optimum.habana.transformers.trainer import _is_peft_model
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import set_seed, warn0
 
 
 logger = get_logger(__name__)
@@ -724,9 +723,9 @@ def parse_args(input_args=None):
     else:
         # logger is not available yet
         if args.class_data_dir is not None:
-            warnings.warn("You need not use --class_data_dir without --with_prior_preservation.")
+            warn0("You need not use --class_data_dir without --with_prior_preservation.")
         if args.class_prompt is not None:
-            warnings.warn("You need not use --class_prompt without --with_prior_preservation.")
+            warn0("You need not use --class_prompt without --with_prior_preservation.")
 
     return args
 

--- a/examples/stable-diffusion/training/train_dreambooth_lora_sd3.py
+++ b/examples/stable-diffusion/training/train_dreambooth_lora_sd3.py
@@ -25,7 +25,6 @@ import os
 import random
 import shutil
 import time
-import warnings
 from contextlib import nullcontext
 from math import ceil
 from pathlib import Path
@@ -73,7 +72,7 @@ from optimum.habana.diffusers import GaudiStableDiffusion3Pipeline
 from optimum.habana.diffusers.models.attention_processor import GaudiJointAttnProcessor2_0
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 from optimum.habana.transformers.trainer import _is_peft_model
-from optimum.habana.utils import HabanaProfile, set_seed, to_gb_rounded
+from optimum.habana.utils import HabanaProfile, set_seed, to_gb_rounded, warn0
 
 
 if is_wandb_available():
@@ -705,9 +704,9 @@ def parse_args(input_args=None):
     else:
         # logger is not available yet
         if args.class_data_dir is not None:
-            warnings.warn("You need not use --class_data_dir without --with_prior_preservation.")
+            warn0("You need not use --class_data_dir without --with_prior_preservation.")
         if args.class_prompt is not None:
-            warnings.warn("You need not use --class_prompt without --with_prior_preservation.")
+            warn0("You need not use --class_prompt without --with_prior_preservation.")
 
     return args
 

--- a/examples/stable-diffusion/training/train_dreambooth_lora_sdxl.py
+++ b/examples/stable-diffusion/training/train_dreambooth_lora_sdxl.py
@@ -25,7 +25,6 @@ import logging
 import math
 import os
 import shutil
-import warnings
 from pathlib import Path
 
 import diffusers
@@ -71,7 +70,7 @@ from optimum.habana import GaudiConfig
 from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiStableDiffusionXLPipeline
 from optimum.habana.transformers.trainer import _is_peft_model
-from optimum.habana.utils import set_seed
+from optimum.habana.utils import set_seed, warn0
 
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.
@@ -596,9 +595,9 @@ def parse_args(input_args=None):
     else:
         # logger is not available yet
         if args.class_data_dir is not None:
-            warnings.warn("You need not use --class_data_dir without --with_prior_preservation.")
+            warn0("You need not use --class_data_dir without --with_prior_preservation.")
         if args.class_prompt is not None:
-            warnings.warn("You need not use --class_prompt without --with_prior_preservation.")
+            warn0("You need not use --class_prompt without --with_prior_preservation.")
 
     return args
 

--- a/examples/stable-diffusion/training/train_text_to_image_sd3.py
+++ b/examples/stable-diffusion/training/train_text_to_image_sd3.py
@@ -25,7 +25,6 @@ import os
 import random
 import shutil
 import time
-import warnings
 from contextlib import nullcontext
 from math import ceil
 from pathlib import Path
@@ -66,7 +65,7 @@ from optimum.habana.accelerate import GaudiAccelerator
 from optimum.habana.diffusers import GaudiStableDiffusion3Pipeline
 from optimum.habana.diffusers.models.attention_processor import GaudiJointAttnProcessor2_0
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
-from optimum.habana.utils import HabanaProfile, set_seed, to_gb_rounded
+from optimum.habana.utils import HabanaProfile, set_seed, to_gb_rounded, warn0
 
 
 if is_wandb_available():
@@ -692,9 +691,9 @@ def parse_args(input_args=None):
     else:
         # logger is not available yet
         if args.class_data_dir is not None:
-            warnings.warn("You need not use --class_data_dir without --with_prior_preservation.")
+            warn0("You need not use --class_data_dir without --with_prior_preservation.")
         if args.class_prompt is not None:
-            warnings.warn("You need not use --class_prompt without --with_prior_preservation.")
+            warn0("You need not use --class_prompt without --with_prior_preservation.")
 
     return args
 

--- a/optimum/habana/peft/peft_model.py
+++ b/optimum/habana/peft/peft_model.py
@@ -1,9 +1,9 @@
-import warnings
-
 import packaging.version
 import torch
 import transformers
 from peft import PeftType
+
+from ..utils import warn0
 
 
 def gaudi_generate(self, *args, **kwargs):
@@ -76,11 +76,11 @@ def gaudi_prepare_inputs_for_generation(self, *args, task_ids: torch.Tensor = No
             model_kwargs["token_idx_cpu"] = token_idx_cpu
 
         if model_kwargs.get("position_ids", None) is not None and token_idx is None:
-            warnings.warn("Position ids are not supported for parameter efficient tuning. Ignoring position ids.")
+            warn0("Position ids are not supported for parameter efficient tuning. Ignoring position ids.")
             model_kwargs["position_ids"] = None
 
         if kwargs.get("token_type_ids", None) is not None:
-            warnings.warn("Token type ids are not supported for parameter efficient tuning. Ignoring token type ids")
+            warn0("Token type ids are not supported for parameter efficient tuning. Ignoring token type ids")
             kwargs["token_type_ids"] = None
 
         if model_kwargs["past_key_values"] is None and peft_config.peft_type == PeftType.PREFIX_TUNING:

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -17,7 +17,6 @@
 import copy
 import inspect
 import math
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -75,7 +74,7 @@ from transformers.utils import ModelOutput, is_hqq_available, is_optimum_quanto_
 
 from optimum.utils import logging
 
-from ...utils import HabanaGenerationTime, HabanaProfile
+from ...utils import HabanaGenerationTime, HabanaProfile, warn0
 from ..integrations.deepspeed import unwrap_deepspeed_model
 from .candidate_generator import GaudiAssistedCandidateGenerator
 from .configuration_utils import GaudiGenerationConfig
@@ -931,7 +930,7 @@ class GaudiGenerationMixin(GenerationMixin):
             ):
                 new_generation_config = GaudiGenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:  # 4)
-                    warnings.warn(
+                    warn0(
                         "You have modified the pretrained model configuration to control generation. This is a"
                         " deprecated strategy to control generation and will be removed in v5."
                         " Please use and modify the model generation configuration (see"
@@ -1045,7 +1044,7 @@ class GaudiGenerationMixin(GenerationMixin):
         # Quick escape route 3: model that only supports legacy caches = nothing to prepare
         if not self._supports_default_dynamic_cache():
             if generation_config.cache_implementation is not None:
-                warnings.warn(
+                warn0(
                     "This model does not support `Cache` instances, it only supports the legacy cache format (tuple "
                     f"of tuples). `cache_implementation` (set to {generation_config.cache_implementation}) will be "
                     "ignored.",
@@ -1593,7 +1592,7 @@ class GaudiGenerationMixin(GenerationMixin):
             )
 
         if self.device.type != input_ids.device.type:
-            warnings.warn(
+            warn0(
                 (
                     "You are calling .generate() with the `input_ids` being on a device type different"
                     f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"

--- a/optimum/habana/transformers/gradient_checkpointing.py
+++ b/optimum/habana/transformers/gradient_checkpointing.py
@@ -35,6 +35,8 @@ from torch.utils.checkpoint import (
     set_device_states,
 )
 
+from ..utils import warn0
+
 
 __all__ = [
     "checkpoint",
@@ -45,7 +47,7 @@ __all__ = [
 # Extra warning if we are using old PyTorch version
 if version.parse(version.parse(torch.__version__).base_version) < version.parse("2.1.0"):
     warnings.simplefilter("error", UserWarning)
-    warnings.warn("PyTorch version is less than 2.1. Please upgrade to continue.", UserWarning)
+    warn0("PyTorch version is less than 2.1. Please upgrade to continue.", UserWarning)
 
 
 if not hthpu.is_initialized() and DefaultDeviceType.get_device_type() != "hpu":
@@ -70,7 +72,7 @@ def _infer_device_type(*args):
 
     device_types_set = set(device_types)
     if len(device_types_set) > 1:
-        warnings.warn(
+        warn0(
             "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. "
             "Device state will only be saved for devices of a single device type, and the remaining "
             "devices will be ignored. Consequently, if any checkpointed functions involve randomness, "
@@ -338,14 +340,13 @@ def checkpoint(
         Output of running :attr:`function` on :attr:`*args`
     """
     if use_reentrant is None:
-        warnings.warn(
+        warn0(
             "torch.utils.checkpoint: the use_reentrant parameter should be "
             "passed explicitly. In version 2.5 we will raise an exception "
             "if use_reentrant is not passed. use_reentrant=False is "
             "recommended, but if you need to preserve the current default "
             "behavior, you can pass use_reentrant=True. Refer to docs for more "
-            "details on the differences between the two variants.",
-            stacklevel=2,
+            "details on the differences between the two variants."
         )
         use_reentrant = True
 

--- a/optimum/habana/transformers/models/bloom/modeling_bloom.py
+++ b/optimum/habana/transformers/models/bloom/modeling_bloom.py
@@ -17,7 +17,6 @@
 ###############################################################################
 import math
 import os
-import warnings
 from typing import Optional, Tuple, Union
 
 import torch
@@ -27,6 +26,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttenti
 from transformers.models.bloom.modeling_bloom import BloomForCausalLM, BloomMLP, dropout_add
 from transformers.utils import logging
 
+from ....utils import warn0
 from ...modeling_attn_mask_utils import _gaudi_prepare_4d_causal_attention_mask
 
 
@@ -340,10 +340,11 @@ def gaudi_bloom_model_forward(
 ) -> Union[Tuple[torch.Tensor, ...], BaseModelOutputWithPastAndCrossAttentions]:
     if deprecated_arguments.pop("position_ids", False) is not False:
         # `position_ids` could have been `torch.Tensor` or `None` so defaulting pop to `False` allows to detect if users were passing explicitly `None`
-        warnings.warn(
+        warn0(
             "`position_ids` have no functionality in BLOOM and will be removed in v5.0.0. You can safely ignore"
             " passing `position_ids`.",
-            FutureWarning,
+            category=FutureWarning,
+            state=self.accelerator.state,
         )
     if len(deprecated_arguments) > 0:
         raise ValueError(f"Got unexpected arguments: {deprecated_arguments}")
@@ -547,10 +548,11 @@ class GaudiBloomForCausalLM(BloomForCausalLM):
         num_items_in_batch = deprecated_arguments.pop("num_items_in_batch", None)
         if deprecated_arguments.pop("position_ids", False) is not False:
             # `position_ids` could have been `torch.Tensor` or `None` so defaulting pop to `False` allows to detect if users were passing explicitly `None`
-            warnings.warn(
+            warn0(
                 "`position_ids` have no functionality in BLOOM and will be removed in v5.0.0. You can safely ignore"
                 " passing `position_ids`.",
-                FutureWarning,
+                category=FutureWarning,
+                state=self.accelerator.state,
             )
         if len(deprecated_arguments) > 0:
             raise ValueError(f"Got unexpected arguments: {deprecated_arguments}")

--- a/optimum/habana/transformers/models/chatglm/modeling_chatglm.py
+++ b/optimum/habana/transformers/models/chatglm/modeling_chatglm.py
@@ -22,7 +22,6 @@ import copy
 import json
 import math
 import os
-import warnings
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -43,6 +42,7 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 from transformers.utils import logging
 
+from ....utils import warn0
 from ...modeling_attn_mask_utils import _gaudi_prepare_4d_causal_attention_mask
 from .configuration_chatglm import ChatGLMConfig
 
@@ -1697,11 +1697,12 @@ class ChatGLMForConditionalGeneration(ChatGLMPreTrainedModel):
 
         has_default_max_length = kwargs.get("max_length") is None and generation_config.max_length is not None
         if has_default_max_length and generation_config.max_new_tokens is None:
-            warnings.warn(
+            warn0(
                 f"Using `max_length`'s default ({generation_config.max_length}) to control the generation length. "
                 "This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we"
                 " recommend using `max_new_tokens` to control the maximum length of the generation.",
-                UserWarning,
+                category=UserWarning,
+                state=self.accelerator.state,
             )
         elif generation_config.max_new_tokens is not None:
             generation_config.max_length = generation_config.max_new_tokens + input_ids_seq_length

--- a/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -21,7 +21,6 @@
 
 import math
 import os
-import warnings
 from typing import List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -60,6 +59,7 @@ from transformers.utils import (
 )
 
 from ....distributed.tensorparallel import _all_reduce
+from ....utils import warn0
 from ...modeling_attn_mask_utils import _gaudi_prepare_4d_causal_attention_mask
 from .configuration_deepseek_v2 import DeepseekV2Config
 
@@ -1032,8 +1032,9 @@ class DeepseekV2Attention(nn.Module):
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
         bsz, q_len, _ = hidden_states.size()
         if self.q_lora_rank is None:
@@ -1403,8 +1404,9 @@ class DeepseekV2Attention(nn.Module):
         """
 
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
 
         bsz, q_len, _ = hidden_states.size()
@@ -1533,8 +1535,9 @@ class DeepseekV2DecoderLayer(nn.Module):
             past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
         """
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
         residual = hidden_states
 

--- a/optimum/habana/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/optimum/habana/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -28,7 +28,6 @@ The main differences are:
 """
 
 import math
-import warnings
 from typing import List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -59,6 +58,7 @@ from transformers.utils import (
 )
 
 from ....distributed.tensorparallel import _all_reduce
+from ....utils import warn0
 from ...modeling_attn_mask_utils import _gaudi_prepare_4d_causal_attention_mask
 from ..modeling_all_models import apply_customized_rope_module
 from .configuration_deepseek_v3 import DeepseekV3Config
@@ -925,14 +925,16 @@ class DeepseekV3Attention(nn.Module):
         """
 
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
 
         if self.training:
             if "padding_mask" in kwargs:
-                warnings.warn(
-                    "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+                warn0(
+                    "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                    state=self.accelerator.state,
                 )
             bsz, q_len, _ = hidden_states.size()
             if self.q_lora_rank is None:
@@ -1252,8 +1254,9 @@ class DeepseekV3DecoderLayer(nn.Module):
             past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
         """
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
         residual = hidden_states
 

--- a/optimum/habana/transformers/models/minicpm/modeling_minicpm.py
+++ b/optimum/habana/transformers/models/minicpm/modeling_minicpm.py
@@ -22,7 +22,6 @@ PyTorch MiniCPM model. Adapted from https://huggingface.co/openbmb/MiniCPM3-4B/t
 """
 
 import math
-import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -54,6 +53,7 @@ from transformers.utils import (
 )
 from transformers.utils.import_utils import is_torch_fx_available
 
+from ....utils import warn0
 from .configuration_minicpm import MiniCPM3Config
 
 
@@ -88,7 +88,7 @@ def _get_unpad_data(attention_mask):
 
 
 def _expand_mask(mask: torch.Tensor, dtype: torch.dtype, tgt_len: Optional[int] = None):
-    warnings.warn(
+    warn0(
         "Calling `transformers.models.minicpm.modeling_minicpm._prepare_4d_attention_mask` is deprecated and will be removed in v4.37. Use `transformers.modeling_attn_mask_utils._prepare_4d_attention_mask"
     )
     return _prepare_4d_attention_mask(mask=mask, dtype=dtype, tgt_len=tgt_len)
@@ -97,7 +97,7 @@ def _expand_mask(mask: torch.Tensor, dtype: torch.dtype, tgt_len: Optional[int] 
 def _make_causal_mask(
     input_ids_shape: torch.Size, dtype: torch.dtype, device: torch.device, past_key_values_length: int = 0
 ):
-    warnings.warn(
+    warn0(
         "Calling `transformers.models.minicpm.modeling_minicpm._make_causal_mask` is deprecated and will be removed in v4.37. Use `transformers.models.minicpm.modeling_minicpm.AttentionMaskConverter._make_causal_mask"
     )
     return AttentionMaskConverter._make_causal_mask(
@@ -446,8 +446,9 @@ class MiniCPMAttention(nn.Module):
         - Add token_idx support
         """
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
 
         bsz, q_len, _ = hidden_states.size()
@@ -577,8 +578,9 @@ class MiniCPMFlashAttention2(MiniCPMAttention):
         """
         # MiniCPMFlashAttention2 attention does not support output_attentions
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
 
             # overwrite attention_mask with padding_mask
@@ -962,8 +964,9 @@ class MiniCPMDecoderLayer(nn.Module):
             past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
         """
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
 
         residual = hidden_states

--- a/optimum/habana/transformers/models/modeling_all_models.py
+++ b/optimum/habana/transformers/models/modeling_all_models.py
@@ -14,12 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from typing import Tuple
 
 import torch
 from transformers.modeling_utils import ModuleUtilsMixin, PretrainedConfig
 from transformers.utils.import_utils import is_torch_sdpa_available
+
+from ...utils import warn0
 
 
 try:
@@ -147,8 +148,10 @@ def gaudi_get_extended_attention_mask(
     if not (attention_mask.dim() == 2 and self.config.is_decoder):
         # show warning only if it won't be shown in `create_extended_attention_mask_for_decoder`
         if device is not None:
-            warnings.warn(
-                "The `device` argument is deprecated and will be removed in v5 of Transformers.", FutureWarning
+            warn0(
+                "The `device` argument is deprecated and will be removed in v5 of Transformers.",
+                category=FutureWarning,
+                state=self.accelerator.state,
             )
     # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
     # ourselves in which case we just need to make it broadcastable to all heads.

--- a/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -20,7 +20,6 @@
 """PyTorch Qwen2MoE model."""
 
 import math
-import warnings
 from typing import List, Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -43,6 +42,7 @@ from transformers.models.qwen2_moe.modeling_qwen2_moe import (
 )
 from transformers.utils import logging
 
+from ....utils import warn0
 from ...modeling_attn_mask_utils import (
     _gaudi_prepare_4d_causal_attention_mask,
 )
@@ -663,8 +663,9 @@ class GaudiQwen2MoeDecoderLayer(Qwen2MoeDecoderLayer):
         - add new arg flash_attention_fast_softmax
         """
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
         residual = hidden_states
         hidden_states, self_attn_weights, present_key_value = self.pre_attn(

--- a/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -19,7 +19,6 @@
 # limitations under the License.
 """PyTorch Qwen3MoE model."""
 
-import warnings
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -46,6 +45,7 @@ from transformers.models.qwen3_moe.modeling_qwen3_moe import (
 )
 
 from ....distributed import parallel_state
+from ....utils import warn0
 from ...modeling_attn_mask_utils import (
     _gaudi_prepare_4d_causal_attention_mask,
 )
@@ -694,8 +694,9 @@ class GaudiQwen3MoeDecoderLayer(Qwen3MoeDecoderLayer):
         **kwargs,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if "padding_mask" in kwargs:
-            warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            warn0(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`",
+                state=self.accelerator.state,
             )
         residual = hidden_states
         hidden_states, self_attn_weights, present_key_value = self.pre_attn(

--- a/optimum/habana/transformers/models/t5/modeling_t5.py
+++ b/optimum/habana/transformers/models/t5/modeling_t5.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional, Tuple, Union
 
 import habana_frameworks.torch.core as htcore
@@ -14,6 +13,8 @@ from transformers.models.t5.modeling_t5 import __HEAD_MASK_WARNING_MSG
 from transformers.utils import (
     logging,
 )
+
+from ....utils import warn0
 
 
 logger = logging.get_logger(__name__)
@@ -524,7 +525,7 @@ def gaudi_T5ForConditionalGeneration_forward(
     # FutureWarning: head_mask was separated into two input args - head_mask, decoder_head_mask
     if head_mask is not None and decoder_head_mask is None:
         if self.config.num_layers == self.config.num_decoder_layers:
-            warnings.warn(__HEAD_MASK_WARNING_MSG, FutureWarning)
+            warn0(__HEAD_MASK_WARNING_MSG, category=FutureWarning, state=self.accelerate.state)
             decoder_head_mask = head_mask
 
     # Encode if needed (training, first prediction pass)

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -117,6 +117,7 @@ from ..utils import (
     set_seed,
     speed_metrics,
     to_device_dtype,
+    warn0,
 )
 from .gaudi_configuration import GAUDI_CONFIG_NAME, GaudiConfig
 from .integrations.deepspeed import deepspeed_init
@@ -545,12 +546,13 @@ class GaudiTrainer(Trainer):
 
         if "model_path" in kwargs:
             resume_from_checkpoint = kwargs.pop("model_path")
-            warnings.warn(
+            warn0(
                 (
                     "`model_path` is deprecated and will be removed in a future version. Use `resume_from_checkpoint` "
                     "instead."
                 ),
-                FutureWarning,
+                category=FutureWarning,
+                state=self.accelerator.state,
             )
         if len(kwargs) > 0:
             raise TypeError(f"train() got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -15,7 +15,6 @@
 
 import json
 import os
-import warnings
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from pathlib import Path
@@ -54,7 +53,7 @@ from transformers.utils import (
 from optimum.utils import logging
 
 from ..distributed import parallel_state
-from ..utils import get_habana_frameworks_version
+from ..utils import get_habana_frameworks_version, warn0
 from .gaudi_configuration import GaudiConfig
 
 
@@ -394,7 +393,7 @@ class GaudiTrainingArguments(TrainingArguments):
 
     def __post_init__(self):
         if self.use_hpu_graphs:
-            warnings.warn(
+            warn0(
                 (
                     "`--use_hpu_graphs` is deprecated and will be removed in a future version of 🤗 Optimum Habana. Use `--use_hpu_graphs_for_training` or `--use_hpu_graphs_for_inference` instead."
                 ),
@@ -472,7 +471,7 @@ class GaudiTrainingArguments(TrainingArguments):
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
 
         if isinstance(self.eval_strategy, EvaluationStrategy):
-            warnings.warn(
+            warn0(
                 "using `EvaluationStrategy` for `eval_strategy` is deprecated and will be removed in version 5"
                 " of 🤗 Transformers. Use `IntervalStrategy` instead",
                 FutureWarning,
@@ -578,7 +577,7 @@ class GaudiTrainingArguments(TrainingArguments):
 
         self.optim = OptimizerNames(self.optim)
         if self.adafactor:
-            warnings.warn(
+            warn0(
                 (
                     "`--adafactor` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `--optim"
                     " adafactor` instead"
@@ -713,7 +712,7 @@ class GaudiTrainingArguments(TrainingArguments):
 
         if isinstance(self.fsdp_config, str):
             if len(self.fsdp) == 0:
-                warnings.warn("`--fsdp_config` is useful only when `--fsdp` is specified.")
+                warn0("`--fsdp_config` is useful only when `--fsdp` is specified.")
             with open(self.fsdp_config, encoding="utf-8") as f:
                 self.fsdp_config = json.load(f)
                 for k in list(self.fsdp_config.keys()):
@@ -722,7 +721,7 @@ class GaudiTrainingArguments(TrainingArguments):
                         self.fsdp_config[k[5:]] = v
 
         if self.fsdp_min_num_params > 0:
-            warnings.warn("using `--fsdp_min_num_params` is deprecated. Use fsdp_config instead ", FutureWarning)
+            warn0("using `--fsdp_min_num_params` is deprecated. Use fsdp_config instead ", FutureWarning)
 
         self.fsdp_config["min_num_params"] = max(self.fsdp_config.get("min_num_params", 0), self.fsdp_min_num_params)
 
@@ -731,18 +730,19 @@ class GaudiTrainingArguments(TrainingArguments):
             self.fsdp_config["transformer_layer_cls_to_wrap"] = [self.fsdp_config["transformer_layer_cls_to_wrap"]]
 
         if self.fsdp_transformer_layer_cls_to_wrap is not None:
-            warnings.warn(
-                "using `--fsdp_transformer_layer_cls_to_wrap` is deprecated. Use fsdp_config instead ", FutureWarning
+            warn0(
+                "using `--fsdp_transformer_layer_cls_to_wrap` is deprecated. Use fsdp_config instead ",
+                FutureWarning,
             )
             self.fsdp_config["transformer_layer_cls_to_wrap"] = self.fsdp_config.get(
                 "transformer_layer_cls_to_wrap", []
             ) + [self.fsdp_transformer_layer_cls_to_wrap]
 
         if len(self.fsdp) == 0 and self.fsdp_config["min_num_params"] > 0:
-            warnings.warn("`min_num_params` is useful only when `--fsdp` is specified.")
+            warn0("`min_num_params` is useful only when `--fsdp` is specified.")
 
         if len(self.fsdp) == 0 and self.fsdp_config.get("transformer_layer_cls_to_wrap", None) is not None:
-            warnings.warn("`transformer_layer_cls_to_wrap` is useful only when `--fsdp` is specified.")
+            warn0("`transformer_layer_cls_to_wrap` is useful only when `--fsdp` is specified.")
 
         if (
             len(self.fsdp) > 0
@@ -852,7 +852,7 @@ class GaudiTrainingArguments(TrainingArguments):
             )
 
         if self.push_to_hub_token is not None:
-            warnings.warn(
+            warn0(
                 (
                     "`--push_to_hub_token` is deprecated and will be removed in version 5 of 🤗 Transformers. Use "
                     "`--hub_token` instead."
@@ -866,7 +866,7 @@ class GaudiTrainingArguments(TrainingArguments):
                 self.push_to_hub_model_id, organization=self.push_to_hub_organization, token=self.hub_token
             )
             if self.push_to_hub_organization is not None:
-                warnings.warn(
+                warn0(
                     (
                         "`--push_to_hub_model_id` and `--push_to_hub_organization` are deprecated and will be removed"
                         " in version 5 of 🤗 Transformers. Use `--hub_model_id` instead and pass the full repo name to"
@@ -875,7 +875,7 @@ class GaudiTrainingArguments(TrainingArguments):
                     FutureWarning,
                 )
             else:
-                warnings.warn(
+                warn0(
                     (
                         "`--push_to_hub_model_id` is deprecated and will be removed in version 5 of 🤗 Transformers."
                         " Use `--hub_model_id` instead and pass the full repo name to this argument (in this case"
@@ -885,7 +885,7 @@ class GaudiTrainingArguments(TrainingArguments):
                 )
         elif self.push_to_hub_organization is not None:
             self.hub_model_id = f"{self.push_to_hub_organization}/{Path(self.output_dir).name}"
-            warnings.warn(
+            warn0(
                 (
                     "`--push_to_hub_organization` is deprecated and will be removed in version 5 of 🤗 Transformers."
                     " Use `--hub_model_id` instead and pass the full repo name to this argument (in this case"

--- a/optimum/habana/trl/models/modeling_sd_base.py
+++ b/optimum/habana/trl/models/modeling_sd_base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
@@ -29,6 +28,7 @@ from ...diffusers import (
     GaudiDDIMScheduler,
     GaudiStableDiffusionPipeline,
 )
+from ...utils import warn0
 
 
 def scheduler_step(
@@ -357,7 +357,7 @@ class GaudiDefaultDDPOStableDiffusionPipeline(DefaultDDPOStableDiffusionPipeline
             self.use_lora = True
         except OSError:
             if use_lora:
-                warnings.warn(
+                warn0(
                     "If you are aware that the pretrained model has no lora weights to it, ignore this message. "
                     "Otherwise please check the if `pytorch_lora_weights.safetensors` exists in the model folder."
                 )

--- a/optimum/habana/trl/trainer/dpo_trainer.py
+++ b/optimum/habana/trl/trainer/dpo_trainer.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-import warnings
 from collections import defaultdict
 from contextlib import nullcontext
 from functools import partial
@@ -45,6 +44,7 @@ from trl.trainer.utils import (
 )
 
 from ... import GaudiConfig, GaudiTrainer
+from ...utils import warn0
 from .dpo_config import GaudiDPOConfig
 
 
@@ -106,7 +106,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         - cast peft model to bf16.
         """
         if model_init_kwargs is not None:
-            warnings.warn(
+            warn0(
                 "You passed `model_init_kwargs` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.model_init_kwargs = model_init_kwargs
@@ -134,7 +134,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             model_init_kwargs["torch_dtype"] = torch_dtype
 
         if ref_model_init_kwargs is not None:
-            warnings.warn(
+            warn0(
                 "You passed `ref_model_init_kwargs` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.ref_model_init_kwargs = ref_model_init_kwargs
@@ -161,14 +161,14 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             ref_model_init_kwargs["torch_dtype"] = torch_dtype
 
         if isinstance(model, str):
-            warnings.warn(
+            warn0(
                 "You passed a model_id to the DPOTrainer. This will automatically create an "
                 "`AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you."
             )
             model = AutoModelForCausalLM.from_pretrained(model, **model_init_kwargs)
 
         if isinstance(ref_model, str):
-            warnings.warn(
+            warn0(
                 "You passed a ref model_id to the DPOTrainer. This will automatically create an `AutoModelForCausalLM`"
             )
             ref_model = AutoModelForCausalLM.from_pretrained(ref_model, **ref_model_init_kwargs)
@@ -178,7 +178,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         self._peft_has_been_casted_to_bf16 = False
 
         if force_use_ref_model:
-            warnings.warn(
+            warn0(
                 "You passed `force_use_ref_model` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.force_use_ref_model = force_use_ref_model
@@ -245,7 +245,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
                 model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
         if generate_during_eval:
-            warnings.warn(
+            warn0(
                 "You passed `generate_during_eval` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.generate_during_eval = generate_during_eval
@@ -256,7 +256,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             )
 
         if is_encoder_decoder is not None:
-            warnings.warn(
+            warn0(
                 "You passed `is_encoder_decoder` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.is_encoder_decoder = is_encoder_decoder
@@ -272,9 +272,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         if model is not None:
             self.is_vision_model = model.config.model_type in MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES.keys()
         else:
-            warnings.warn(
-                "No model provided, cannot determine if it is a vision model. Setting is_vision_model to False."
-            )
+            warn0("No model provided, cannot determine if it is a vision model. Setting is_vision_model to False.")
             self.is_vision_model = False
 
         if self.is_vision_model:
@@ -285,28 +283,28 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
 
         self.is_peft_model = is_peft_available() and isinstance(model, PeftModel)
         if model_adapter_name is not None:
-            warnings.warn(
+            warn0(
                 "You passed `model_adapter_name` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.model_adapter_name = model_adapter_name
         self.model_adapter_name = args.model_adapter_name
 
         if ref_adapter_name is not None:
-            warnings.warn(
+            warn0(
                 "You passed `ref_adapter_name` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.ref_adapter_name = ref_adapter_name
         self.ref_adapter_name = args.ref_adapter_name
 
         if reference_free:
-            warnings.warn(
+            warn0(
                 "You passed `reference_free` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.reference_free = reference_free
         self.reference_free = args.reference_free
 
         if precompute_ref_log_probs:
-            warnings.warn(
+            warn0(
                 "You passed `precompute_ref_log_probs` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.precompute_ref_log_probs = precompute_ref_log_probs
@@ -323,12 +321,12 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             raise ValueError("tokenizer must be specified to tokenize a DPO dataset.")
 
         if max_length is not None:
-            warnings.warn(
+            warn0(
                 "You passed `max_length` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.max_length = max_length
         if args.max_length is None:
-            warnings.warn(
+            warn0(
                 "`max_length` is not set in the DPOConfig's init"
                 " it will default to `512` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -336,12 +334,12 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             args.max_length = 512
 
         if max_prompt_length is not None:
-            warnings.warn(
+            warn0(
                 "You passed `max_prompt_length` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.max_prompt_length = max_prompt_length
         if args.max_prompt_length is None:
-            warnings.warn(
+            warn0(
                 "`max_prompt_length` is not set in the DPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -349,12 +347,12 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             args.max_prompt_length = 128
 
         if max_target_length is not None:
-            warnings.warn(
+            warn0(
                 "You passed `max_target_length` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.max_target_length = max_target_length
         if args.max_target_length is None and self.is_encoder_decoder:
-            warnings.warn(
+            warn0(
                 "When using an encoder decoder architecture, you should set `max_target_length` in the DPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -362,7 +360,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             args.max_target_length = 128
 
         if label_pad_token_id != -100:
-            warnings.warn(
+            warn0(
                 "You passed `label_pad_token_id` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.label_pad_token_id = label_pad_token_id
@@ -376,7 +374,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             if args.remove_unused_columns:
                 args.remove_unused_columns = False
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using DPODataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
@@ -387,7 +385,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
             self.use_dpo_data_collator = False
 
         if not disable_dropout:
-            warnings.warn(
+            warn0(
                 "You passed `disable_dropout` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.disable_dropout = disable_dropout
@@ -400,14 +398,14 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         self.generate_during_eval = args.generate_during_eval
         self.label_pad_token_id = args.label_pad_token_id
         if padding_value is not None:
-            warnings.warn(
+            warn0(
                 "You passed `padding_value` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.padding_value = padding_value
         self.padding_value = args.padding_value if padding_value is not None else self.tokenizer.pad_token_id
         self.max_prompt_length = args.max_prompt_length
         if truncation_mode != "keep_end":
-            warnings.warn(
+            warn0(
                 "You passed `truncation_mode` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.truncation_mode = truncation_mode
@@ -421,24 +419,24 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         self._precomputed_eval_ref_log_probs = False
 
         if loss_type != "sigmoid":
-            warnings.warn(
+            warn0(
                 "You passed `loss_type` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.loss_type = loss_type
         if label_smoothing != 0:
-            warnings.warn(
+            warn0(
                 "You passed `label_smoothing` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.label_smoothing = label_smoothing
         if args.loss_type in ["hinge", "ipo", "bco_pair"] and args.label_smoothing > 0:
-            warnings.warn(
+            warn0(
                 "You are using a loss type that does not support label smoothing. Ignoring label_smoothing parameter."
             )
         if args.loss_type == "kto_pair":
             raise ValueError("Support for kto_pair has been removed in DPOTrainer. Please use KTOTrainer.")
 
         if beta != 0.1:
-            warnings.warn(
+            warn0(
                 "You passed `beta` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.beta = beta
@@ -453,7 +451,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         self.f_divergence_params = {FDivergenceConstants.ALPHA_DIVERGENCE_COEF_KEY: args.f_alpha_divergence_coef}
 
         if dataset_num_proc is not None:
-            warnings.warn(
+            warn0(
                 "You passed `dataset_num_proc` to the DPOTrainer, the value you passed will override the one in the `DPOConfig`."
             )
             args.dataset_num_proc = dataset_num_proc
@@ -697,7 +695,7 @@ class GaudiDPOTrainer(DPOTrainer, GaudiTrainer):
         - use hpu autocast
         """
         if not self.use_dpo_data_collator:
-            warnings.warn(
+            warn0(
                 "compute_loss is only implemented for DPODataCollatorWithPadding, and you passed a datacollator that is different than "
                 "DPODataCollatorWithPadding - you might see unexpected behavior. Alternatively, you can implement your own prediction_step method if you are using a custom data collator"
             )

--- a/optimum/habana/trl/trainer/ppo_config.py
+++ b/optimum/habana/trl/trainer/ppo_config.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
 from dataclasses import dataclass
 
 import numpy as np
 from trl import PPOConfig, is_wandb_available
 from trl.trainer.utils import exact_div
+
+from ...utils import warn0
 
 
 @dataclass
@@ -41,7 +42,7 @@ class GaudiPPOConfig(PPOConfig):
         - add adapt_transformers_to_gaudi for habana
         """
         if self.forward_batch_size is not None:
-            warnings.warn(
+            warn0(
                 "Note that using `forward_batch_size` is deprecated, use `mini_batch_size` instead. By setting it you overwrite `mini_batch_size` which affects both the batch size during forward passes and also the mini batch size for PPO optimization."
             )
             self.mini_batch_size = self.forward_batch_size

--- a/optimum/habana/trl/trainer/ppo_trainer.py
+++ b/optimum/habana/trl/trainer/ppo_trainer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import math
 import typing
-import warnings
 from contextlib import nullcontext
 from typing import Callable, List, Optional, Union
 
@@ -52,7 +51,7 @@ from trl.trainer import (
     RunningMoments,
 )
 
-from ...utils import HabanaGenerationTime, set_seed
+from ...utils import HabanaGenerationTime, set_seed, warn0
 from . import GaudiPPOConfig
 
 
@@ -130,7 +129,7 @@ class GaudiPPOTrainer(PPOTrainer):
         if isinstance(ref_model, SUPPORTED_ARCHITECTURES):
             self.ref_model = ref_model.to(self.accelerator.device.type)
             if num_shared_layers is not None:
-                warnings.warn(
+                warn0(
                     "num_shared_layers is ignored when ref_model is provided. Two different models are used for the "
                     "model and the reference model and no layers are shared.",
                     UserWarning,
@@ -159,7 +158,7 @@ class GaudiPPOTrainer(PPOTrainer):
         if dataset is not None and not (isinstance(dataset, torch.utils.data.Dataset) or isinstance(dataset, Dataset)):
             raise ValueError("dataset must be a torch.utils.data.Dataset or datasets.Dataset")
         elif dataset is None:
-            warnings.warn(
+            warn0(
                 "No dataset is provided. Make sure to set config.batch_size to the correct value before training.",
                 UserWarning,
             )
@@ -168,7 +167,7 @@ class GaudiPPOTrainer(PPOTrainer):
         if self.dataset is not None:
             self.dataloader = self.prepare_dataloader(self.dataset, data_collator)
         elif self.dataset is None and self.accelerator.num_processes > 1:
-            warnings.warn(
+            warn0(
                 "No dataset is provided. In a multi-GPU setting, this will lead to an error. You should"
                 " prepare your dataloader yourself with `dataloader = ppo_trainer.accelerator.prepare(dataloader)`"
                 " and using `torch.utils.data.DataLoader`, or pass a dataset to the `PPOTrainer`. Please "

--- a/optimum/habana/trl/trainer/sft_trainer.py
+++ b/optimum/habana/trl/trainer/sft_trainer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import dataclasses
 import inspect
-import warnings
 from collections.abc import Mapping
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -48,6 +47,7 @@ if is_peft_available():
     from peft import PeftConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
 
 from ... import GaudiConfig, GaudiTrainer
+from ...utils import warn0
 from .sft_config import GaudiSFTConfig
 
 
@@ -136,9 +136,10 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             assert data_collator is None, (
                 "For bucketing (num_buckets > 0), we only support data_collator=None (later it becomes DataCollatorForLanguageModeling)"
             )
+        state = PartialState()
         if args is None:
             output_dir = "tmp_trainer"
-            warnings.warn(f"No `SFTConfig` passed, using `output_dir={output_dir}`.")
+            warn0(f"No `SFTConfig` passed, using `output_dir={output_dir}`.", state=state)
             args = GaudiSFTConfig(output_dir=output_dir)
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
             args_as_dict = args.to_dict()
@@ -147,8 +148,9 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             args = GaudiSFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:
-            warnings.warn(
-                "You passed `model_init_kwargs` to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed `model_init_kwargs` to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.model_init_kwargs = model_init_kwargs
         if getattr(args, "model_init_kwargs", None) is None:
@@ -172,25 +174,29 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             model_init_kwargs["torch_dtype"] = torch_dtype
 
         if infinite is not None:
-            warnings.warn(
-                "The `infinite` argument is deprecated and will be removed in a future version of TRL. Use `TrainingArguments.max_steps` or `TrainingArguments.num_train_epochs` instead to control training length."
+            warn0(
+                "The `infinite` argument is deprecated and will be removed in a future version of TRL. Use `TrainingArguments.max_steps` or `TrainingArguments.num_train_epochs` instead to control training length.",
+                state=state,
             )
 
         if isinstance(model, str):
-            warnings.warn(
+            warn0(
                 "You passed a model_id to the SFTTrainer. This will automatically create an "
-                "`AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you."
+                "`AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you.",
+                state=state,
             )
             model = AutoModelForCausalLM.from_pretrained(model, **model_init_kwargs)
 
         if packing:
-            warnings.warn(
-                "You passed a `packing` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `packing` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.packing = packing
         if eval_packing is not None:
-            warnings.warn(
-                "You passed a `eval_packing` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `eval_packing` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.eval_packing = eval_packing
 
@@ -272,14 +278,16 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
                 tokenizer.pad_token = tokenizer.eos_token
 
         if max_seq_length is not None:
-            warnings.warn(
-                "You passed a `max_seq_length` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `max_seq_length` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.max_seq_length = max_seq_length
 
         if pad_max is not None:
-            warnings.warn(
-                "You passed a `pad_max` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `pad_max` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.pad_max = pad_max
 
@@ -287,20 +295,23 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             # to overcome some issues with broken tokenizers
             max_seq_length = min(tokenizer.model_max_length, 1024)
 
-            warnings.warn(
-                f"You didn't pass a `max_seq_length` argument to the SFTTrainer, this will default to {max_seq_length}"
+            warn0(
+                f"You didn't pass a `max_seq_length` argument to the SFTTrainer, this will default to {max_seq_length}",
+                state=state,
             )
 
         if dataset_num_proc is not None:
-            warnings.warn(
-                "You passed a `dataset_num_proc` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `dataset_num_proc` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.dataset_num_proc = dataset_num_proc
         self.dataset_num_proc = args.dataset_num_proc
 
         if dataset_batch_size != args.dataset_batch_size:
-            warnings.warn(
-                "You passed a `dataset_batch_size` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `dataset_batch_size` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.dataset_batch_size = dataset_batch_size
         self.dataset_batch_size = args.dataset_batch_size
@@ -308,16 +319,18 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
         self._trainer_supports_neftune = hasattr(args, "neftune_noise_alpha")
         if neftune_noise_alpha is not None and self._trainer_supports_neftune:
             args.neftune_noise_alpha = neftune_noise_alpha
-            warnings.warn(
-                "You passed a `neftune_noise_alpha` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `neftune_noise_alpha` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             # self.neftune_noise_alpha is done at Trainer level
         elif not self._trainer_supports_neftune:
             self.neftune_noise_alpha = neftune_noise_alpha
 
         if dataset_text_field is not None:
-            warnings.warn(
-                "You passed a `dataset_text_field` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `dataset_text_field` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.dataset_text_field = dataset_text_field
 
@@ -350,22 +363,25 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
         if num_of_sequences != args.num_of_sequences:
-            warnings.warn(
-                "You passed a `num_of_sequences` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `num_of_sequences` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.num_of_sequences = num_of_sequences
 
         if chars_per_token != args.chars_per_token:
-            warnings.warn(
-                "You passed a `chars_per_token` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+            warn0(
+                "You passed a `chars_per_token` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                state=state,
             )
             args.chars_per_token = chars_per_token
 
         # Pre-process the datasets only once per node. The remaining processes will use the cache.
-        with PartialState().local_main_process_first():
+        with state.local_main_process_first():
             if dataset_kwargs is not None:
-                warnings.warn(
-                    "You passed a `dataset_kwargs` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`."
+                warn0(
+                    "You passed a `dataset_kwargs` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.",
+                    state=state,
                 )
                 args.dataset_kwargs = dataset_kwargs
             if args.dataset_kwargs is None:
@@ -407,9 +423,10 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
                     eval_dataset = _eval_datasets["singleton"]
 
         if tokenizer.padding_side is not None and tokenizer.padding_side != "right":
-            warnings.warn(
+            warn0(
                 "You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to "
                 "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
+                state=state,
             )
 
         GaudiTrainer.__init__(
@@ -433,8 +450,9 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
             self.model.add_model_tags(self._tag_names)
 
         if self.args.max_steps > 0 and args.packing:
-            warnings.warn(
-                "You passed `packing=True` to the SFTTrainer/SFTConfig, and you are training your model with `max_steps` strategy. The dataset will be iterated until the `max_steps` are reached."
+            warn0(
+                "You passed `packing=True` to the SFTTrainer/SFTConfig, and you are training your model with `max_steps` strategy. The dataset will be iterated until the `max_steps` are reached.",
+                state=self.accelerator.state,
             )
             self.train_dataset.infinite = True
         elif self.args.max_steps == -1 and args.packing:
@@ -488,8 +506,9 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
         )
         if column_names and "input_ids" in column_names:
             if formatting_func is not None:
-                warnings.warn(
-                    "You passed a dataset that is already processed (contains an `input_ids` field) together with a valid formatting function. Therefore `formatting_func` will be ignored."
+                warn0(
+                    "You passed a dataset that is already processed (contains an `input_ids` field) together with a valid formatting function. Therefore `formatting_func` will be ignored.",
+                    state=self.accelerator.state,
                 )
 
             return dataset
@@ -574,9 +593,10 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
         extra_columns = list(set(dataset.column_names) - set(signature_columns))
 
         if not remove_unused_columns and len(extra_columns) > 0:
-            warnings.warn(
+            warn0(
                 "You passed `remove_unused_columns=False` on a non-packed dataset. This might create some issues with the default collator and yield to errors. If you want to "
-                f"inspect dataset other columns (in this case {extra_columns}), you can subclass `DataCollatorForLanguageModeling` in case you used the default collator and create your own data collator in order to inspect the unused dataset columns."
+                f"inspect dataset other columns (in this case {extra_columns}), you can subclass `DataCollatorForLanguageModeling` in case you used the default collator and create your own data collator in order to inspect the unused dataset columns.",
+                state=self.accelerator.state,
             )
 
         tokenized_dataset = dataset.map(

--- a/optimum/habana/trl/trainer/sft_trainer.py
+++ b/optimum/habana/trl/trainer/sft_trainer.py
@@ -425,7 +425,7 @@ class GaudiSFTTrainer(SFTTrainer, GaudiTrainer):
         if tokenizer.padding_side is not None and tokenizer.padding_side != "right":
             warn0(
                 "You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to "
-                "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
+                "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code.",
                 state=state,
             )
 

--- a/optimum/habana/utils/__init__.py
+++ b/optimum/habana/utils/__init__.py
@@ -1,1 +1,2 @@
 from .misc import *  # NOTE(pbielak): mimic previous imports from `utils.py`
+from .warn0 import warn0

--- a/optimum/habana/utils/warn0.py
+++ b/optimum/habana/utils/warn0.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# Copyright 2025 the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+from accelerate import PartialState
+
+
+def warn0(message, *args, state=None, **kwargs):
+    """
+    A wrapper for warnings.warn that only emits warnings on the main process (rank 0).
+    """
+    if state is None:
+        state = PartialState()
+    if state.is_main_process:
+        kwargs.setdefault("stacklevel", 2)
+        warnings.warn(message, *args, **kwargs)


### PR DESCRIPTION
# What does this PR do?

### Summary

This PR introduces a new utility function `warn0`, which wraps `warnings.warn` to ensure that warnings are only emitted on the main process (rank 0). This helps reduce noise in distributed training environments.

### Changes

- Added `warn0` to `optimum/habana/utils/warn0.py`
- Replaced instances of `warnings.warn` in the code with `warn0`
- Ensured compatibility with `PartialState` for rank detection

### Motivation

In distributed training, emitting the same warning from every process can clutter logs and make debugging harder. This change ensures that warnings are only shown once, from the main process.

### Example

```python
from optimum.habana.utils import warn0

warn0("This warning will only appear on rank 0.")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
