### PR TITLE
[image-classification] README example fix

### DIFF
--- a/examples/image-classification/README.md
+++ b/examples/image-classification/README.md
@@ -241,8 +241,8 @@ python ../gaudi_spawn.py \
     --do_eval \
     --learning_rate 2e-4 \
     --num_train_epochs 5 \
-    --per_device_train_batch_size 128 \
-    --per_device_eval_batch_size 64 \
+    --per_device_train_batch_size 32 \
+    --per_device_eval_batch_size 32 \
     --eval_strategy epoch \
     --save_strategy epoch \
     --load_best_model_at_end True \


### PR DESCRIPTION
One of the examples in image-classification README failed with an exception. The fix requires that train and eval batch sizes are be equal.
