### PR TITLE
fix text classification for datasets 4.0.0

### DIFF
--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -5,4 +5,4 @@ scikit-learn == 1.5.2
 protobuf == 5.29.4
 tensorboard == 2.19.0
 torch >= 1.3
-evaluate == 0.4.3
+evaluate == 0.4.5


### PR DESCRIPTION
This PR updates the requirements to enforce evaluate>=0.4.5, as older versions of the library crash during metric computation when used together with datasets>=4.0.0.

After upgrading datasets from 3.6.0 to 4.0.0, evaluation on GLUE tasks started failing with evaluate==0.4.3 (and reproducible with 0.4.4). The issue occurs inside the simple_accuracy function of the GLUE metric:
AttributeError: 'bool' object has no attribute 'mean'

The problem was observed when running MRPC evaluation with Habana trainer:
"path": "/root/optimum-habana-fork/examples/text-classification", "command": "PT_HPU_LAZY_MODE=1  python3 run_glue.py --task_name mrpc --learning_rate 3e-5 --max_seq_length 128 --output_dir ./output/mrpc/ --use_hpu_graphs_for_inference  --model_name_or_path bert-large-uncased-whole-word-masking --gaudi_config_name Habana/bert-large-uncased-whole-word-masking --do_eval  --per_device_eval_batch_size 8 --use_habana  --use_lazy_mode  --throughput_warmup_steps 3 --sdp_on_bf16 "

Upgrading to evaluate>=0.4.5 resolves the crash and restores correct metric computation.