### PR TITLE
Pin `datasets==3.6.0` for question answering examples

### DIFF
--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,3 +1,3 @@
-datasets >= 2.4.0, <= 2.19.2
+datasets == 3.6.0
 torch >= 1.3.0
 evaluate == 0.4.3


### PR DESCRIPTION
# What does this PR do?

Some tests use question answering and text classification examples together. When installing the requirements files, pip returns a conflict, because question answering examples require: `datasets >= 2.4.0, <= 2.19.2`, whereas text classification pins `datasets==3.6.0`. This commit loosens the `datasets` version bounds.

Validated that `datasets==3.6.0` works fine for the question answering example in the README file.