### PR TITLE
Fixes for bad use of potential None value

### DIFF
--- a/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
+++ b/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
@@ -530,7 +530,7 @@ class GaudiFluxPipeline(GaudiDiffusionPipeline, FluxPipeline):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = timestep.expand(latents_batch.shape[0]).to(latents_batch.dtype)
 
-                if i >= quant_mixed_step:
+                if quant_mode == "quantize-mixed" and i >= quant_mixed_step:
                     # Mixed quantization
                     noise_pred = transformer_bf16(
                         hidden_states=latents_batch,

--- a/optimum/habana/diffusers/pipelines/flux/pipeline_flux_img2img.py
+++ b/optimum/habana/diffusers/pipelines/flux/pipeline_flux_img2img.py
@@ -562,7 +562,7 @@ class GaudiFluxImg2ImgPipeline(GaudiDiffusionPipeline, FluxImg2ImgPipeline):
                 # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
                 timestep = timestep.expand(latents_batch.shape[0]).to(latents_batch.dtype)
 
-                if i >= quant_mixed_step:
+                if quant_mode == "quantize-mixed" and i >= quant_mixed_step:
                     # Mixed quantization
                     noise_pred = transformer_bf16(
                         hidden_states=latents_batch,


### PR DESCRIPTION
Fix instances where there's a possibility to access a variable that is uninstantiated or None.

`transformer_bf16` is defined only when `if quant_mode == "quantize-mixed"`. Adding the condition before `transformer_bf16` is called ensures that there is no way it will be called uninstantiated.