### PR TITLE
Fix requirements in text-classification

### DIFF
--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -1,7 +1,8 @@
-datasets >= 2.4.0, <= 2.19.2
+datasets == 3.6.0
 sentencepiece != 0.1.92
 scipy == 1.13.1
 scikit-learn == 1.5.2
 protobuf == 5.29.4
+tensorboard == 2.19.0
 torch >= 1.3
 evaluate == 0.4.3


### PR DESCRIPTION
# What does this PR do?

The currently pinned `protobuf` version is incompatible with the tensorboard version that is shipped in the Gaudi containers. Moreover, this commit bumps the version of `datasets` due to an imcompatibility with newer Numpy versions.



