### PR TITLE
Check if generation_config has attr 'static_shapes' before accessing value

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1034,7 +1034,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 if generation_config.decoder_start_token_id is None:
                     generation_config.decoder_start_token_id = self.generation_config.decoder_start_token_id
 
-        if not hasattr(generation_config, "static_shapes") or generation_config.static_shapes is None:
+        if getattr(generation_config, "static_shapes") is None:
             generation_config.static_shapes = self.config.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES
             if self.config.model_type == "vision-encoder-decoder":
                 generation_config.static_shapes = self.config.decoder.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1034,7 +1034,7 @@ class GaudiGenerationMixin(GenerationMixin):
                 if generation_config.decoder_start_token_id is None:
                     generation_config.decoder_start_token_id = self.generation_config.decoder_start_token_id
 
-        if generation_config.static_shapes is None:
+        if not hasattr(generation_config, "static_shapes") or generation_config.static_shapes is None:
             generation_config.static_shapes = self.config.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES
             if self.config.model_type == "vision-encoder-decoder":
                 generation_config.static_shapes = self.config.decoder.model_type in MODELS_OPTIMIZED_WITH_STATIC_SHAPES


### PR DESCRIPTION
# What does this PR do?

This is W/A for not having properly assigned static_shapes property of generation_config.
This should unblock CI runs of Model Llama 3-2-11B 2048/2048 Tokens bfloat16 tests, which have been failing for some time now.