### PR TITLE
Ensure output directory exists before trying to write to output file.

### DIFF
--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -126,6 +126,11 @@ def main() -> None:
                 print("{:35} = {} GB".format(k[:-5].replace("_", " ").capitalize(), v))
 
         json_str = json.dumps(results, indent=2, default=utils.handle_non_serializable, ensure_ascii=False)
+        from pathlib import Path
+
+        output_dir = Path(args.output_file).parent
+        if not output_dir.exists():
+            os.makedirs(output_dir)
         with open(args.output_file, "w", encoding="utf-8") as f:
             f.write(json_str)
         if args.show_config:


### PR DESCRIPTION
# What does this PR do?

Check if output directory exists, and create it if it doesn't, before trying to write to output file, in order to properly output results to user-specified path, even if it doesn't exist.