### PR TITLE
Bump `neural_compressor_pt` version to `3.4.1`

### DIFF
--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -3,3 +3,4 @@ datasets>=3.0.2, <=3.6.0
 tiktoken
 blobfile
 sentencepiece
+neural_compressor_pt >= 3.4.1


### PR DESCRIPTION
# What does this PR do?

With lower versions of the neural compressor, the LM eval script for Llama fails with `TypeError: no_init_weights() got an unexpected keyword argument '_enable'`.

