### PR TITLE
Fix next_decoder_cache formula based on use_new_cache after tranformers 4.55 upgrade

### DIFF
--- a/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -1783,7 +1783,6 @@ class DeepseekV2Model(DeepseekV2PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         ignore_cache_position = True  # Ignoring cache position for HPU
-        use_new_cache = False  # Ignoring new Cache path for HPU
 
         past_seen_tokens = 0
 
@@ -1794,7 +1793,6 @@ class DeepseekV2Model(DeepseekV2PreTrainedModel):
                 else:
                     past_seen_tokens = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 if past_key_values[0] is not None:  ##added for (None, None)
                     past_seen_tokens = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/optimum/habana/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -1830,7 +1830,7 @@ class DeepseekV2Model(DeepseekV2PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
         all_router_logits = () if output_router_logits else None
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/gemma/modeling_gemma.py
+++ b/optimum/habana/transformers/models/gemma/modeling_gemma.py
@@ -648,7 +648,7 @@ class GaudiGemmaModel(GemmaModel):
         normalizer = torch.tensor(self.config.hidden_size**0.5, dtype=hidden_states.dtype, device=inputs_embeds.device)
         hidden_states = hidden_states * normalizer
 
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/gemma/modeling_gemma.py
+++ b/optimum/habana/transformers/models/gemma/modeling_gemma.py
@@ -616,14 +616,12 @@ class GaudiGemmaModel(GemmaModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        use_new_cache = False  # Ignoring new Cache path for HPU
         past_seen_tokens = 0
 
         if past_key_values is not None and use_cache:  # kept for BC (cache positions)
             if reuse_cache:
                 past_seen_tokens = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 past_seen_tokens = past_key_values[0][0].shape[2]
 
         cache_position = None

--- a/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
+++ b/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
@@ -602,7 +602,6 @@ class GaudiGemma2Model(Gemma2Model):
             inputs_embeds = self.embed_tokens(input_ids)
 
         ignore_cache_position = True  # Ignoring cache position for HPU
-        use_new_cache = False  # Ignoring new Cache path for HPU
 
         past_seen_tokens = 0
 
@@ -613,7 +612,6 @@ class GaudiGemma2Model(Gemma2Model):
                 else:
                     past_seen_tokens = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 past_seen_tokens = past_key_values[0][0].shape[2]
 
         if ignore_cache_position is False:

--- a/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
+++ b/optimum/habana/transformers/models/gemma2/modeling_gemma2.py
@@ -683,7 +683,7 @@ class GaudiGemma2Model(Gemma2Model):
         # decoder layers
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -1278,7 +1278,7 @@ class GaudiLlamaModel(LlamaModel):
         hidden_states = inputs_embeds
         position_embeddings = None  # self.rotary_emb(hidden_states, position_ids)
 
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -24,7 +24,7 @@ from typing import Optional, Union
 
 import habana_frameworks.torch.core as htcore
 import torch
-from transformers.cache_utils import Cache, DynamicCache
+from transformers.cache_utils import Cache
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.models.mistral.configuration_mistral import MistralConfig
 from transformers.models.mistral.modeling_mistral import (

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -467,20 +467,9 @@ class GaudiMistralModel(MistralModel):
             raise ValueError("You have to specify either decoder_input_ids or decoder_inputs_embeds")
 
         past_key_values_length = 0
-        use_new_cache = False
-        return_legacy_cache = False
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
-
-        if use_cache and not isinstance(past_key_values, Cache) and use_new_cache:
-            past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-            return_legacy_cache = True
-            logger.warning_once(
-                "We detected that you are passing `past_key_values` as a tuple and this is deprecated and will be removed in v4.43. "
-                "Please use an appropriate `Cache` class (https://huggingface.co/docs/transformers/v4.41.3/en/internal/generation_utils#transformers.Cache)"
-            )
-            past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
 
         if cache_position is None:
             cache_position = torch.arange(
@@ -541,11 +530,7 @@ class GaudiMistralModel(MistralModel):
 
         next_cache = None
         if use_cache:
-            next_cache = (
-                next_decoder_cache
-                if not use_new_cache
-                else (next_decoder_cache.to_legacy_cache() if return_legacy_cache else next_decoder_cache)
-            )
+            next_cache = next_decoder_cache
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -637,7 +637,7 @@ class GaudiMixtralModel(MixtralModel):
         hidden_states = inputs_embeds
 
         # decoder layers
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             layer_outputs = decoder_layer(

--- a/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
+++ b/optimum/habana/transformers/models/mixtral/modeling_mixtral.py
@@ -585,13 +585,11 @@ class GaudiMixtralModel(MixtralModel):
             raise ValueError("You have to specify either decoder_input_ids or decoder_inputs_embeds")
 
         past_key_values_length = 0
-        use_new_cache = False  # Ignoring new Cache path for HPU
 
         if past_key_values is not None and use_cache:
             if reuse_cache:
                 past_key_values_length = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 past_key_values_length = past_key_values[0][0].shape[2]
 
         if inputs_embeds is None:

--- a/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -858,7 +858,6 @@ class GaudiQwen2MoeModel(Qwen2MoeModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         ignore_cache_position = True  # Ignoring cache position for HPU
-        use_new_cache = False  # Ignoring new Cache path for HPU
 
         past_seen_tokens = 0
 
@@ -869,7 +868,6 @@ class GaudiQwen2MoeModel(Qwen2MoeModel):
                 else:
                     past_seen_tokens = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 if past_key_values[0] is not None:  ##added for (None, None)
                     past_seen_tokens = past_key_values[0][0].shape[2]
 

--- a/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/optimum/habana/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -909,7 +909,7 @@ class GaudiQwen2MoeModel(Qwen2MoeModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
         all_router_logits = () if output_router_logits else None
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()

--- a/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
+++ b/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
@@ -793,7 +793,6 @@ class GaudiQwen3Model(Qwen3Model):
             inputs_embeds = self.embed_tokens(input_ids)
 
         ignore_cache_position = True  # Ignoring cache position for HPU
-        use_new_cache = False  # Ignoring new Cache path for HPU
 
         past_seen_tokens = 0
 
@@ -804,7 +803,6 @@ class GaudiQwen3Model(Qwen3Model):
                 else:
                     past_seen_tokens = past_key_values[0][0][2]
             else:
-                # HPU uses legacy cache path (use_new_cache = False)
                 past_seen_tokens = past_key_values[0][0].shape[2]
 
         if ignore_cache_position is False:

--- a/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
+++ b/optimum/habana/transformers/models/qwen3/modeling_qwen3.py
@@ -856,7 +856,7 @@ class GaudiQwen3Model(Qwen3Model):
         # embed positions
         hidden_states = inputs_embeds
 
-        next_decoder_cache = () if not use_new_cache else None
+        next_decoder_cache = ()
 
         if lazy_mode:
             htcore.mark_step()


### PR DESCRIPTION
The statement `next_decoder_cache = () if not use_new_cache else None` was always evaluating to () because `use_new_cache` is hardcoded to False, making `not use_new_cache` always True.

Similar thing happens for optimum/habana/transformers/models/mistral/modeling_mistral.py, where there is even more dead code because of hardcoded `use_new_cache`.

This PR allows as to pass security scans required for the release.