### PR TITLE
Fix PT_HPU_LAZY_MODE assertion to match updated default value

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -348,11 +348,11 @@ def setup_model(args, model_dtype, model_kwargs, logger):
                 model.base_model.model = wrap_in_hpu_graph(model.base_model.model)
 
     if args.torch_compile:
-        model = get_torch_compiled_model(model, logger, args)
         if "PT_HPU_LAZY_MODE" in os.environ:
             assert os.environ["PT_HPU_LAZY_MODE"] != "1", (
                 "`--torch_compile` is not compatible with PT_HPU_LAZY_MODE=1. Please set it to 0 or unset the variable."
             )
+        model = get_torch_compiled_model(model, logger, args)
         # if args.assistant_model is not None:
         #     assistant_model = get_torch_compiled_model(assistant_model, logger)
 

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -349,8 +349,8 @@ def setup_model(args, model_dtype, model_kwargs, logger):
 
     if args.torch_compile:
         model = get_torch_compiled_model(model, logger, args)
-        assert "PT_HPU_LAZY_MODE" in os.environ and os.environ["PT_HPU_LAZY_MODE"] == "0", (
-            "Please set PT_HPU_LAZY_MODE=0 on command line when using `--torch_compile`"
+        assert "PT_HPU_LAZY_MODE" in os.environ and os.environ["PT_HPU_LAZY_MODE"] != "1", (
+            "`--torch_compile` is not compatible with PT_HPU_LAZY_MODE=1. Please set it to 0 or unset the variable."
         )
         # if args.assistant_model is not None:
         #     assistant_model = get_torch_compiled_model(assistant_model, logger)

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -349,9 +349,10 @@ def setup_model(args, model_dtype, model_kwargs, logger):
 
     if args.torch_compile:
         model = get_torch_compiled_model(model, logger, args)
-        assert "PT_HPU_LAZY_MODE" in os.environ and os.environ["PT_HPU_LAZY_MODE"] != "1", (
-            "`--torch_compile` is not compatible with PT_HPU_LAZY_MODE=1. Please set it to 0 or unset the variable."
-        )
+        if "PT_HPU_LAZY_MODE" in os.environ:
+            assert os.environ["PT_HPU_LAZY_MODE"] != "1", (
+                "`--torch_compile` is not compatible with PT_HPU_LAZY_MODE=1. Please set it to 0 or unset the variable."
+            )
         # if args.assistant_model is not None:
         #     assistant_model = get_torch_compiled_model(assistant_model, logger)
 


### PR DESCRIPTION
(cherry picked from commit f210ebf2606502bef8f749d81bf3bb7f9cf56136)

# What does this PR do?

This is cherry-pick of PR #2032
Make sure that PT_HPU_LAZY_MODE env variable is set to proper value when running --torch_compile

This PR replaces #2032 
