### PR TITLE
Update datasets to `3.6.0` in text-to-speech and translation

### DIFF
--- a/examples/text-to-speech/requirements.txt
+++ b/examples/text-to-speech/requirements.txt
@@ -1,3 +1,3 @@
-datasets == 2.19.2
+datasets == 3.6.0
 soundfile == 0.12.1
 sentencepiece

--- a/examples/translation/requirements.txt
+++ b/examples/translation/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 2.4.0, <= 2.19.2
+datasets == 3.6.0
 sentencepiece != 0.1.92
 protobuf == 3.20.3
 sacrebleu >= 1.4.12, <= 2.4.2


### PR DESCRIPTION
# What does this PR do?
The pinned datasets versions for `text-to-speech` and `translation` examples caused the scripts to fail with `UTF-8` decode errors. Upgrading the version to `3.6.0` fixes this problem.


