### PR TITLE
lm_eval to 0.4.9.1 and support for new args - rebased

### DIFF
--- a/examples/text-generation/model_adapter.py
+++ b/examples/text-generation/model_adapter.py
@@ -221,8 +221,8 @@ class HabanaModelAdapter(HFLM):
         # to avoid graph recompilation
         if self.options.static_shapes:
             self.options.bucket_internal = True
-            bucket_length = self.find_bucket(context.shape[1])
-            max_gen_toks = max_length - bucket_length
+            _ = self.find_bucket(context.shape[1])
+            max_gen_toks = max_length - context.shape[1]
         # move context & attention_mask to hpu
         context = context.to("hpu")
         generation_kwargs["attention_mask"] = generation_kwargs["attention_mask"].to("hpu")

--- a/examples/text-generation/model_adapter.py
+++ b/examples/text-generation/model_adapter.py
@@ -127,8 +127,18 @@ class HabanaModelAdapter(HFLM):
         # Returning 'cpu' to keep tensors on CPU in lm_eval code
         return "cpu"
 
-    def find_bucket(self, length: int) -> list[int]:
-        return [b for b in self.buckets if b >= length][0]
+    @max_length.setter
+    def max_length(self, value: int) -> None:
+        self._max_length = value
+
+    def find_bucket(self, length: int, key=lambda b, length: b >= length) -> int:
+        for b in self.buckets:
+            if key(b, length):
+                return b
+        new_bucket = length
+        self.buckets.append(new_bucket)
+        self.buckets.sort()
+        return new_bucket
 
     def _model_call(self, inps: torch.Tensor) -> torch.Tensor:
         bs, seq_length = inps.shape

--- a/examples/text-generation/model_adapter.py
+++ b/examples/text-generation/model_adapter.py
@@ -23,11 +23,16 @@ from typing import List, Literal, Optional, Union
 
 import torch
 import torch.nn.functional as F
+from lm_eval.api.instance import Instance
 from lm_eval.models.huggingface import HFLM, TemplateLM
 from lm_eval.models.utils import get_dtype, stop_sequences_criteria
 
+# Local imports
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 class HabanaModelAdapter(HFLM):

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,7 @@
-lm-eval==0.4.7
-datasets==3.6.0
+lm-eval==0.4.9.1
+datasets == 3.6.0
+langdetect <= 1.0.9
+immutabledict <= 4.2.1
 tiktoken
 blobfile
 sentencepiece

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -117,6 +117,12 @@ def setup_lm_eval_parser():
         help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
     )
     parser.add_argument(
+        "--system_instruction",
+        type=str,
+        default=None,
+        help="System instruction to be used in the prompt",
+    )
+    parser.add_argument(
         "--apply_chat_template",
         type=str,
         nargs="?",
@@ -182,6 +188,7 @@ def main() -> None:
                 log_samples=args.log_samples,
                 num_fewshot=args.num_fewshot,
                 fewshot_as_multiturn=args.fewshot_as_multiturn,
+                system_instruction=args.system_instruction,
                 apply_chat_template=args.apply_chat_template,
                 metadata=metadata,
             )

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -167,6 +167,11 @@ def setup_lm_eval_parser():
         metavar="/path/to/json",
         help='JSON string or path to JSON file containing doc indices of selected examples to test. Format: {"task_name":[indices],...}',
     )
+    parser.add_argument(
+        "--confirm_run_unsafe_code",
+        action="store_true",
+        help="Confirm that you understand the risks of running unsafe code for tasks that require it",
+    )
     args = setup_parser(parser)
     return args
 
@@ -216,6 +221,7 @@ def main() -> None:
                 system_instruction=args.system_instruction,
                 apply_chat_template=args.apply_chat_template,
                 metadata=metadata,
+                confirm_run_unsafe_code=args.confirm_run_unsafe_code,
             )
         if args.device == "hpu":
             import habana_frameworks.torch.hpu as torch_hpu

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -22,6 +22,7 @@ import json
 import logging
 import multiprocessing as mp
 import os
+from pathlib import Path
 
 import psutil
 
@@ -128,6 +129,14 @@ def setup_lm_eval_parser():
             "E.g. `--apply_chat_template template_name`"
         ),
     )
+    parser.add_argument(
+        "--samples",
+        "-E",
+        default=None,
+        type=str,
+        metavar="/path/to/json",
+        help='JSON string or path to JSON file containing doc indices of selected examples to test. Format: {"task_name":[indices],...}',
+    )
     args = setup_parser(parser)
     return args
 
@@ -142,13 +151,21 @@ def main() -> None:
     from model_adapter import HabanaModelAdapter
 
     max_length = None
+    metadata = None
     if args.metadata:
+        metadata = args.metadata if isinstance(args.metadata, dict) else utils.sample_parse_args_string(args.metadata)
         max_length = args.metadata.get("max_length")
 
     if args.fewshot_as_multiturn and args.apply_chat_template is False:
         raise ValueError(
             "When `fewshot_as_multiturn` is selected, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
         )
+    if args.samples:
+        assert args.limit is None, "If --samples is not None, then --limit must be None."
+        if (samples := Path(args.samples)).is_file():
+            args.samples = json.loads(samples.read_text())
+        else:
+            args.samples = json.loads(args.samples)
 
     with torch.no_grad():
         lm = HabanaModelAdapter(tokenizer, model, args, generation_config, max_length=max_length)
@@ -161,10 +178,12 @@ def main() -> None:
                 lm,
                 tasks=args.tasks,
                 limit=args.limit,
+                samples=args.samples,
                 log_samples=args.log_samples,
                 num_fewshot=args.num_fewshot,
                 fewshot_as_multiturn=args.fewshot_as_multiturn,
                 apply_chat_template=args.apply_chat_template,
+                metadata=metadata,
             )
         if args.device == "hpu":
             import habana_frameworks.torch.hpu as torch_hpu

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -115,6 +115,19 @@ def setup_lm_eval_parser():
         default=None,
         help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
     )
+    parser.add_argument(
+        "--apply_chat_template",
+        type=str,
+        nargs="?",
+        const=True,
+        default=False,
+        help=(
+            "If True, apply chat template to the prompt. "
+            "Providing `--apply_chat_template` without an argument will apply the default chat template to the prompt. "
+            "To apply a specific template from the available list of templates, provide the template name as an argument. "
+            "E.g. `--apply_chat_template template_name`"
+        ),
+    )
     args = setup_parser(parser)
     return args
 
@@ -132,6 +145,11 @@ def main() -> None:
     if args.metadata:
         max_length = args.metadata.get("max_length")
 
+    if args.fewshot_as_multiturn and args.apply_chat_template is False:
+        raise ValueError(
+            "When `fewshot_as_multiturn` is selected, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
+        )
+
     with torch.no_grad():
         lm = HabanaModelAdapter(tokenizer, model, args, generation_config, max_length=max_length)
 
@@ -146,7 +164,7 @@ def main() -> None:
                 log_samples=args.log_samples,
                 num_fewshot=args.num_fewshot,
                 fewshot_as_multiturn=args.fewshot_as_multiturn,
-                apply_chat_template=args.use_chat_template,
+                apply_chat_template=args.apply_chat_template,
             )
         if args.device == "hpu":
             import habana_frameworks.torch.hpu as torch_hpu

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -109,6 +109,12 @@ def setup_lm_eval_parser():
         default=False,
         help="If True, uses the fewshot as a multi-turn conversation",
     )
+    parser.add_argument(
+        "--metadata",
+        type=json.loads,
+        default=None,
+        help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
+    )
     args = setup_parser(parser)
     return args
 
@@ -122,8 +128,12 @@ def main() -> None:
     from lm_eval import evaluator, utils
     from model_adapter import HabanaModelAdapter
 
+    max_length = None
+    if args.metadata:
+        max_length = args.metadata.get("max_length")
+
     with torch.no_grad():
-        lm = HabanaModelAdapter(tokenizer, model, args, generation_config)
+        lm = HabanaModelAdapter(tokenizer, model, args, generation_config, max_length=max_length)
 
     from optimum.habana.utils import HabanaGenerationTime, get_hpu_memory_stats
 


### PR DESCRIPTION
Cherry-picked from https://github.com/huggingface/optimum-habana/pull/2193 to have it on `main`.

Changes are as follow:  
**Argument parsing and evaluation configuration:**

* Added new command-line arguments in `run_lm_eval.py` for controlling evaluation, including support for generation kwargs, few-shot and multi-turn settings, metadata, system instructions, chat template application, and sample selection. This allows for more granular and customizable evaluation runs. 
* Add `try_parse_json` to robustly handle JSON or string input for generation arguments.
* Updated main evaluation logic to pass new arguments through to the evaluator, and added validation for combinations of options (e.g., requiring chat template when using multi-turn few-shot).

**Model adapter enhancements:**

* Added support for `softmax_dtype`, `think_end_token`, `enable_thinking`, and `chat_template_args` in `HabanaModelAdapter` initialization, enabling more advanced generation and prompt formatting features. 
* Improved bucket selection logic for static shape generation, and switched to using `max_new_tokens` for generation instead of `max_length`, aligning with HuggingFace's recommended API usage. 

**Dependency update:**

* Upgraded the `lm-eval` package to version 0.4.9.1 to support new features and bug fixes.

**General improvements:**

* Minor refactoring for imports and typing to support new features. 

