### PR TITLE
Fix test_calculate_loss failure by updating peft to version 0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ slow_tests_fsdp: test_installs
 
 slow_tests_trl: test_installs
 	python -m pip install trl==0.9.6
-	python -m pip install peft==0.12.0
+	python -m pip install peft==0.15.0
 	python -m pytest tests/test_trl.py -v -s -k "test_calculate_loss"
 
 slow_tests_object_segmentation: test_installs


### PR DESCRIPTION
This PR updates the peft dependency to version 0.15.0 to resolve an import error triggered by recent changes in the diffusers library.

Updated peft from ==0.12.0 to ==0.15.0.

Failing Test:
pytest tests/test_trl.py -v -s -k "test_calculate_loss"