### PR TITLE
Disable SDP on BF16 default for generic diffusers HPU support

### DIFF
--- a/optimum/habana/diffusers/pipelines/pipeline_utils.py
+++ b/optimum/habana/diffusers/pipelines/pipeline_utils.py
@@ -349,6 +349,7 @@ class GaudiDiffusionPipeline(DiffusionPipeline):
         Intercept to() method and disable gpu-hpu migration before sending to diffusers
         """
         kwargs["hpu_migration"] = False
+        kwargs["sdp_on_bf16"] = False
         return super().to(
             *args,
             **kwargs,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
@@ -286,6 +286,7 @@ class StableDiffusionXLPipeline_HPU(StableDiffusionXLPipeline):
         Intercept to() method and disable gpu-hpu migration before sending to diffusers
         """
         kwargs["hpu_migration"] = False
+        kwargs["sdp_on_bf16"] = False
         return super().to(
             *args,
             **kwargs,


### PR DESCRIPTION
# What does this PR do?

HPU OOB functionality for diffusers' models use GPU-HPU Migration Toolkit.  After 1.21 we default to eager mode where the default SDP kernel in FP32 precision. Previously, the default lazy mode in GPU-HPU Migration Toolkit used SDP in BF16 precision (SW-226104).  This causes performance degradation. https://github.com/huggingface/diffusers/pull/12310 PR is submitted to improve performance on HPU devices.

In OH we want to keep the default as is, which is what this PR is for.