### PR TITLE
Migrate common_language dataset to Datasets v4.0.0 and switch audio decoding to SoundFile

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -2,3 +2,4 @@ datasets[audio]>=4.0.0
 evaluate
 numba==0.60.0
 librosa
+soundfile

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -24,7 +24,7 @@ import datasets
 import evaluate
 import numpy as np
 import transformers
-from datasets import DatasetDict, load_dataset
+from datasets import Audio, DatasetDict, load_dataset
 from transformers import AutoConfig, AutoFeatureExtractor, AutoModelForAudioClassification, HfArgumentParser
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
@@ -316,10 +316,10 @@ def main():
         trust_remote_code=model_args.trust_remote_code,
     )
 
-    # `datasets` takes care of automatically loading and resampling the audio,
-    # so we just need to set the correct target sampling rate.
+    # Make sure datasets does not auto-decode audio (we'll open via soundfile in prepare_dataset).
     raw_datasets = raw_datasets.cast_column(
-        data_args.audio_column_name, datasets.features.Audio(sampling_rate=feature_extractor.sampling_rate)
+        data_args.audio_column_name,
+        Audio(sampling_rate=feature_extractor.sampling_rate, decode=False),
     )
 
     # Max input length

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -50,6 +50,9 @@ check_optimum_habana_min_version("1.19.0.dev0")
 
 require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/audio-classification/requirements.txt")
 
+# Disable torchcodec decoding in datasets before any dataset ops
+os.environ.setdefault("HF_DATASETS_DISABLE_TORCHCODEC", "1")
+
 
 def random_subsample(wav: np.ndarray, max_length: float, sample_rate: int = 16000):
     """Randomly sample chunks of `max_length` seconds from the input audio"""

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -280,14 +280,12 @@ def main():
         data_args.dataset_config_name,
         split=data_args.train_split_name,
         token=model_args.token,
-        trust_remote_code=model_args.trust_remote_code,
     )
     raw_datasets["eval"] = load_dataset(
         data_args.dataset_name,
         data_args.dataset_config_name,
         split=data_args.eval_split_name,
         token=model_args.token,
-        trust_remote_code=model_args.trust_remote_code,
     )
 
     if data_args.audio_column_name not in raw_datasets["train"].column_names:

--- a/tests/configs/examples/ast_finetuned_speech_commands_v2.json
+++ b/tests/configs/examples/ast_finetuned_speech_commands_v2.json
@@ -1,6 +1,6 @@
 {
     "gaudi2": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {
@@ -24,15 +24,14 @@
                         "--dataloader_num_workers 1",
                         "--ignore_mismatched_sizes=True",
                         "--use_hpu_graphs_for_training",
-                        "--use_hpu_graphs_for_inference",
-                        "--trust_remote_code True"
+                        "--use_hpu_graphs_for_inference"
                     ]
                 }
             }
         }
     },
     "gaudi3": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {
@@ -56,8 +55,7 @@
                         "--dataloader_num_workers 1",
                         "--ignore_mismatched_sizes=True",
                         "--use_hpu_graphs_for_training",
-                        "--use_hpu_graphs_for_inference",
-                        "--trust_remote_code True"
+                        "--use_hpu_graphs_for_inference"
                     ]
                 }
             }

--- a/tests/configs/examples/wav2vec2_base.json
+++ b/tests/configs/examples/wav2vec2_base.json
@@ -23,8 +23,7 @@
                         "--seed 0",
                         "--dataloader_num_workers 1",
                         "--use_hpu_graphs_for_training",
-                        "--use_hpu_graphs_for_inference",
-                        "--trust_remote_code True"
+                        "--use_hpu_graphs_for_inference"
                     ]
                 }
             }
@@ -54,8 +53,7 @@
                         "--seed 0",
                         "--dataloader_num_workers 1",
                         "--use_hpu_graphs_for_training",
-                        "--use_hpu_graphs_for_inference",
-                        "--trust_remote_code True"
+                        "--use_hpu_graphs_for_inference"
                     ]
                 }
             }
@@ -85,8 +83,7 @@
                         "--seed 0",
                         "--dataloader_num_workers 1",
                         "--use_hpu_graphs_for_training",
-                        "--use_hpu_graphs_for_inference",
-                        "--trust_remote_code True"
+                        "--use_hpu_graphs_for_inference"
                     ]
                 }
             }

--- a/tests/configs/examples/wav2vec2_base.json
+++ b/tests/configs/examples/wav2vec2_base.json
@@ -1,6 +1,6 @@
 {
     "gaudi1": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 10,
             "eval_batch_size": 64,
             "distribution": {
@@ -30,7 +30,7 @@
         }
     },
     "gaudi2": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 5,
             "eval_batch_size": 64,
             "distribution": {
@@ -60,7 +60,7 @@
         }
     },
     "gaudi3": {
-        "common_language": {
+        "regisss/common_language": {
             "num_train_epochs": 5,
             "eval_batch_size": 64,
             "distribution": {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -936,7 +936,7 @@ class MultiCardMaskedLanguageModelingExampleTester(
 class MultiCardAudioClassificationExampleTester(
     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_audio_classification", multi_card=True
 ):
-    TASK_NAME = "common_language"
+    TASK_NAME = "regisss/common_language"
 
 
 class MultiCardSpeechRecognitionExampleTester(


### PR DESCRIPTION
This PR addresses compatibility issues with datasets>=4.0.0 by:

Dataset Migration

- Replaced the legacy anton-l/common_language dataset with a Parquet-converted version (regisss/common_language), which is fully supported under datasets v4.0.0.
- Ensures training, validation, and test splits are properly mapped without relying on trust_remote_code.

Audio Decoding

- The previous decoding mechanism expected an array field (auto-decoded audio). In datasets v4.0.0, decoding is disabled for performance and compatibility with HPUs.
- Introduced an explicit decoding step using SoundFile, handling both file paths and in-memory bytes.
- Added downmix to mono and validation of sample rates to ensure consistency with the feature extractor.
- 