### PR TITLE
Update datasets that do not work with `datasets > 4.0.0`

### DIFF
--- a/examples/audio-classification/README.md
+++ b/examples/audio-classification/README.md
@@ -72,13 +72,13 @@ On a single HPU, this script should run in ~13 minutes and yield an accuracy of 
 
 ## Multi-HPU
 
-The following command shows how to fine-tune [wav2vec2-base](https://huggingface.co/facebook/wav2vec2-base) for 🌎 **Language Identification** on the [CommonLanguage dataset](https://huggingface.co/datasets/anton-l/common_language) on 8 HPUs.
+The following command shows how to fine-tune [wav2vec2-base](https://huggingface.co/facebook/wav2vec2-base) for 🌎 **Language Identification** on the [CommonLanguage dataset](https://huggingface.co/datasets/regisss/common_language) on 8 HPUs.
 
 ```bash
 python ../gaudi_spawn.py \
     --world_size 8 --use_mpi run_audio_classification.py \
     --model_name_or_path facebook/wav2vec2-base \
-    --dataset_name common_language \
+    --dataset_name regisss/common_language \
     --audio_column_name audio \
     --label_column_name language \
     --output_dir /tmp/wav2vec2-base-lang-id \

--- a/tests/configs/examples/ast_finetuned_speech_commands_v2.json
+++ b/tests/configs/examples/ast_finetuned_speech_commands_v2.json
@@ -1,6 +1,6 @@
 {
     "gaudi2": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {
@@ -32,7 +32,7 @@
         }
     },
     "gaudi3": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {

--- a/tests/configs/examples/wav2vec2_base.json
+++ b/tests/configs/examples/wav2vec2_base.json
@@ -1,6 +1,6 @@
 {
     "gaudi1": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {
@@ -31,7 +31,7 @@
         }
     },
     "gaudi2": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 5,
             "eval_batch_size": 64,
             "distribution": {
@@ -62,7 +62,7 @@
         }
     },
     "gaudi3": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 5,
             "eval_batch_size": 64,
             "distribution": {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -863,7 +863,7 @@ class MultiCardMaskedLanguageModelingExampleTester(
 class MultiCardAudioClassificationExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_audio_classification", multi_card=True
 ):
-    TASK_NAME = "common_language"
+    TASK_NAME = "regisss/common_language"
 
 
 class MultiCardSpeechRecognitionExampleTester(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

From Datasets v4, datasets that require the execution of remote code cannot be loaded anymore. This PR ensures references to these datasets are updated.

Impacted datasets:
- Common Language :heavy_check_mark: 
- LM eval:
  - PIQA :heavy_check_mark: 
  - MathQA :heavy_check_mark: 

For uploading a v4-compatible version of dataset, you can do ass follow:
1. ```
    pip install datasets==3.6.0
   ```
2. ```
    huggingface-cli login --token <token_with_write_rights>
    ```
3. ```py
    from datasets import load_dataset

    ds = load_dataset(<dataset_name>)
    ds.push_to_hub(<new_dataset_name>)  # e.g. "regisss/piqa" for PIQA
    ```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
