### PR TITLE
Remove 'is_pt_flax_cross_test` from `wav2vec` tests

### DIFF
--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -30,7 +30,6 @@ from transformers import Wav2Vec2Config, is_torch_available
 from transformers.testing_utils import (
     CaptureLogger,
     backend_empty_cache,
-    is_pt_flax_cross_test,
     is_pyctcdecode_available,
     is_torchaudio_available,
     require_flash_attn,
@@ -509,16 +508,6 @@ class Wav2Vec2ModelTest(ModelTesterMixin, unittest.TestCase):
     # and thus the `get_input_embeddings` fn
     # is not implemented
     def test_model_common_attributes(self):
-        pass
-
-    @is_pt_flax_cross_test
-    @unittest.skip(reason="Non-rubst architecture does not exist in Flax")
-    def test_equivalence_flax_to_pt(self):
-        pass
-
-    @is_pt_flax_cross_test
-    @unittest.skip(reason="Non-rubst architecture does not exist in Flax")
-    def test_equivalence_pt_to_flax(self):
         pass
 
     def test_retain_grad_hidden_states_attentions(self):


### PR DESCRIPTION
# What does this PR do?

Following PR [1], the `is_pt_flax_cross_test` mark was removed. This commit applies the same changes for the `wav2vec` tests [2].

[1] https://github.com/huggingface/transformers/pull/36283/
[2] https://github.com/huggingface/transformers/pull/36283/files#diff-1063ef75ba73fe97fec48faf71f5020152ca85811784caaef74d4ca18fc6049f


