### PR TITLE
Pin datasets for text-generation/lm_eval example

### DIFF
--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.7
-datasets>=3.0.2
+datasets>=3.0.2, <=3.6.0
 tiktoken
 blobfile
 sentencepiece


### PR DESCRIPTION
For lm_eval (i.e. text-generation examples), we have tasks that can work with datasets 4.0.0.

This PR pins datasets, so the tests pass for 1.18.1. Until final solution is delivered. 