### PR TITLE
Fix QLoRA test

### DIFF
--- a/tests/test_bnb_qlora.py
+++ b/tests/test_bnb_qlora.py
@@ -69,7 +69,7 @@ def get_model(token: str, model_id: str):
     )
 
     model = AutoModelForCausalLM.from_pretrained(
-        model_id, quantization_config=nf4_config, device_map={"": "hpu"}, torch_dtype=torch.bfloat16, token=token.value
+        model_id, quantization_config=nf4_config, torch_dtype=torch.bfloat16, token=token.value
     )
 
     return model


### PR DESCRIPTION
test_bnb_qlora.py fails due to following 2 issues,
(1)  "ImportError: cannot import name '_reverse_4bit_compress_format' from 'bitsandbytes.utils'"
(2)  "/usr/local/lib/python3.10/dist-packages/accelerate/accelerator.py:1783: TypeError " 

Issue (1) will get fixed with this PR https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1757 in bitsandbytes.
Issue (2) is fixed in this PR by allowing device_map to be automatically detected for Gaudi. 