### PR TITLE
Fix version extraction regex and pip command in get_build()

### DIFF
--- a/optimum/habana/utils/environment.py
+++ b/optimum/habana/utils/environment.py
@@ -34,13 +34,13 @@ def get_build():
     import sys
 
     output = subprocess.run(
-        f"{sys.executable} pip show habana-torch-plugin",
+        f"{sys.executable} -m pip show habana-torch-plugin",
         shell=True,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    version_re = re.compile(r"Version:\s*(?P<version>.*)")
+    version_re = re.compile(r"Version:\s*(?P<version>.*)", re.MULTILINE)
     match = version_re.search(output.stdout)
     if output.returncode == 0 and match:
         return match.group("version")


### PR DESCRIPTION
# What does this PR do?

This PR makes two minor but important fixes to the `get_build()` function:

- Corrects the pip command to use `-m pip` instead of relying on shell path resolution, ensuring compatibility across environments.
- Adds `re.MULTILINE` to the regex compilation to support matching the version line in multi-line output.

Before:
```sh
[WARNING|environment.py:48] 2025-07-18 16:24:51,546 >> Unknown software version
```

After:
```sh
'build': '1.21.0.555'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
