### PR TITLE
Revert to datasets==3.6.0 in audio classification module

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -1,4 +1,4 @@
-datasets[audio]>=4.0.0
+datasets[audio]==3.6.0
 evaluate
 numba==0.60.0
 librosa

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 check_min_version("4.55.0")
 check_optimum_habana_min_version("1.19.0.dev0")
 
-require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/audio-classification/requirements.txt")
+require_version("datasets>=3.6.0", "To fix: pip install -r examples/pytorch/audio-classification/requirements.txt")
 
 
 def random_subsample(wav: np.ndarray, max_length: float, sample_rate: int = 16000):


### PR DESCRIPTION
This PR reverts the audio classification module back to datasets==3.6.0.
The recent upgrade to datasets==4.0.0 caused compatibility issues with audio dataset loading (e.g., common_language parquet conversion). Restoring version 3.6.0 ensures stable dataset handling until a proper migration path is implemented.