### PR TITLE
Add inference context manager wrap to Mixtral

### DIFF
--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -867,7 +867,9 @@ class GaudiMixtralForCausalLM(MixtralForCausalLM):
                     attention_mask,
                 )
                 if labels is not None:
-                    loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device
+                    loss += self.router_aux_loss_coef * aux_loss.to(
+                        loss.device
+                    )  # make sure to reside in the same device
 
         return MoeCausalLMOutputWithPast(
             loss=loss,


### PR DESCRIPTION
This PR wraps Mixtral in inference context manager (torch.inference_mode()). This change ensures that the correct flavor of moe kernel (namely moe_bf16 instead of moe_fwd_bf16) is picked for inference. 

This requirement is the result of added training support in 1.20.1\1.21.

moe_fwd_bf16 includes a redundant memset operation for router chunk tokens output + results in different decision for chunk count and size for higher token count (prefill) that is advantageous to training but not to inference.