### PR TITLE
Remove `.float()` conversion from Mixtral

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -851,7 +851,7 @@ class GaudiMixtralForCausalLM(MixtralForCausalLM):
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :]).float()
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
# What does this PR do?

Removing the `.float()` upcasting increases Mixtral's throughput from about 14.5k tokens/second to approx. 17k tokens/seconds (for FP8).

