### PR TITLE
Properly apply dropout in GPTBigCode only when in training.

### DIFF
--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -142,7 +142,7 @@ class GaudiGPTBigCodeAttention(GPTBigCodeAttention):
 
             attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1)
 
-        attn_weights = torch.nn.functional.dropout(attn_weights, p=self.attn_dropout)
+        attn_weights = torch.nn.functional.dropout(attn_weights, p=self.attn_dropout, training=self.training)
 
         # Mask heads if we want to
         if head_mask is not None:


### PR DESCRIPTION
# What does this PR do?

Pass `training` parameter to dropout in BigCodeAttention, which was omitted in previous change.
