### PR TITLE
Bump datasets to ≥4.0.0 across examples; keep LM-Eval on <4.0.0

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets[audio]>=1.14.0
+datasets[audio]>=4.0.0
 evaluate
 numba==0.60.0
 librosa

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.14.0", "To fix: pip install -r examples/pytorch/audio-classification/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/audio-classification/requirements.txt")
 
 
 def random_subsample(wav: np.ndarray, max_length: float, sample_rate: int = 16000):

--- a/examples/contrastive-image-text/README.md
+++ b/examples/contrastive-image-text/README.md
@@ -52,7 +52,7 @@ import os
 import datasets
 
 COCO_DIR = os.path.join(os.getcwd(), "data")
-ds = datasets.load_dataset("ydshieh/coco_dataset_script", "2017", data_dir=COCO_DIR)
+ds = datasets.load_dataset("sentence-transformers/coco-captions", split="train")
 ```
 
 ## CLIP-like models

--- a/examples/contrastive-image-text/README.md
+++ b/examples/contrastive-image-text/README.md
@@ -45,7 +45,7 @@ wget http://images.cocodataset.org/annotations/image_info_test2017.zip
 cd ..
 ```
 
-Having downloaded COCO dataset manually you should be able to load with the `ydshieh/coco_dataset_script` dataset loading script:
+Having downloaded COCO dataset manually you should be able to load with the `imagefolder` ImageFolder builder:
 
 ```python
 import os
@@ -100,7 +100,7 @@ python run_clip.py \
     --output_dir ./clip-roberta-finetuned \
     --model_name_or_path ./clip-roberta \
     --data_dir $PWD/data \
-    --dataset_name ydshieh/coco_dataset_script \
+    --dataset_name imagefolder \
     --dataset_config_name=2017 \
     --image_column image_path \
     --caption_column caption \
@@ -133,7 +133,7 @@ python3 ../gaudi_spawn.py --world_size 8 --use_mpi run_clip.py \
     --output_dir=/tmp/clip_roberta \
     --model_name_or_path=./clip-roberta \
     --data_dir $PWD/data \
-    --dataset_name ydshieh/coco_dataset_script \
+    --dataset_name imagefolder \
     --dataset_config_name 2017 \
     --image_column image_path \
     --caption_column caption \
@@ -210,7 +210,7 @@ PT_HPU_LAZY_MODE=1 python run_clip.py \
     --output_dir ./clip-roberta-finetuned \
     --model_name_or_path ./clip-roberta \
     --data_dir $PWD/data \
-    --dataset_name ydshieh/coco_dataset_script \
+    --dataset_name imagefolder \
     --dataset_config_name=2017 \
     --image_column image_path \
     --caption_column caption \

--- a/examples/contrastive-image-text/requirements.txt
+++ b/examples/contrastive-image-text/requirements.txt
@@ -1,1 +1,1 @@
-datasets>=1.8.0
+datasets>=4.0.0

--- a/examples/contrastive-image-text/run_bridgetower.py
+++ b/examples/contrastive-image-text/run_bridgetower.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/contrastive-image-text/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/contrastive-image-text/requirements.txt")
 
 
 @dataclass

--- a/examples/contrastive-image-text/run_clip.py
+++ b/examples/contrastive-image-text/run_clip.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/contrastive-image-text/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/contrastive-image-text/requirements.txt")
 
 
 @dataclass

--- a/examples/image-classification/requirements.txt
+++ b/examples/image-classification/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.5.0
 torchvision>=0.6.0
-datasets>=2.14.0
+datasets>=4.0.0
 evaluate
 scikit-learn == 1.5.2
 timm>=0.9.16

--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/image-classification/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/image-classification/requirements.txt")
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)

--- a/examples/image-to-text/requirements.txt
+++ b/examples/image-to-text/requirements.txt
@@ -3,4 +3,4 @@ Levenshtein
 sentencepiece != 0.1.92
 tiktoken
 blobfile
-datasets
+datasets>=4.0.0

--- a/examples/language-modeling/peft_poly_seq2seq_with_generate.py
+++ b/examples/language-modeling/peft_poly_seq2seq_with_generate.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.38.0")
 check_optimum_habana_min_version("1.10.0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
 
 @dataclass
@@ -233,7 +233,7 @@ def main():
 
     # boolq
     boolq_dataset = (
-        load_dataset("super_glue", "boolq", trust_remote_code=model_args.trust_remote_code)
+        load_dataset("super_glue", "boolq" )
         .map(
             lambda x: {
                 "input": f"{x['passage']}\nQuestion: {x['question']}\nA. Yes\nB. No\nAnswer:",
@@ -248,7 +248,7 @@ def main():
 
     # multirc
     multirc_dataset = (
-        load_dataset("super_glue", "multirc", trust_remote_code=model_args.trust_remote_code)
+        load_dataset("super_glue", "multirc" )
         .map(
             lambda x: {
                 "input": (
@@ -266,7 +266,7 @@ def main():
 
     # rte
     rte_dataset = (
-        load_dataset("super_glue", "rte", trust_remote_code=model_args.trust_remote_code)
+        load_dataset("super_glue", "rte" )
         .map(
             lambda x: {
                 "input": (
@@ -284,7 +284,7 @@ def main():
 
     # wic
     wic_dataset = (
-        load_dataset("super_glue", "wic", trust_remote_code=model_args.trust_remote_code)
+        load_dataset("super_glue", "wic" )
         .map(
             lambda x: {
                 "input": (

--- a/examples/language-modeling/peft_poly_seq2seq_with_generate.py
+++ b/examples/language-modeling/peft_poly_seq2seq_with_generate.py
@@ -233,7 +233,7 @@ def main():
 
     # boolq
     boolq_dataset = (
-        load_dataset("super_glue", "boolq" )
+        load_dataset("super_glue", "boolq")
         .map(
             lambda x: {
                 "input": f"{x['passage']}\nQuestion: {x['question']}\nA. Yes\nB. No\nAnswer:",
@@ -248,7 +248,7 @@ def main():
 
     # multirc
     multirc_dataset = (
-        load_dataset("super_glue", "multirc" )
+        load_dataset("super_glue", "multirc")
         .map(
             lambda x: {
                 "input": (
@@ -266,7 +266,7 @@ def main():
 
     # rte
     rte_dataset = (
-        load_dataset("super_glue", "rte" )
+        load_dataset("super_glue", "rte")
         .map(
             lambda x: {
                 "input": (
@@ -284,7 +284,7 @@ def main():
 
     # wic
     wic_dataset = (
-        load_dataset("super_glue", "wic" )
+        load_dataset("super_glue", "wic")
         .map(
             lambda x: {
                 "input": (

--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 2.14.0
+datasets>=4.0.0
 sentencepiece != 0.1.92
 protobuf
 evaluate

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -554,7 +554,7 @@ def main():
             torch_dtype=torch_dtype,
         )
     else:
-        model = AutoModelForCausalLM.from_config(config )
+        model = AutoModelForCausalLM.from_config(config, trust_remote_code=model_args.trust_remote_code)
         n_params = sum({p.data_ptr(): p.numel() for p in model.parameters()}.values())
         logger.info(f"Training new model from scratch - Total size={n_params / 2**20:.2f}M params")
 

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
 adapt_transformers_to_gaudi()
 
@@ -260,7 +260,7 @@ class DataTrainingArguments:
 
     def __post_init__(self):
         if self.streaming:
-            require_version("datasets>=2.0.0", "The streaming feature requires `datasets>=2.0.0`")
+            require_version("datasets>=4.0.0", "The streaming feature requires `datasets>=2.0.0`")
 
         if self.dataset_name is None and self.train_file is None and self.validation_file is None:
             raise ValueError("Need either a dataset name or a training/validation file.")
@@ -554,7 +554,7 @@ def main():
             torch_dtype=torch_dtype,
         )
     else:
-        model = AutoModelForCausalLM.from_config(config, trust_remote_code=model_args.trust_remote_code)
+        model = AutoModelForCausalLM.from_config(config )
         n_params = sum({p.data_ptr(): p.numel() for p in model.parameters()}.values())
         logger.info(f"Training new model from scratch - Total size={n_params / 2**20:.2f}M params")
 

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_MASKED_LM_MAPPING.keys())
@@ -229,7 +229,7 @@ class DataTrainingArguments:
 
     def __post_init__(self):
         if self.streaming:
-            require_version("datasets>=2.0.0", "The streaming feature requires `datasets>=2.0.0`")
+            require_version("datasets>=4.0.0", "The streaming feature requires `datasets>=2.0.0`")
 
         if self.dataset_name is None and self.train_file is None and self.validation_file is None:
             raise ValueError("Need either a dataset name or a training/validation file.")
@@ -446,7 +446,7 @@ def main():
         )
     else:
         logger.info("Training new model from scratch")
-        model = AutoModelForMaskedLM.from_config(config, trust_remote_code=model_args.trust_remote_code)
+        model = AutoModelForMaskedLM.from_config(config )
 
     # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
     # on a small vocab and want a smaller embedding size, remove this test.

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -446,7 +446,7 @@ def main():
         )
     else:
         logger.info("Training new model from scratch")
-        model = AutoModelForMaskedLM.from_config(config )
+        model = AutoModelForMaskedLM.from_config(config, trust_remote_code=model_args.trust_remote_code)
 
     # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
     # on a small vocab and want a smaller embedding size, remove this test.

--- a/examples/language-modeling/run_multitask_prompt_tuning.py
+++ b/examples/language-modeling/run_multitask_prompt_tuning.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
 
 @dataclass

--- a/examples/language-modeling/run_prompt_tuning_clm.py
+++ b/examples/language-modeling/run_prompt_tuning_clm.py
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 
 
 @dataclass
@@ -200,7 +200,7 @@ class DataTrainingArguments:
 
     def __post_init__(self):
         if self.streaming:
-            require_version("datasets>=2.0.0", "The streaming feature requires `datasets>=2.0.0`")
+            require_version("datasets>=4.0.0", "The streaming feature requires `datasets>=2.0.0`")
 
         if self.dataset_name is None:
             raise ValueError("Need either a dataset name or a training/validation file.")

--- a/examples/protein-folding/requirements.txt
+++ b/examples/protein-folding/requirements.txt
@@ -1,2 +1,2 @@
-datasets>=2.14.0
+datasets>=4.0.0
 scikit-learn == 1.5.2

--- a/examples/protein-folding/run_sequence_classification.py
+++ b/examples/protein-folding/run_sequence_classification.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
     model = AutoModel.from_pretrained(
-        model_args.model_name_or_path, torch_dtype=torch_dtype
+        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, torch_dtype=torch_dtype
     )
     tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name)
 

--- a/examples/protein-folding/run_sequence_classification.py
+++ b/examples/protein-folding/run_sequence_classification.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
     model = AutoModel.from_pretrained(
-        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, torch_dtype=torch_dtype
+        model_args.model_name_or_path, torch_dtype=torch_dtype
     )
     tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name)
 

--- a/examples/protein-folding/run_zero_shot_eval.py
+++ b/examples/protein-folding/run_zero_shot_eval.py
@@ -133,7 +133,7 @@ def main(args):
     device = torch.device("hpu")
     model_dtype = torch.bfloat16 if args.bf16 else None
     protst_model = AutoModel.from_pretrained(
-        "mila-intel/ProtST-esm1b", trust_remote_code=True, torch_dtype=model_dtype
+        "mila-intel/ProtST-esm1b", torch_dtype=model_dtype
     ).to(device)
     protein_model = protst_model.protein_model
     text_model = protst_model.text_model

--- a/examples/protein-folding/run_zero_shot_eval.py
+++ b/examples/protein-folding/run_zero_shot_eval.py
@@ -133,7 +133,7 @@ def main(args):
     device = torch.device("hpu")
     model_dtype = torch.bfloat16 if args.bf16 else None
     protst_model = AutoModel.from_pretrained(
-        "mila-intel/ProtST-esm1b", torch_dtype=model_dtype
+        "mila-intel/ProtST-esm1b", trust_remote_code=True, torch_dtype=model_dtype
     ).to(device)
     protein_model = protst_model.protein_model
     text_model = protst_model.text_model

--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,3 +1,3 @@
-datasets >= 2.4.0
+datasets>=4.0.0
 torch >= 1.3.0
 evaluate

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 
 
 @dataclass

--- a/examples/question-answering/run_seq2seq_qa.py
+++ b/examples/question-answering/run_seq2seq_qa.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 
 
 @dataclass

--- a/examples/sentence-transformers-training/nli/requirements.txt
+++ b/examples/sentence-transformers-training/nli/requirements.txt
@@ -1,2 +1,2 @@
-datasets
+datasets>=4.0.0
 peft

--- a/examples/sentence-transformers-training/paraphrases/requirements.txt
+++ b/examples/sentence-transformers-training/paraphrases/requirements.txt
@@ -1,1 +1,1 @@
-datasets
+datasets>=4.0.0

--- a/examples/sentence-transformers-training/sts/requirements.txt
+++ b/examples/sentence-transformers-training/sts/requirements.txt
@@ -1,2 +1,2 @@
-datasets
+datasets>=4.0.0
 peft

--- a/examples/speech-recognition/requirements.txt
+++ b/examples/speech-recognition/requirements.txt
@@ -1,4 +1,4 @@
-datasets[audio] >= 1.18.0
+datasets[audio]>=4.0.0
 numba==0.60.0
 librosa
 jiwer

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.18.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
 
 
 def list_field(default=None, metadata=None):

--- a/examples/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/speech-recognition/run_speech_recognition_seq2seq.py
@@ -57,7 +57,7 @@ except ImportError:
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.18.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/stable-diffusion/training/requirements.txt
+++ b/examples/stable-diffusion/training/requirements.txt
@@ -1,5 +1,5 @@
 compel
-datasets
+datasets>=4.0.0
 imagesize
 opencv-python
 peft==0.16.0

--- a/examples/summarization/requirements.txt
+++ b/examples/summarization/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 2.4.0
+datasets>=4.0.0
 sentencepiece != 0.1.92
 protobuf
 rouge-score

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
 
 
 # A list of all multilingual tokenizer which require lang attribute.

--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 2.4.0
+datasets>=4.0.0
 sentencepiece != 0.1.92
 scipy
 scikit-learn == 1.5.2

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
 
 task_to_keys = {
     "cola": ("sentence", None),

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -822,7 +822,7 @@ pip install -r requirements_lm_eval.txt
 >
 > COMPLEXGUID_DISABLE_RMS_NORM=true ENABLE_EXPERIMENTAL_FLAGS=true for Llama-3.1-70B-Instruct[PTQ fp8] and llama-2-70b-hf[bf16]
 >
-> If custom models on hub is being used, please set env variable HF_DATASETS_TRUST_REMOTE_CODE=true instead of arg --trust_remote_code with the installed lm_eval version and dependency datasets==3.6.0
+> For lm-eval tasks that still rely on dataset scripts, use a separate env with datasets 3.x or switch to Parquet/Arrow variants. This repo requires datasets>=4.0.0.
 
 
 ### Examples

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets>=4.0.0
 peft
 sentencepiece
 tiktoken

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.9.1
-datasets==3.6.0
+datasets>=4.0.0
 langdetect<=1.0.9
 immutabledict<=4.2.1
 tiktoken

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.9.1
-datasets>=4.0.0
+datasets<4.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; relax when lm-eval supports datasets>=4
 langdetect<=1.0.9
 immutabledict<=4.2.1
 tiktoken

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.9.1
-datasets<4.0.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; relax when lm-eval supports datasets>=4.0.0
+datasets<4.0.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; unpin to datasets>=4.0.0 when supported
 langdetect<=1.0.9
 immutabledict<=4.2.1
 tiktoken

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.9.1
-datasets<4.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; relax when lm-eval supports datasets>=4
+datasets<4.0.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; relax when lm-eval supports datasets>=4.0.0
 langdetect<=1.0.9
 immutabledict<=4.2.1
 tiktoken

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -958,7 +958,7 @@ def main():
 
         assert not args.simulate_dyn_prompt, "Both dataset_name and simulate_dyn_prompt are set"
 
-        raw_dataset = load_dataset(args.dataset_name )
+        raw_dataset = load_dataset(args.dataset_name)
         if "test" in raw_dataset:
             split = "test"
         elif "validation" in raw_dataset:

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -1004,7 +1004,7 @@ def main():
         )
         # After tokenization, we can remove the column of interest
         raw_dataset = raw_dataset.remove_columns([column_name])
-        raw_dataset.set_format(type="torch")
+        raw_dataset = raw_dataset.with_format("torch")
 
         if prompt_length <= 0:
             # Todo please check if this collate function is suitable for your model

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -958,7 +958,7 @@ def main():
 
         assert not args.simulate_dyn_prompt, "Both dataset_name and simulate_dyn_prompt are set"
 
-        raw_dataset = load_dataset(args.dataset_name, trust_remote_code=args.trust_remote_code)
+        raw_dataset = load_dataset(args.dataset_name )
         if "test" in raw_dataset:
             split = "test"
         elif "validation" in raw_dataset:

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -185,7 +185,7 @@ def main() -> None:
     require_version(
         "datasets<4.0,>=2.16.0",
         "Use a separate environment for LM-Eval and install:\n"
-        "  pip install -r examples/text-generation/requirements_lm_eval.txt"
+        "  pip install -r examples/text-generation/requirements_lm_eval.txt",
     )
 
     # Always enable dataset scripts for lm-eval<=0.4.9.1 (remove when lm-eval supports datasets>=4.0)

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -179,6 +179,28 @@ def setup_lm_eval_parser():
 def main() -> None:
     # Modified based on cli_evaluate function in https://github.com/EleutherAI/lm-evaluation-harness/blob/v0.4.9.1/lm_eval/__main__.py#L301
     args = setup_lm_eval_parser()
+
+    # lm-eval==0.4.9.1 requires datasets<4.0 — fail fast if 4.x detected. Remove this block after upgrading lm-eval.
+    try:
+        import datasets as _ds
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'datasets' package is not installed. Run this script in a separate environment and install:\n"
+            "  pip install -r examples/text-generation/requirements_lm_eval.txt"
+        ) from e
+
+    _major = int((str(_ds.__version__).split(".")[0]) or 0)
+    if _major >= 4:
+        raise RuntimeError(
+            f"lm-eval 0.4.9.1 requires datasets<4.0, but detected datasets=={_ds.__version__}. "
+            "Run this script in a separate environment and install:\n"
+            "  pip install -r examples/text-generation/requirements_lm_eval.txt"
+        )
+
+    # Always enable dataset scripts for lm-eval<=0.4.9.1 (remove when lm-eval supports datasets>=4.0)
+    os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "true"
+    print("[lm-eval] HF_DATASETS_TRUST_REMOTE_CODE=true")
+
     model, _, tokenizer, generation_config = initialize_model(args, logger)
 
     import torch

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -188,9 +188,6 @@ def main() -> None:
         "  pip install -r examples/text-generation/requirements_lm_eval.txt",
     )
 
-    # Always enable dataset scripts for lm-eval<=0.4.9.1 (remove when lm-eval supports datasets>=4.0)
-    # os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "true"
-
     model, _, tokenizer, generation_config = initialize_model(args, logger)
 
     import torch

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -29,6 +29,7 @@ import psutil
 
 # Local imports
 from run_generation import setup_parser
+from transformers.utils.versions import require_version
 from utils import finalize_quantization, initialize_model, save_model
 
 
@@ -180,26 +181,15 @@ def main() -> None:
     # Modified based on cli_evaluate function in https://github.com/EleutherAI/lm-evaluation-harness/blob/v0.4.9.1/lm_eval/__main__.py#L301
     args = setup_lm_eval_parser()
 
-    # lm-eval==0.4.9.1 requires datasets<4.0 — fail fast if 4.x detected. Remove this block after upgrading lm-eval.
-    try:
-        import datasets as _ds
-    except ImportError as e:
-        raise RuntimeError(
-            "The 'datasets' package is not installed. Run this script in a separate environment and install:\n"
-            "  pip install -r examples/text-generation/requirements_lm_eval.txt"
-        ) from e
-
-    _major = int((str(_ds.__version__).split(".")[0]) or 0)
-    if _major >= 4:
-        raise RuntimeError(
-            f"lm-eval 0.4.9.1 requires datasets<4.0, but detected datasets=={_ds.__version__}. "
-            "Run this script in a separate environment and install:\n"
-            "  pip install -r examples/text-generation/requirements_lm_eval.txt"
-        )
+    # lm-eval==0.4.9.1 needs datasets<4.0 (and >=2.16.0). Remove when lm-eval supports datasets>=4.
+    require_version(
+        "datasets<4.0,>=2.16.0",
+        "Use a separate environment for LM-Eval and install:\n"
+        "  pip install -r examples/text-generation/requirements_lm_eval.txt"
+    )
 
     # Always enable dataset scripts for lm-eval<=0.4.9.1 (remove when lm-eval supports datasets>=4.0)
-    os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "true"
-    print("[lm-eval] HF_DATASETS_TRUST_REMOTE_CODE=true")
+    # os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "true"
 
     model, _, tokenizer, generation_config = initialize_model(args, logger)
 

--- a/examples/text-to-speech/requirements.txt
+++ b/examples/text-to-speech/requirements.txt
@@ -1,3 +1,3 @@
-datasets
+datasets>=4.0.0
 soundfile
 sentencepiece

--- a/examples/translation/requirements.txt
+++ b/examples/translation/requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 2.4.0
+datasets>=4.0.0
 sentencepiece != 0.1.92
 protobuf
 sacrebleu >= 1.4.12

--- a/examples/translation/run_translation.py
+++ b/examples/translation/run_translation.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
+require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
 
 # A list of all multilingual tokenizer which require src_lang and tgt_lang attributes.
 MULTILINGUAL_TOKENIZERS = [

--- a/examples/trl/grpo.py
+++ b/examples/trl/grpo.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     else:
         peft_config = None
 
-    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path )
     if training_args.chat_template is not None:
         tokenizer.chat_template = training_args.chat_template
 

--- a/examples/trl/grpo.py
+++ b/examples/trl/grpo.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     else:
         peft_config = None
 
-    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path )
+    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path, trust_remote_code=True)
     if training_args.chat_template is not None:
         tokenizer.chat_template = training_args.chat_template
 

--- a/examples/trl/ppo.py
+++ b/examples/trl/ppo.py
@@ -176,7 +176,7 @@ def build_dataset(
     )
     ds = ds.filter(lambda x: len(x["input_ids"]) < input_max_length, batched=False)
 
-    ds.set_format(type="torch")
+    ds = ds.with_format("torch")
     return ds
 
 

--- a/examples/trl/requirements.txt
+++ b/examples/trl/requirements.txt
@@ -1,6 +1,6 @@
 trl == 0.9.6
 peft == 0.15.0
-datasets == 2.19.2
+datasets>=4.0.0
 tyro
 evaluate
 scikit-learn == 1.5.2

--- a/examples/trl/requirements_grpo.txt
+++ b/examples/trl/requirements_grpo.txt
@@ -1,6 +1,6 @@
 trl == 0.17.0
 peft == 0.15.0
-datasets
+datasets>=4.0.0
 tyro
 evaluate
 scikit-learn == 1.5.2

--- a/examples/trl/sft.py
+++ b/examples/trl/sft.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     if is_zero3_enabled and training_args.use_zero3_leaf_promotion:
         apply_zero3_leaf_promotion(base_model)
 
-    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path )
     tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "right"  # Fix weird overflow issue with fp16 training
 

--- a/examples/trl/sft.py
+++ b/examples/trl/sft.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     if is_zero3_enabled and training_args.use_zero3_leaf_promotion:
         apply_zero3_leaf_promotion(base_model)
 
-    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path )
+    tokenizer = AutoTokenizer.from_pretrained(script_args.model_name_or_path, trust_remote_code=True)
     tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "right"  # Fix weird overflow issue with fp16 training
 

--- a/tests/configs/examples/clip_roberta.json
+++ b/tests/configs/examples/clip_roberta.json
@@ -1,6 +1,6 @@
 {
     "gaudi1": {
-        "ydshieh/coco_dataset_script": {
+         "imagefolder":  {
             "num_train_epochs": 1,
             "eval_batch_size": 64,
             "distribution": {
@@ -30,7 +30,7 @@
         }
     },
     "gaudi2": {
-        "ydshieh/coco_dataset_script": {
+         "imagefolder":  {
             "eval_batch_size": 64,
             "num_train_epochs": 1,
             "distribution": {
@@ -62,7 +62,7 @@
         }
     },
     "gaudi3": {
-        "ydshieh/coco_dataset_script": {
+         "imagefolder":  {
             "eval_batch_size": 64,
             "num_train_epochs": 1,
             "distribution": {

--- a/tests/example_diff/run_clm.txt
+++ b/tests/example_diff/run_clm.txt
@@ -28,7 +28,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 59c54,60
-< require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -42,7 +42,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 > 
 78c85,86
 <                 "The model checkpoint for weights initialization. Don't set if you want to train a model from scratch."

--- a/tests/example_diff/run_generation.txt
+++ b/tests/example_diff/run_generation.txt
@@ -996,7 +996,7 @@
 > 
 >         assert not args.simulate_dyn_prompt, "Both dataset_name and simulate_dyn_prompt are set"
 > 
->         raw_dataset = load_dataset(args.dataset_name, trust_remote_code=args.trust_remote_code)
+>         raw_dataset = load_dataset(args.dataset_name )
 >         if "test" in raw_dataset:
 >             split = "test"
 >         elif "validation" in raw_dataset:

--- a/tests/example_diff/run_generation.txt
+++ b/tests/example_diff/run_generation.txt
@@ -996,7 +996,7 @@
 > 
 >         assert not args.simulate_dyn_prompt, "Both dataset_name and simulate_dyn_prompt are set"
 > 
->         raw_dataset = load_dataset(args.dataset_name )
+>         raw_dataset = load_dataset(args.dataset_name)
 >         if "test" in raw_dataset:
 >             split = "test"
 >         elif "validation" in raw_dataset:

--- a/tests/example_diff/run_generation.txt
+++ b/tests/example_diff/run_generation.txt
@@ -1090,7 +1090,7 @@
 436a720,743
 >         # After tokenization, we can remove the column of interest
 >         raw_dataset = raw_dataset.remove_columns([column_name])
->         raw_dataset.set_format(type="torch")
+>         raw_dataset = raw_dataset.with_format("torch")
 > 
 >         if prompt_length <= 0:
 >             # Todo please check if this collate function is suitable for your model

--- a/tests/example_diff/run_mlm.txt
+++ b/tests/example_diff/run_mlm.txt
@@ -24,7 +24,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 58c53,59
-< require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -39,7 +39,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
 > 
 > 
 136c145

--- a/tests/example_diff/run_qa.txt
+++ b/tests/example_diff/run_qa.txt
@@ -22,7 +22,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 54c52,58
-< require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -36,7 +36,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 > 
 145c155
 <                 " batching to the maximum length in the batch (which can be faster on GPU but will be slower on TPU)."

--- a/tests/example_diff/run_seq2seq_qa.txt
+++ b/tests/example_diff/run_seq2seq_qa.txt
@@ -19,7 +19,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 50c48,54
-< require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -33,7 +33,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 > 
 177c187
 <                 " batching to the maximum length in the batch (which can be faster on GPU but will be slower on TPU)."

--- a/tests/example_diff/run_speech_recognition_ctc.txt
+++ b/tests/example_diff/run_speech_recognition_ctc.txt
@@ -21,7 +21,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 54c51,56
-< require_version("datasets>=1.18.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -34,7 +34,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=1.18.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
 > 
 143c151
 <             "help": "Whether a convolutional attention network should be stacked on top of the Wav2Vec2Bert Encoder. Can be very"

--- a/tests/example_diff/run_summarization.txt
+++ b/tests/example_diff/run_summarization.txt
@@ -28,7 +28,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 56c56,62
-< require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -52,7 +52,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
 > 
 128a132,140
 >     use_cache: bool = field(

--- a/tests/example_diff/run_translation.txt
+++ b/tests/example_diff/run_translation.txt
@@ -19,7 +19,7 @@
 < # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 < check_min_version("4.52.0.dev0")
 56c54,60
-< require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
+< require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
 ---
 > try:
 >     from optimum.habana.utils import check_optimum_habana_min_version
@@ -33,7 +33,7 @@
 > check_min_version("4.51.0")
 > check_optimum_habana_min_version("1.18.0.dev0")
 > 
-> require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
+> require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
 > 
 61c71,78
 < MULTILINGUAL_TOKENIZERS = [MBartTokenizer, MBartTokenizerFast, MBart50Tokenizer, MBart50TokenizerFast, M2M100Tokenizer]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -924,7 +924,7 @@ class MultiCardSeq2SeqQuestionAnsweringExampleTester(
 class MultiCardVisionLanguageExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_clip", multi_card=True, torch_compile=True
 ):
-    TASK_NAME = "ydshieh/coco_dataset_script"
+    TASK_NAME = "imagefolder"
 
 
 class ProteinFoldingExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_esmfold"):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -713,7 +713,7 @@ class GaudiTrainerIntegrationPrerunTest(TestCasePlus, GaudiTrainerIntegrationCom
             self.check_trained_model(trainer.model)
 
             # Can return tensors.
-            train_dataset.set_format(type="torch", dtype=torch.float32)
+            train_dataset = train_dataset.with_format("torch")
             model = RegressionModel()
             trainer = GaudiTrainer(model, gaudi_config, args, train_dataset=train_dataset)
             trainer.train()

--- a/tests/test_trainer_seq2seq.py
+++ b/tests/test_trainer_seq2seq.py
@@ -93,10 +93,8 @@ class GaudiSeq2seqTrainerTester(TestCasePlus):
             batch_size=batch_size,
             remove_columns=["article", "highlights"],
         )
-        train_dataset.set_format(
-            type="torch",
-            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
-        )
+        train_dataset = train_dataset.with_format("torch",
+            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],)
 
         # same for validation dataset
         val_dataset = val_dataset.map(
@@ -105,10 +103,8 @@ class GaudiSeq2seqTrainerTester(TestCasePlus):
             batch_size=batch_size,
             remove_columns=["article", "highlights"],
         )
-        val_dataset.set_format(
-            type="torch",
-            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
-        )
+        val_dataset = val_dataset.with_format("torch",
+            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],)
 
         # instantiate trainer
         trainer = GaudiSeq2SeqTrainer(

--- a/tests/test_trainer_seq2seq.py
+++ b/tests/test_trainer_seq2seq.py
@@ -93,8 +93,10 @@ class GaudiSeq2seqTrainerTester(TestCasePlus):
             batch_size=batch_size,
             remove_columns=["article", "highlights"],
         )
-        train_dataset = train_dataset.with_format("torch",
-            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],)
+        train_dataset = train_dataset.with_format(
+            "torch",
+            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
+        )
 
         # same for validation dataset
         val_dataset = val_dataset.map(
@@ -103,8 +105,10 @@ class GaudiSeq2seqTrainerTester(TestCasePlus):
             batch_size=batch_size,
             remove_columns=["article", "highlights"],
         )
-        val_dataset = val_dataset.with_format("torch",
-            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],)
+        val_dataset = val_dataset.with_format(
+            "torch",
+            columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
+        )
 
         # instantiate trainer
         trainer = GaudiSeq2SeqTrainer(

--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1279,7 +1279,7 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         return [x["array"] for x in speech_samples]
 
     def _load_superb(self, task, num_samples):
-        ds = load_dataset("anton-l/superb_dummy", task, split="test", trust_remote_code=True)
+        ds = load_dataset("anton-l/superb_dummy", task, split="test" )
 
         return ds[:num_samples]
 

--- a/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/transformers/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1279,7 +1279,7 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         return [x["array"] for x in speech_samples]
 
     def _load_superb(self, task, num_samples):
-        ds = load_dataset("anton-l/superb_dummy", task, split="test" )
+        ds = load_dataset("anton-l/superb_dummy", task, split="test")
 
         return ds[:num_samples]
 


### PR DESCRIPTION
Summary of changes (concise):

- Raise lower bound to datasets>=4.0.0 in example requirements.txt files (audio, speech-recognition, image/text classification, seq2seq, summarization, translation, TTS, stable-diffusion, TRL, etc.); use datasets[audio]>=4.0.0 where applicable.
- Update runtime guards to require_version("datasets>=4.0.0") in example scripts.
- Migrate API usage from deprecated .set_format(type="torch", ...) to .with_format("torch", ...) in examples and tests.
- Contrastive image-text example: switch COCO guidance from ydshieh/coco_dataset_script to the Parquet-based sentence-transformers/coco-captions; docs and CLI snippets now use imagefolder where relevant; test configs updated accordingly.
- Remove unnecessary trust_remote_code flags in several load_dataset(...) calls (e.g., generation and PEFT examples, wav2vec2 tests) where standard builders are used.
- LM-Eval carve-out: keep a dedicated env by pinning datasets<4.0.0,>=2.16.0 in examples/text-generation/requirements_lm_eval.txt and add a guard in run_lm_eval.py; README note adjusted to reflect this.
- Refresh example-diff artifacts and tests to match the above changes (including tests/test_examples.py and tests/test_trainer* adjustments).

Notes

- No training logic changes; this is a dependency & API-compatibility sweep.
- Users relying on dataset scripts should run LM-Eval in the separate env as documented; all other examples require datasets>=4.0.0.