### PR TITLE
Move torch and transformers imports to local scope in run_generation.py.

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -28,8 +28,6 @@ from itertools import cycle
 from pathlib import Path
 
 import pandas as pd
-import torch
-from transformers import BatchEncoding
 from utils import (
     SetTrueOrFalseOrNone,
     adjust_batch,
@@ -491,6 +489,8 @@ def main():
     args = setup_parser(parser)
     model, assistant_model, tokenizer, generation_config = initialize_model(args, logger)
 
+    import torch
+
     use_lazy_mode = True
     if args.torch_compile or args.pt2e_path:
         use_lazy_mode = False
@@ -735,6 +735,8 @@ def main():
 
         def generate(size=None, reduce_recompile=False, disable_profiling=False):
             """Generates sequences from the input sentences and returns them."""
+            from transformers import BatchEncoding
+
             profiler = disabled_profiler if disable_profiling else per_token_profiler
             timer = HabanaGenerationTime()
             timer.start()


### PR DESCRIPTION
Premature import of torch and transformers libraries in run_generation.py script, caused loading habana shared object before environmental variables were setup, leading to faulty behaviour.

# What does this PR do?

This PR delays loading habana shared object by importing troch and transformers in local scope where they're needed, after the env vars are initialized properly.

Fixes # `RuntimeError: collective nonSFG is not supported during hpu graph capturing` should no longer occur when executing examples with run_generations.py script.
