### PR TITLE
fix for GenerationConfig issue for pipeline init changes by transformers update

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -315,6 +315,7 @@ from .models import (
     gaudi_XLMRoberta_Sdpa_SelfAttention_forward,
 )
 from .models.deepseek_v2.modeling_deepseek_v2 import DeepseekV2ForCausalLM as GaudiDeepseekV2ForCausalLM
+from .pipelines import GaudiImageToTextPipeline
 
 
 def adapt_transformers_to_gaudi():
@@ -394,6 +395,9 @@ def adapt_transformers_to_gaudi():
     transformers.generation.MaxTimeCriteria.__call__ = gaudi_MaxTimeCriteria_call
     transformers.generation.EosTokenCriteria.__call__ = gaudi_EosTokenCriteria_call
     transformers.generation.StoppingCriteriaList.__call__ = gaudi_StoppingCriteriaList_call
+    transformers.pipelines.image_to_text.ImageToTextPipeline._default_generation_config = (
+        GaudiImageToTextPipeline._default_generation_config
+    )
 
     # Optimization for BLOOM generation on Gaudi
     transformers.models.bloom.modeling_bloom.BloomAttention.forward = gaudi_bloom_attention_forward

--- a/optimum/habana/transformers/pipelines/__init__.py
+++ b/optimum/habana/transformers/pipelines/__init__.py
@@ -1,0 +1,1 @@
+from .image_to_text import GaudiImageToTextPipeline

--- a/optimum/habana/transformers/pipelines/image_to_text.py
+++ b/optimum/habana/transformers/pipelines/image_to_text.py
@@ -1,0 +1,9 @@
+from transformers.pipelines.image_to_text import ImageToTextPipeline
+
+from ..generation import GaudiGenerationConfig
+
+
+class GaudiImageToTextPipeline(ImageToTextPipeline):
+    _default_generation_config = GaudiGenerationConfig(
+        max_new_tokens=256,
+    )


### PR DESCRIPTION

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

With transformers updated to 4.55.4, there are changes in pipeline init method and causes error in optimum-habana when using pipeline for multi-modal inference, error log shown below:

> Traceback (most recent call last):
  File "/workspace/optimum-habana/examples/image-to-text/run_pipeline.py", line 533, in <module>
    main()
  File "/workspace/optimum-habana/examples/image-to-text/run_pipeline.py", line 375, in main
    generator = pipeline(
  File "/usr/local/lib/python3.10/dist-packages/transformers/pipelines/__init__.py", line 1210, in pipeline
    return pipeline_class(model=model, framework=framework, task=task, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/transformers/pipelines/image_to_text.py", line 85, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/transformers/pipelines/base.py", line 1064, in __init__
    prepared_generation_config, kwargs = self.model._prepare_generation_config(
  File "/workspace/optimum-habana/optimum/habana/transformers/generation/utils.py", line 1035, in _prepare_generation_config
    if generation_config.static_shapes is None:
AttributeError: 'GenerationConfig' object has no attribute 'static_shapes'
FAILED



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
