### PR TITLE
[v1.19] Add slow test for installs and update example requirements (tensorboard, peft)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ slow_tests_video_llava_example: test_installs
 	python -m pytest tests/test_video_llava.py
 
 slow_tests_fsdp: test_installs
-	python -m pip install tensorboard == 2.19.0
+	python -m pip install tensorboard==2.19.0
 	python -m pytest tests/test_fsdp_examples.py -v -s --token $(TOKEN)
 
 slow_tests_trl_ddpo: test_installs

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ slow_tests_video_llava_example: test_installs
 	python -m pytest tests/test_video_llava.py
 
 slow_tests_fsdp: test_installs
+	python -m pip install tensorboard == 2.19.0
 	python -m pytest tests/test_fsdp_examples.py -v -s --token $(TOKEN)
 
 slow_tests_trl_ddpo: test_installs

--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -4,3 +4,4 @@ protobuf == 3.20.3
 evaluate == 0.4.3
 scikit-learn == 1.5.2
 peft == 0.12.0
+tensorboard == 2.19.0

--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python == 4.10.0.84
 compel
 sentencepiece
+peft == 0.15.0

--- a/examples/trl/requirements_grpo.txt
+++ b/examples/trl/requirements_grpo.txt
@@ -1,5 +1,5 @@
 trl == 0.17.0
-peft == 0.12.0
+peft == 0.15.0
 datasets
 tyro
 evaluate


### PR DESCRIPTION
This PR introduces the following updates for optimum-habana v1.19:

Slow tests

- Added test_installs under slow_tests to validate installation requirements.

Requirements updates across examples

- Language Modeling (examples/language-modeling/requirements.txt): added tensorboard==2.19.0.
- 
- Stable Diffusion (examples/stable-diffusion/requirements.txt): added peft==0.15.0.
- 
- TRL / GRPO (examples/trl/requirements_grpo.txt): upgraded peft from 0.12.0 → 0.15.0.