### PR TITLE
Add support for --dynamo_allow_unspec_int_on_nn_module option in text generation tests

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -438,6 +438,12 @@ def setup_parser(parser):
         help="Set torch._dynamo.config.specialize_float to True.",
     )
 
+    parser.add_argument(
+        "--dynamo_allow_unspec_int_on_nn_module",
+        action="store_true",
+        help="Set torch._dynamo.config.allow_unspec_int_on_nn_module flag to True",
+    )
+
     args = parser.parse_args()
 
     if args.torch_compile:

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -205,6 +205,8 @@ def get_torch_compiled_model(model, logger, args):
         compile_fn = compile_regions
     if args.dynamo_specialize_float:
         torch._dynamo.config.specialize_float = True
+    if args.dynamo_allow_unspec_int_on_nn_module:
+        torch._dynamo.config.allow_unspec_int_on_nn_module = True
 
     compile_kwargs = {
         "backend": "hpu_backend",


### PR DESCRIPTION
Description:
This PR introduces a new command-line argument --dynamo_allow_unspec_int_on_nn_module to enable the torch._dynamo.config.allow_unspec_int_on_nn_module flag in text generation tests.

Changes:
Added CLI argument --dynamo_allow_unspec_int_on_nn_module with store_true action.



