### PR TITLE
Remove potential weakness reported by static code analysis -- CWE 398 -- redundant if

### DIFF
--- a/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -1570,10 +1570,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        if isinstance(self.mlp, DeepseekV2MoE):
-            hidden_states = self.mlp(hidden_states)
-        else:
-            hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)


### PR DESCRIPTION
Simplify statement where `if` and `else` had identical consequences.