### PR TITLE
fea(): WA for run_clm config imports

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -47,6 +47,7 @@ from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
 from optimum.habana import GaudiConfig, GaudiTrainer, GaudiTrainingArguments
+from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 from optimum.habana.utils import set_seed
 
 
@@ -66,6 +67,7 @@ check_optimum_habana_min_version("1.18.0.dev0")
 
 require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
+adapt_transformers_to_gaudi()
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)


### PR DESCRIPTION
# What does this PR do?

There is bug in `run_clm.py` that instead of loading the local OH configuration, it is loading the upstream HF here: 
```py
MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
```


This is WA to fix it. 

## Reproducer 
Applying this patch 
```diff
diff --git a/optimum/habana/transformers/models/mistral/configuration_mistral.py b/optimum/habana/transformers/models/mistral/configuration_mistral.py
index 9af0c897..e273509b 100644
--- a/optimum/habana/transformers/models/mistral/configuration_mistral.py
+++ b/optimum/habana/transformers/models/mistral/configuration_mistral.py
@@ -56,6 +56,7 @@ class MistralConfig(MistralConfig):
             **kwargs,
         )
 
+        breakpoint()
         self.rope_scaling = rope_scaling
 
         # Validate the correctness of rotary position embeddings parameters
```
and run cmd
``` bash 
make test_instals; python3 examples/language-modeling/run_clm.py --model_name_or_path mistralai/Mistral-7B-v0.1 --gaudi_config_name Habana/gpt2 --dataset_name wikitext --do_train --output_dir /tmp/tmp3vtnetji --overwrite_output_dir --learning_rate 0.0002 --per_device_train_batch_size 4 --per_device_eval_batch_size 4 --num_train_epochs 2 --use_habana --throughput_warmup_steps 3 --save_strategy no --use_lazy_mode --do_eval --dataset_config_name wikitext-2-raw-v1 --use_hpu_graphs_for_inference
```

## Results 
 - with this PR: the code load local OH mistral and breaks (expected)
 - without this PR: the code loads the HF mistral and doesn't break (not expected)

## Notes: 
- I've checked the models where we have the configuration overwrite and cross-referenced them with HF [CLM ](https://github.com/huggingface/transformers/blob/98289c5546cf167fb10178053b36719f9732fc03/src/transformers/models/auto/modeling_auto.py#L606) and [MLM](https://github.com/huggingface/transformers/blob/98289c5546cf167fb10178053b36719f9732fc03/src/transformers/models/auto/modeling_auto.py#L1031). **We only have configuration overwrite for CLM models.** 
- This issue has not been noticed since none of the config var changes are not directly used in `modeling_XX.py` files. 
- There might be a better, more comprehensive solution this. Therefore this PR starts with draft. 

-- 
co-authored by Yaser Afshar @yafshar  



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
