### PR TITLE
[WIP] Fix Wav2Vec after TF upgrade

### DIFF
--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -401,6 +401,7 @@ def main():
         token=model_args.token,
         trust_remote_code=model_args.trust_remote_code,
         ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
+        attn_implementation="sdpa",
     )
 
     # freeze the convolutional waveform encoder if supported by model

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -190,7 +190,7 @@ from .models import (
     GaudiT5ForConditionalGeneration,
     GaudiVideoLlavaForConditionalGeneration,
     GaudiVisionSdpaAttention,
-    GaudiWav2Vec2SdpaAttention,
+    GaudiWav2Vec2Attention,
     GaudiWhisperDecoder,
     GaudiWhisperDecoderLayer,
     GaudiWhisperForConditionalGeneration,
@@ -337,7 +337,7 @@ def adapt_transformers_to_gaudi():
     transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2Encoder.forward = gaudi_wav2vec2_encoder_forward
     transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2ForCTC.forward = gaudi_wav2vec2forctc_forward
     transformers.models.wav2vec2.modeling_wav2vec2.TDNNLayer.forward = gaudi_wav2vec2_tdnnlayer_forward
-    transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2Attention = GaudiWav2Vec2SdpaAttention
+    transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2Attention = GaudiWav2Vec2Attention
 
     # Generation is modified to run faster in lazy mode
     transformers.generation.GenerationMixin.prepare_inputs_for_generation = (

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -351,7 +351,7 @@ from .vision_encoder_decoder import (
 from .vit import gaudi_vit_self_attention_forward
 from .vits import gaudi_unconstrained_rational_quadratic_spline
 from .wav2vec2 import (
-    GaudiWav2Vec2SdpaAttention,
+    GaudiWav2Vec2Attention,
     _gaudi_wav2vec2_compute_mask_indices,
     _gaudi_wav2vec2_mask_hidden_states,
     _gaudi_wav2vec2_sample_negative_indices,

--- a/optimum/habana/transformers/models/wav2vec2/__init__.py
+++ b/optimum/habana/transformers/models/wav2vec2/__init__.py
@@ -1,5 +1,5 @@
 from .modeling_wav2vec2 import (
-    GaudiWav2Vec2SdpaAttention,
+    GaudiWav2Vec2Attention,
     _gaudi_wav2vec2_compute_mask_indices,
     _gaudi_wav2vec2_mask_hidden_states,
     _gaudi_wav2vec2_sample_negative_indices,

--- a/optimum/habana/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/optimum/habana/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -16,19 +16,27 @@
 
 import os
 import random
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import torch
 from habana_frameworks.torch.hpu import get_device_name
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.integrations.fsdp import is_fsdp_managed_module
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_outputs import (
     BaseModelOutput,
     CausalLMOutput,
     Wav2Vec2BaseModelOutput,
 )
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 from transformers.models.wav2vec2.configuration_wav2vec2 import Wav2Vec2Config
-from transformers.models.wav2vec2.modeling_wav2vec2 import _HIDDEN_STATES_START_POSITION, Wav2Vec2Attention, logger
+from transformers.models.wav2vec2.modeling_wav2vec2 import (
+    _HIDDEN_STATES_START_POSITION,
+    Wav2Vec2Attention,
+    eager_attention_forward,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils.deprecation import deprecate_kwarg
 
 
 try:
@@ -465,8 +473,9 @@ def gaudi_wav2vec2_tdnnlayer_forward(self, hidden_states: torch.Tensor) -> torch
     return hidden_states
 
 
-class GaudiWav2Vec2SdpaAttention(Wav2Vec2Attention):
-    # Copied from transformers.models.bart.modeling_bart.BartSdpaAttention.forward with Bart->Wav2Vec2
+class GaudiWav2Vec2Attention(Wav2Vec2Attention):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
     def __init__(
         self,
         embed_dim: int,
@@ -478,98 +487,50 @@ class GaudiWav2Vec2SdpaAttention(Wav2Vec2Attention):
         config: Optional[Wav2Vec2Config] = None,
     ):
         super().__init__(
-            embed_dim,
-            num_heads,
-            dropout,
-            is_decoder,
-            bias,
-            is_causal,
-            config,
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            is_decoder=is_decoder,
+            bias=bias,
+            is_causal=is_causal,
+            config=config,
         )
+
         self.use_flash_attention = True if os.getenv("USE_FLASH_ATTENTION") == "1" else False
         self.flash_attention_fast_softmax = True if os.getenv("FLASH_ATTENTION_FAST_SOFTMAX") == "1" else False
         self.flash_attention_recompute = True if os.getenv("FLASH_ATTENTION_RECOMPUTE") == "1" else False
 
+    @deprecate_kwarg("past_key_value", version="4.54.0")
     def forward(
         self,
         hidden_states: torch.Tensor,
         key_value_states: Optional[torch.Tensor] = None,
-        past_key_value: Optional[tuple[torch.Tensor]] = None,
         attention_mask: Optional[torch.Tensor] = None,
         layer_head_mask: Optional[torch.Tensor] = None,
-        output_attentions: bool = False,
+        output_attentions: Optional[bool] = False,
+        # TODO: we need a refactor so that the different attention modules can get their specific kwargs
+        # ATM, we have mixed things encoder, decoder, and encoder-decoder attn
+        **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
-        """
-        Copied from Wav2Vec2SdpaAttention.forward: https://github.com/huggingface/transformers/blob/main/src/transformers/models/wav2vec2/modeling_wav2vec2.py
-        The only difference is If the `USE_FLASH_ATTENTION` switch is enabled, then use the HPU's fused SDPA; otherwise, use PyTorch's native SDPA
-        """
         """Input shape: Batch x Time x Channel"""
-        if output_attentions or layer_head_mask is not None:
-            # TODO: Improve this warning with e.g. `model.config._attn_implementation = "manual"` once this is implemented.
-            logger.warning_once(
-                "Wav2Vec2Model is using Wav2Vec2SdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True` or `layer_head_mask` not None. Falling back to the manual attention"
-                ' implementation, but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
-            )
-            return super().forward(
-                hidden_states,
-                key_value_states=key_value_states,
-                past_key_value=past_key_value,
-                attention_mask=attention_mask,
-                layer_head_mask=layer_head_mask,
-                output_attentions=output_attentions,
-            )
 
         # if key_value_states are provided this layer is used as a cross-attention layer
         # for the decoder
         is_cross_attention = key_value_states is not None
 
-        bsz, tgt_len, _ = hidden_states.size()
+        # determine input shapes
+        bsz, tgt_len = hidden_states.shape[:-1]
+        src_len = key_value_states.shape[1] if is_cross_attention else tgt_len
+
+        q_input_shape = (bsz, tgt_len, -1, self.head_dim)
+        kv_input_shape = (bsz, src_len, -1, self.head_dim)
 
         # get query proj
-        query_states = self.q_proj(hidden_states)
-        # get key, value proj
-        # `past_key_value[0].shape[2] == key_value_states.shape[1]`
-        # is checking that the `sequence_length` of the `past_key_value` is the same as
-        # the provided `key_value_states` to support prefix tuning
-        if (
-            is_cross_attention
-            and past_key_value is not None
-            and past_key_value[0].shape[2] == key_value_states.shape[1]
-        ):
-            # reuse k,v, cross_attentions
-            key_states = past_key_value[0]
-            value_states = past_key_value[1]
-        elif is_cross_attention:
-            # cross_attentions
-            key_states = self._shape(self.k_proj(key_value_states), -1, bsz)
-            value_states = self._shape(self.v_proj(key_value_states), -1, bsz)
-        elif past_key_value is not None:
-            # reuse k, v, self_attention
-            key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
-            value_states = self._shape(self.v_proj(hidden_states), -1, bsz)
-            key_states = torch.cat([past_key_value[0], key_states], dim=2)
-            value_states = torch.cat([past_key_value[1], value_states], dim=2)
-        else:
-            # self_attention
-            key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
-            value_states = self._shape(self.v_proj(hidden_states), -1, bsz)
+        query_states = self.q_proj(hidden_states).view(*q_input_shape).transpose(1, 2)
 
-        if self.is_decoder:
-            # if cross_attention save tuple(torch.Tensor, torch.Tensor) of all cross attention key/value_states.
-            # Further calls to cross_attention layer can then reuse all cross-attention
-            # key/value_states (first "if" case)
-            # if uni-directional self-attention (decoder) save tuple(torch.Tensor, torch.Tensor) of
-            # all previous decoder key/value_states. Further calls to uni-directional self-attention
-            # can concat previous decoder key/value_states to current projected key/value_states (third "elif" case)
-            # if encoder bi-directional self-attention `past_key_value` is always `None`
-            past_key_value = (key_states, value_states)
-
-        query_states = self._shape(query_states, tgt_len, bsz)
-
-        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
-        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
-        # The tgt_len > 1 is necessary to match with AttentionMaskConverter.to_causal_4d that does not create a causal mask in case tgt_len == 1.
-        is_causal = True if self.is_causal and attention_mask is None and tgt_len > 1 else False
+        current_states = key_value_states if is_cross_attention else hidden_states
+        key_states = self.k_proj(current_states).view(*kv_input_shape).transpose(1, 2)
+        value_states = self.v_proj(current_states).view(*kv_input_shape).transpose(1, 2)
 
         if self.use_flash_attention and FusedSDPA:
             if tgt_len == 1:
@@ -587,35 +548,30 @@ class GaudiWav2Vec2SdpaAttention(Wav2Vec2Attention):
                 value_states,
                 attention_mask,
                 self.dropout if self.training else 0.0,
-                is_causal,
+                self.is_causal,
                 None,  # scale ; Non -> default scale
                 softmax_mode,  # "None"  -> Non fast softmax
                 recompute_mode,  # -> recompute_mode = false
             )
         else:
-            # NOTE: SDPA with memory-efficient backend is currently (torch==2.1.2) bugged when using non-contiguous inputs and a custom attn_mask,
-            # but we are fine here as `_shape` do call `.contiguous()`. Reference: https://github.com/pytorch/pytorch/issues/112577
-            attn_output = torch.nn.functional.scaled_dot_product_attention(
+            attention_interface: Callable = eager_attention_forward
+            if self.config._attn_implementation != "eager":
+                attention_interface = ALL_ATTENTION_FUNCTIONS["sdpa"]
+
+            attn_output, attn_weights = attention_interface(
+                self,
                 query_states,
                 key_states,
                 value_states,
-                attn_mask=attention_mask,
-                dropout_p=self.dropout if self.training else 0.0,
-                is_causal=is_causal,
+                attention_mask,
+                dropout=0.0 if not self.training else self.dropout,
+                scaling=self.scaling,
+                output_attentions=output_attentions,
+                head_mask=layer_head_mask,
+                **kwargs,
             )
 
-        if attn_output.size() != (bsz, self.num_heads, tgt_len, self.head_dim):
-            raise ValueError(
-                f"`attn_output` should be of size {(bsz, self.num_heads, tgt_len, self.head_dim)}, but is"
-                f" {attn_output.size()}"
-            )
-
-        attn_output = attn_output.transpose(1, 2)
-
-        # Use the `embed_dim` from the config (stored in the class) rather than `hidden_state` because `attn_output` can be
-        # partitioned across GPUs when using tensor-parallelism.
-        attn_output = attn_output.reshape(bsz, tgt_len, self.embed_dim)
-
+        attn_output = attn_output.reshape(bsz, tgt_len, -1).contiguous()
         attn_output = self.out_proj(attn_output)
 
-        return attn_output, None, past_key_value
+        return attn_output, attn_weights, None


### PR DESCRIPTION
This pull request refactors the Habana-optimized Wav2Vec2 attention implementation for better maintainability and compatibility with recent Hugging Face Transformers changes. The main updates include renaming and reworking the custom attention class, updating all references, and improving how attention mechanisms are selected and invoked.

### Wav2Vec2 Attention Refactor and Improvements

* The custom attention class has been renamed from `GaudiWav2Vec2SdpaAttention` to `GaudiWav2Vec2Attention`, and its implementation has been updated for improved compatibility and maintainability. All imports and references across the codebase have been updated accordingly. [[1]](diffhunk://#diff-1fb53f50b27540f714f21493c73280bc7d65961918df47d0185c4811afb2aa86L193-R193) [[2]](diffhunk://#diff-1fb53f50b27540f714f21493c73280bc7d65961918df47d0185c4811afb2aa86L340-R340) [[3]](diffhunk://#diff-de9061903ff7e8cd3d5b89b20dc2b1fb5edf5da60a977f2795801c8c53f1fdf5L354-R354) [[4]](diffhunk://#diff-df7fe99de09efc70730780a2c8e33da69d775fec4fd691421f90bfbf528feebdL2-R2) [[5]](diffhunk://#diff-e1984f5a07cb34fbaf98b05c8e921ab36f86c9b69b5d0a6165a74290936af937L468-R478)
* The new `GaudiWav2Vec2Attention` class now inherits from `Wav2Vec2Attention` and streamlines the forward method, leveraging the Hugging Face attention interfaces and supporting additional keyword arguments for future extensibility. [[1]](diffhunk://#diff-e1984f5a07cb34fbaf98b05c8e921ab36f86c9b69b5d0a6165a74290936af937L468-R478) [[2]](diffhunk://#diff-e1984f5a07cb34fbaf98b05c8e921ab36f86c9b69b5d0a6165a74290936af937L481-R533)
* The attention implementation now conditionally uses either the eager or SDPA (scaled dot-product attention) backend based on configuration, and passes through advanced parameters such as head mask, scaling, and output attentions.

### Dependency and API Updates

* Added imports for `FlashAttentionKwargs`, `ALL_ATTENTION_FUNCTIONS`, and related utilities to support the new attention mechanism and keyword argument unpacking.
* When loading the model in `run_audio_classification.py`, the `attn_implementation` parameter is now explicitly set to `"sdpa"` to ensure the correct attention backend is used.