### PR TITLE
Remove unnecessary null checks - modeling_mpt.py

### DIFF
--- a/optimum/habana/transformers/models/mpt/modeling_mpt.py
+++ b/optimum/habana/transformers/models/mpt/modeling_mpt.py
@@ -109,15 +109,14 @@ class GaudiMptAttention(MptAttention):
 
         query_length = seq_length + past_key_value[0].shape[2]
 
-        if position_bias is not None:
-            if len(position_bias.shape) != 3:
-                raise ValueError(f"Expecting position_bias shape to be 3 dimensions, got {len(position_bias.shape)}")
-            key_length = key_states.shape[-2]
+        if len(position_bias.shape) != 3:
+            raise ValueError(f"Expecting position_bias shape to be 3 dimensions, got {len(position_bias.shape)}")
+        key_length = key_states.shape[-2]
 
-            position_bias_query_index = max(0, position_bias.size(1) - query_length)
-            position_bias_key_index = max(0, position_bias.size(2) - key_length)
+        position_bias_query_index = max(0, position_bias.size(1) - query_length)
+        position_bias_key_index = max(0, position_bias.size(2) - key_length)
 
-            position_bias = position_bias[:, position_bias_query_index:, position_bias_key_index:]
+        position_bias = position_bias[:, position_bias_query_index:, position_bias_key_index:]
 
         if use_flash_attention and FusedSDPA:
             import habana_frameworks.torch.hpu as ht


### PR DESCRIPTION
## modeling_mpt.py

In the GaudiMptAttention.forward signature, `position_bias: torch.Tensor` is not marked as Optional, but in the code, there is a check: `if position_bias is not None:`
In the calling code `(GaudiMptBlock.forward)`, `position_bias` is always passed as an argument, and it comes from alibi in `GaudiMptModel.forward`:
```python
alibi = self.build_mpt_alibi_tensor(self.num_heads, self.config.max_seq_len, device=hidden_states.device)
```
self.build_mpt_alibi_tensor(...) always returns a tensor, not None.