### PR TITLE
Add configurable DeepSpeed installation via DEEPSPEED_SPEC env var in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,7 @@ slow_tests_8x: test_installs
 	exit $$((status1 + status2))
 
 # Run DeepSpeed non-regression tests
-slow_tests_deepspeed: test_installs
-	python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
+slow_tests_deepspeed: test_installs install_deepspeed
 	python -m pytest tests/test_examples.py -v -s -k "deepspeed"
 
 slow_tests_diffusers: test_installs
@@ -113,10 +112,9 @@ slow_tests_sentence_transformers: test_installs
 	python -m pytest tests/test_sentence_transformers.py -v -s
 
 # Run all text-generation non-regression tests
-slow_tests_text_generation_example: test_installs
+slow_tests_text_generation_example: test_installs install_deepspeed
 	python -m pip install -r examples/text-generation/requirements_awq.txt
 	BUILD_CUDA_EXT=0 python -m pip install -vvv --no-build-isolation git+https://github.com/HabanaAI/AutoGPTQ.git
-	python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
 	python -m pip install tiktoken blobfile
 	python -m pytest tests/test_text_generation_example.py tests/test_encoder_decoder.py -v -s --token $(TOKEN)
 
@@ -127,18 +125,15 @@ slow_tests_text_generation_example_1x: test_installs
 	python -m pytest tests/test_text_generation_example.py tests/test_encoder_decoder.py -m "(not x2) and (not x4) and (not x8)" -v -s --token $(TOKEN)
 
 # Run subset of text-generation non-regression tests that require 2 Gaudi cards
-slow_tests_text_generation_example_2x: test_installs
-	python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
+slow_tests_text_generation_example_2x: test_installs install_deepspeed
 	python -m pytest tests/test_text_generation_example.py -m x2 -v -s --token $(TOKEN)
 
 # Run subset of text-generation non-regression tests that require 4 Gaudi cards
-slow_tests_text_generation_example_4x: test_installs
-	python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
+slow_tests_text_generation_example_4x: test_installs install_deepspeed
 	python -m pytest tests/test_text_generation_example.py -m x4 -v -s --token $(TOKEN)
 
 # Run subset of text-generation non-regression tests that require 8 Gaudi cards
-slow_tests_text_generation_example_8x: test_installs
-	python -m pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
+slow_tests_text_generation_example_8x: test_installs install_deepspeed
 	python -m pytest tests/test_text_generation_example.py -m x8 -v -s --token $(TOKEN)
 
 # Run image-to-text non-regression tests
@@ -225,3 +220,11 @@ clean:
 
 test_installs:
 	python -m pip install .[tests]
+
+DEEPSPEED_SPEC ?= git+https://github.com/HabanaAI/DeepSpeed.git@1.21.0
+
+install_deepspeed:
+	@set -eu
+	@echo "Installing DeepSpeed (customizable via DEEPSPEED_SPEC env var)"
+	# Uwaga: nie echo-ujemy wartości z tokenem
+	python -m pip install --upgrade --prefer-binary "$(DEEPSPEED_SPEC)"


### PR DESCRIPTION
This PR updates the Makefile so that DeepSpeed installation is no longer hardcoded.
Instead, the version (or fork) to install can now be customized through the environment variable DEEPSPEED_SPEC.

- The default value of DEEPSPEED_SPEC is defined directly in the Makefile (currently pointing to the HabanaAI repository and version).
- Users can override it by exporting their own value before running the tests.

Examples:

Default behavior (uses the value defined in the Makefile):
`make slow_tests_text_generation_example_8x`


Custom behavior (installs from internal fork with a GitHub token):
```
export DEEPSPEED_SPEC="git+https://${GH_TOKEN}@github.com/habana-internal/deepspeed-fork.git@v1.22.0"
make slow_tests_text_generation_example_8x
```

This makes it easier to switch between official and internal DeepSpeed forks or test new versions without modifying the Makefile itself.