### PR TITLE
Remove instances of logically dead code

### DIFF
--- a/optimum/habana/transformers/models/chatglm/modeling_chatglm.py
+++ b/optimum/habana/transformers/models/chatglm/modeling_chatglm.py
@@ -1217,9 +1217,7 @@ class ChatGLMModel(ChatGLMPreTrainedModel):
                     device=expanded_attn_mask.device,
                 )
                 expanded_attn_mask = torch.cat([pre_seq_mask, expanded_attn_mask], dim=-1)
-            combined_attention_mask = (
-                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
-            )
+            combined_attention_mask = expanded_attn_mask
 
         return combined_attention_mask
 

--- a/optimum/habana/transformers/models/falcon/modeling_falcon.py
+++ b/optimum/habana/transformers/models/falcon/modeling_falcon.py
@@ -987,11 +987,7 @@ class GaudiFalconForCausalLM(FalconForCausalLM):
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
             if past_key_values:
-                if token_idx is not None:
-                    position_ids = torch.index_select(position_ids, 1, token_idx - 1)
-                else:
-                    position_ids = position_ids[:, -input_ids.shape[1] :]
-
+                position_ids = torch.index_select(position_ids, 1, token_idx - 1)
                 # This `clone` call is needed to avoid recapturing cuda graphs with `torch.compile`'s  `mode="reduce-overhead`, as otherwise the input `position_ids` would have various stride during the decoding. Here, simply using `.contiguous()` is not sufficient as in the batch size = 1 case, `position_ids` is already contiguous but with varying stride which retriggers a capture.
                 position_ids = position_ids.clone(memory_format=torch.contiguous_format)
 

--- a/optimum/habana/transformers/models/glm4v/modeling_chatglm.py
+++ b/optimum/habana/transformers/models/glm4v/modeling_chatglm.py
@@ -1265,9 +1265,7 @@ class GLM4VModel(GLM4VPreTrainedModel):
                     device=expanded_attn_mask.device,
                 )
                 expanded_attn_mask = torch.cat([pre_seq_mask, expanded_attn_mask], dim=-1)
-            combined_attention_mask = (
-                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
-            )
+            combined_attention_mask = expanded_attn_mask
 
         return combined_attention_mask
 

--- a/optimum/habana/transformers/models/llava/modeling_llava.py
+++ b/optimum/habana/transformers/models/llava/modeling_llava.py
@@ -217,7 +217,7 @@ class GaudiLlavaForConditionalGeneration(LlavaForConditionalGeneration):
 
             if not return_dict:
                 output = (logits,) + outputs[1:]
-                return (loss,) + output if loss is not None else output
+                return (loss,) + output
 
             return LlavaCausalLMOutputWithPast(
                 loss=loss,

--- a/optimum/habana/transformers/models/llava_next/modeling_llava_next.py
+++ b/optimum/habana/transformers/models/llava_next/modeling_llava_next.py
@@ -268,7 +268,7 @@ class GaudiLlavaNextForConditionalGeneration(LlavaNextForConditionalGeneration):
         else:
             legacy_processing = (
                 (input_ids == self.config.image_token_index).sum(1).max() < self.config.image_seq_length
-            ) or ((input_ids.shape[-1] == 1 if token_idx is None else token_idx == 1) and pixel_values is not None)
+            ) or (token_idx == 1 and pixel_values is not None)
             use_flash_attention = kwargs.get("use_flash_attention", False)
             flash_attention_recompute = kwargs.get("flash_attention_recompute", False)
             position_ids = kwargs.get("position_ids", None)

--- a/optimum/habana/transformers/models/llava_onevision/modeling_llava_onevision.py
+++ b/optimum/habana/transformers/models/llava_onevision/modeling_llava_onevision.py
@@ -274,9 +274,7 @@ class GaudiLlavaOnevisionForConditionalGeneration(LlavaOnevisionForConditionalGe
                 **kwargs,
             )
         else:
-            legacy_processing = (
-                input_ids.shape[-1] == 1 if token_idx is None else token_idx == 1
-            ) and pixel_values is not None
+            legacy_processing = token_idx == 1 and pixel_values is not None
             use_flash_attention = kwargs.get("use_flash_attention", False)
             flash_attention_recompute = kwargs.get("flash_attention_recompute", False)
             position_ids = kwargs.get("position_ids", None)

--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -107,7 +107,7 @@ class GaudiMptAttention(MptAttention):
             else:
                 past_key_value = [key_states.clone(), value_states.clone()]
 
-        query_length = seq_length if past_key_value is None else seq_length + past_key_value[0].shape[2]
+        query_length = seq_length + past_key_value[0].shape[2]
 
         if position_bias is not None:
             if len(position_bias.shape) != 3:

--- a/optimum/habana/transformers/models/phi/modeling_phi.py
+++ b/optimum/habana/transformers/models/phi/modeling_phi.py
@@ -23,7 +23,7 @@ from functools import partial
 from typing import List, Optional, Tuple, Union
 
 import torch
-from transformers.cache_utils import Cache, DynamicCache
+from transformers.cache_utils import Cache
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.models.phi.configuration_phi import PhiConfig
 from transformers.models.phi.modeling_phi import (
@@ -360,20 +360,12 @@ class GaudiPhiModel(PhiModel):
             )
             use_cache = False
 
-        use_legacy_cache = True
-        use_new_cache = False
         past_seen_tokens = 0
         if past_key_values is not None and use_cache:
             if reuse_cache:
                 past_seen_tokens = past_key_values[0][0][2]
             else:
-                if use_new_cache:
-                    use_legacy_cache = not isinstance(past_key_values, Cache)
-                    if use_legacy_cache:
-                        past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-                    past_seen_tokens = past_key_values.get_seq_length()
-                else:
-                    past_seen_tokens = past_key_values[0][0].shape[2]
+                past_seen_tokens = past_key_values[0][0].shape[2]
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -402,7 +394,7 @@ class GaudiPhiModel(PhiModel):
         # decoder layers
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             if output_hidden_states:


### PR DESCRIPTION
Removing blocks of dead code:

* transformers/models/glm4v/modeling_chatglm.py
* transformers/models/chatglm/modeling_chatglm.py
`combined_attention_mask = (expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask)` is after `if attention_mask is not None:`

* transformers/models/falcon/modeling_falcon.py
`if token_idx is not None` is in a block executed only if `token_idx is not None`

* transformers/models/llava/modeling_llava.py
```
loss = None
[...]
return (loss,) + output if loss is not None else output
```

* transformers/models/llava_next/modeling_llava_next.py
if token_idx is None:
    [...]
else:
    legacy_processing = [...] (input_ids.shape[-1] == 1 if token_idx is None else token_idx == 1)
    [...]

* transformers/models/llava_onevision/modeling_llava_onevision.py
```
if token_idx is None:
    [...]
else:
    legacy_processing = [...] (input_ids.shape[-1] == 1 if token_idx is None else token_idx == 1)

* transformers/models/mpt/modeling_mpt.py
There's no way `past_key_value is None`, because previous paths either check if it's not `None` or assign a tensor to it.

* transformers/models/phi/modeling_phi.py
* transformers/models/starcoder2/modeling_starcoder2.py
Since `use_new_cache` is set to `False`, whole block after `if use_new_cache` is dead. This was probably left for compatibility with upstream transformers, but the transformers code changed since.




