### PR TITLE
qwen3: Fix missing max_position_embeddings init from config

### DIFF
--- a/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
+++ b/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
@@ -280,6 +280,7 @@ class GaudiQwen3Attention(Qwen3Attention):
         self.k_cache = KVCache()
         self.v_cache = KVCache()
 
+        self.max_position_embeddings = config.max_position_embeddings
         self.inp_seq_len = -1
 
         self.rotary_emb = GaudiRotaryEmbedding(config=self.config)

--- a/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -297,6 +297,7 @@ class GaudiQwen3MoeAttention(Qwen3MoeAttention):
         self.k_cache = KVCache()
         self.v_cache = KVCache()
 
+        self.max_position_embeddings = config.max_position_embeddings
         self.inp_seq_len = -1
 
         self.rotary_emb = GaudiRotaryEmbedding(config=self.config)


### PR DESCRIPTION


# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

max_position_embeddings is not initialized in qwen3 and qwen3_moe attention, which will cause failure in generation when self.config.max_position_embeddings < calculated_max_length.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
