### PR TITLE
Fix: Convert np.float64 to native float in memory logging

### DIFF
--- a/optimum/habana/utils/misc.py
+++ b/optimum/habana/utils/misc.py
@@ -155,7 +155,7 @@ def to_gb_rounded(mem: float) -> float:
     Returns:
         float: memory in GB rounded to the second decimal
     """
-    return np.round(mem / 1024**3, 2)
+    return float(np.round(mem / 1024**3, 2))
 
 
 def get_hpu_memory_stats(device=None) -> Dict[str, float]:


### PR DESCRIPTION
### Summary
This PR updates the `to_gb_rounded()` utility function to return a native Python `float` instead of a `np.float64`. This change ensures cleaner and more readable logging output when memory stats are reported.

### Changes
- Cast result of `np.round()` to `float` in `to_gb_rounded()`.

### Motivation
Previously, memory values were logged as `np.float64(82.78)`, which is verbose and less readable. 
```sh
{'loss': 0.8835, 'grad_norm': 0.45611411333084106, 'learning_rate': 0.0004, 'epoch': 1.82, 'memory_allocated (GB)': np.float64(44.35), 'max_memory_allocated (GB)': np.float64(82.8), 'total_memory_available (GB)': np.float64(94.62)}
```

By converting to native `float`, logs now show values like `82.78`, improving clarity for users and developers.
```sh
{'loss': 0.8835, 'grad_norm': 0.45611411333084106, 'learning_rate': 0.0004, 'epoch': 1.82, 'memory_allocated (GB)': 44.35, 'max_memory_allocated (GB)': 82.8, 'total_memory_available (GB)': 94.62}
```

### Impact
- Improves log readability.
- No functional changes to memory calculations.
- Safe and backward-compatible.

### Testing
- Verified that memory values are now printed as native floats.
- No changes to numerical accuracy or behavior.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
