### PR TITLE
Remove unnececary None checks for attention_mask

### DIFF
--- a/optimum/habana/transformers/models/baichuan/modeling_baichuan.py
+++ b/optimum/habana/transformers/models/baichuan/modeling_baichuan.py
@@ -367,8 +367,7 @@ class Attention(nn.Module):
         q_tiles = (q_len // self.block_size) if (q_len % self.block_size == 0) else math.ceil(q_len / self.block_size)
         q_padding = q_tiles * self.block_size - q_len
         query_layer = F.pad(query_layer, (0, 0, 0, q_padding), "constant", 0)
-        if attention_mask is not None:
-            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_layer.dtype).min)
+        attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_layer.dtype).min)
 
         row_o_list = []
         for i in range(q_tiles):
@@ -635,10 +634,7 @@ class Attention(nn.Module):
             )
             q_padding = q_tiles * self.q_block_size - q_len
             query_states = F.pad(query_states, (0, 0, 0, q_padding), "constant", 0)
-            if attention_mask is not None:
-                attention_mask = F.pad(
-                    attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_states.dtype).min
-                )
+            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_states.dtype).min)
 
             row_o_list = []
 

--- a/optimum/habana/transformers/models/gemma/modeling_gemma.py
+++ b/optimum/habana/transformers/models/gemma/modeling_gemma.py
@@ -252,8 +252,7 @@ class GaudiGemmaAttention(GemmaAttention):
         q_tiles = (q_len // q_block_size) if (q_len % q_block_size == 0) else math.ceil(q_len / q_block_size)
         q_padding = q_tiles * q_block_size - q_len
         query_layer = F.pad(query_layer, (0, 0, 0, q_padding), "constant", 0)
-        if attention_mask is not None:
-            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
+        attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
 
         row_o_list = []
         for i in range(q_tiles):

--- a/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
+++ b/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
@@ -339,8 +339,7 @@ class GaudiGemma2Attention(Gemma2Attention):
         q_tiles = (q_len // q_block_size) if (q_len % q_block_size == 0) else math.ceil(q_len / q_block_size)
         q_padding = q_tiles * q_block_size - q_len
         query_layer = F.pad(query_layer, (0, 0, 0, q_padding), "constant", 0)
-        if attention_mask is not None:
-            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
+        attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
 
         row_o_list = []
         for i in range(q_tiles):

--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -169,8 +169,7 @@ class GaudiGPTBigCodeAttention(GPTBigCodeAttention):
         q_tiles = (q_len // q_block_size) if (q_len % q_block_size == 0) else math.ceil(q_len / q_block_size)
         q_padding = q_tiles * q_block_size - q_len
         query_layer = F.pad(query_layer, (0, 0, 0, q_padding), "constant", 0)
-        if attention_mask is not None:
-            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
+        attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", -10000.0)
         row_o_list = []
         for i in range(q_tiles):
             s, e = i * q_block_size, (i + 1) * q_block_size


### PR DESCRIPTION

## Redudant None checks for attention_mask
In the following fragments, if attention_mask is not None: suggests that attention_mask can be `None`, but then it is used "normally".

```python
638         if attention_mask is not None:
639                attention_mask = F.pad(
640                    attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_states.dtype).min
641                )
            row_o_list = []
            for i in range(q_tiles):
                ...
                row_mask = attention_mask[:, :, s:e, :]
```
and
```python
370 def gaudi_flash_attn_v1(self, query_layer, key_layer, value_layer, attention_mask, dropout_rate, softmax_mode):
        ...
        if attention_mask is not None:
            attention_mask = F.pad(attention_mask, (0, 0, 0, q_padding), "constant", torch.finfo(key_layer.dtype).min)
        row_o_list = []
        for i in range(q_tiles):
            ...
            attn_output_partial = self.fused_scaled_dot_product_attention(
```

Based on the code and its usage, `attention_mask` is often passed through from higher-level functions and can be set to `None` by default. However, in practice, most of the logic expects `attention_mask` to be a tensor and performs slicing, padding, and other operations that would fail if it were `None`.

- In `prepare_inputs_for_generation`, `attention_mask` is defaulted to `None`, but almost all downstream logic assumes it is a tensor if present.
- In `gaudi_flash_attn_v1` and `pre_attn_forward`, there are checks for `if attention_mask is not None:`, but the code expects it to be a tensor for correct masking and padding.
- The model's forward and attention logic rely on `attention_mask` for correct behavior, especially for batch generation and position id creation.

**Conclusion:**  
While `attention_mask` can technically be `None` (by default), the model expects it to be a tensor for correct operation. Passing `None` will likely break masking logic or result in incorrect outputs. So, in real usage, `attention_mask` should not be `None`.