### PR TITLE
 Fixed CWE-561 Dead Code for "next_decoder_cache" Pattern

### DIFF
--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -501,7 +501,8 @@ class GaudiMistralModel(MistralModel):
 
         hidden_states = inputs_embeds
 
-        next_decoder_cache = () if not use_new_cache else None
+        # HPU uses legacy cache path (use_new_cache = False)
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
+++ b/optimum/habana/transformers/models/qwen2/modeling_qwen2.py
@@ -864,7 +864,8 @@ class GaudiQwen2Model(Qwen2Model):
         # embed positions
         hidden_states = inputs_embeds
 
-        next_decoder_cache = () if not use_new_cache else None
+        # HPU uses legacy cache path (use_new_cache = False)
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/optimum/habana/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -956,7 +956,8 @@ class GaudiQwen3MoeModel(Qwen3MoeModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        next_decoder_cache = () if not use_new_cache else None
+        # HPU uses legacy cache path (use_new_cache = False)
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()


### PR DESCRIPTION
The statement `next_decoder_cache = () if not use_new_cache else None` was always evaluating to `()` because `use_new_cache` is hardcoded to `False`, making `not use_new_cache` always `True`.

This PR allows as to pass security scans required for the release.