### PR TITLE
Ensure decoder_only tests are not performed on encoder-only models.

### DIFF
--- a/tests/transformers/tests/generation/test_utils.py
+++ b/tests/transformers/tests/generation/test_utils.py
@@ -2155,7 +2155,7 @@ class GenerationTesterMixin:
 
             # This test is for decoder-only models (encoder-decoder models have native input embeddings support in the
             # decoder)
-            if config.is_encoder_decoder:
+            if config.is_encoder_decoder or not config.is_decoder:
                 continue
 
             # Skip models without explicit support


### PR DESCRIPTION
# What does this PR do?

Add check to ensure that encoder-only models aren't tested with decoder-only tests.