### PR TITLE
Fix import of check_torch_load_is_safe

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -100,13 +100,13 @@ from transformers.utils import (
     WEIGHTS_INDEX_NAME,
     WEIGHTS_NAME,
     PushInProgress,
-    check_torch_load_is_safe,
     is_accelerate_available,
     is_datasets_available,
     is_peft_available,
     is_safetensors_available,
 )
 from transformers.utils.deprecation import deprecate_kwarg
+from transformers.utils.import_utils import check_torch_load_is_safe
 
 from ..accelerate import GaudiAccelerator
 from ..accelerate.utils import FP8ContextWrapper

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -80,11 +80,11 @@ from transformers.utils import (
     SAFE_WEIGHTS_NAME,
     WEIGHTS_INDEX_NAME,
     WEIGHTS_NAME,
-    check_torch_load_is_safe,
     is_accelerate_available,
     is_safetensors_available,
 )
 from transformers.utils.hp_naming import TrialShortNamer
+from transformers.utils.import_utils import check_torch_load_is_safe
 
 from optimum.habana import GaudiConfig, GaudiTrainingArguments
 from optimum.habana.accelerate import GaudiAccelerator


### PR DESCRIPTION
Updated import of check_torch_load_is_safe to use transformers.utils.import_utils instead of transformers.utils, ensuring compatibility with Transformers 4.55.