### PR TITLE
Align evaluate version to 0.4.5 in question-answering requirements

### DIFF
--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,3 +1,3 @@
 datasets>=4.0.0
 torch >= 1.3.0
-evaluate == 0.4.3
+evaluate == 0.4.5


### PR DESCRIPTION
This PR updates the evaluate package version in
`examples/question-answering/requirements.txt` from 0.4.3 to 0.4.5
to align it with `examples/text-classification/requirements.txt`
on the master_next branch.

Background:
- The previous mismatch between 0.4.3 (QA) and 0.4.5 (Text Classification)
  caused dependency conflicts in CI:
  `Cannot install evaluate==0.4.3 and evaluate==0.4.5`.

Changes:
- Updated evaluate==0.4.3 → evaluate==0.4.5 in question-answering requirements.
- No functional code changes, only dependency alignment.

This resolves the version conflict reported in the
`Test_pytorch_training_tests_gaudi2_asic_8cards_topology_8cards_master_next`
job and ensures consistent dependency management across examples.