### PR TITLE
[wav2vec2] Bring back gaudi fused sdpa attention

### DIFF
--- a/examples/audio-classification/README.md
+++ b/examples/audio-classification/README.md
@@ -59,7 +59,7 @@ PT_HPU_LAZY_MODE=1 python run_audio_classification.py \
     --sdp_on_bf16 \
     --bf16 \
     --trust_remote_code True \
-    --attn_implementation sdpa
+    --attn_implementation gaudi_fused_sdpa
 ```
 
 On a single HPU, this script should run in ~13 minutes and yield an accuracy of **97.96%**.
@@ -100,7 +100,7 @@ python ../gaudi_spawn.py \
     --trust_remote_code True \
     --torch_compile \
     --torch_compile_backend hpu_backend \
-    --attn_implementation sdpa
+    --attn_implementation gaudi_fused_sdpa
 ```
 
 On 8 HPUs, this script should run in ~12 minutes and yield an accuracy of **80.49%**.

--- a/examples/audio-classification/run_audio_classification.py
+++ b/examples/audio-classification/run_audio_classification.py
@@ -180,33 +180,6 @@ class ModelArguments:
         default=False,
         metadata={"help": "Will enable to load a pretrained model whose head dimensions are different."},
     )
-    use_flash_attention: bool = field(
-        default=False, metadata={"help": "Whether to use Habana flash attention for fine-tuning"}
-    )
-    flash_attention_recompute: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to enable recompute in Habana flash attention for fine-tuning."
-            " It is applicable only when use_flash_attention is True."
-        },
-    )
-    flash_attention_fast_softmax: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use fast softmax for Habana flash attention."
-            " It is applicable only when use_flash_attention is True."
-        },
-    )
-
-    def __post_init__(self):
-        if self.use_flash_attention:
-            os.environ["USE_FLASH_ATTENTION"] = "1"
-        if self.flash_attention_recompute:
-            assert self.use_flash_attention, "flash_attention_recompute is set, but use_flash_attention is not"
-            os.environ["FLASH_ATTENTION_RECOMPUTE"] = "1"
-        if self.flash_attention_fast_softmax:
-            assert self.use_flash_attention, "flash_attention_fast_softmax is set, but use_flash_attention is not"
-            os.environ["FLASH_ATTENTION_FAST_SOFTMAX"] = "1"
 
 
 def main():

--- a/examples/speech-recognition/README.md
+++ b/examples/speech-recognition/README.md
@@ -89,7 +89,7 @@ PT_HPU_LAZY_MODE=1 python run_speech_recognition_ctc.py \
     --bf16 \
     --use_hpu_graphs_for_training \
     --use_hpu_graphs_for_inference \
-    --attn_implementation sdpa \
+    --attn_implementation gaudi_fused_sdpa \
     --trust_remote_code True
 ```
 
@@ -133,7 +133,7 @@ PT_HPU_LAZY_MODE=1 python ../gaudi_spawn.py \
     --sdp_on_bf16 \
     --use_hpu_graphs_for_training \
     --use_hpu_graphs_for_inference \
-    --attn_implementation sdpa \
+    --attn_implementation gaudi_fused_sdpa \
     --trust_remote_code True
 ```
 
@@ -184,7 +184,7 @@ PT_HPU_LAZY_MODE=1 python ../gaudi_spawn.py \
     --throughput_warmup_steps 3 \
     --deepspeed ../../tests/configs/deepspeed_zero_2.json \
     --sdp_on_bf16 \
-    --attn_implementation sdpa \
+    --attn_implementation gaudi_fused_sdpa \
     --trust_remote_code True
 ```
 

--- a/examples/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/speech-recognition/run_speech_recognition_ctc.py
@@ -153,33 +153,6 @@ class ModelArguments:
             "useful to downsample the output length."
         },
     )
-    use_flash_attention: bool = field(
-        default=False, metadata={"help": "Whether to use Habana flash attention for fine-tuning"}
-    )
-    flash_attention_recompute: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to enable recompute in Habana flash attention for fine-tuning."
-            " It is applicable only when use_flash_attention is True."
-        },
-    )
-    flash_attention_fast_softmax: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use fast softmax for Habana flash attention."
-            " It is applicable only when use_flash_attention is True."
-        },
-    )
-
-    def __post_init__(self):
-        if self.use_flash_attention:
-            os.environ["USE_FLASH_ATTENTION"] = "1"
-        if self.flash_attention_recompute:
-            assert self.use_flash_attention, "flash_attention_recompute is set, but use_flash_attention is not"
-            os.environ["FLASH_ATTENTION_RECOMPUTE"] = "1"
-        if self.flash_attention_fast_softmax:
-            assert self.use_flash_attention, "flash_attention_fast_softmax is set, but use_flash_attention is not"
-            os.environ["FLASH_ATTENTION_FAST_SOFTMAX"] = "1"
 
 
 @dataclass
@@ -660,6 +633,7 @@ def main():
         config=config,
         token=data_args.token,
         trust_remote_code=data_args.trust_remote_code,
+        attn_implementation=training_args.attn_implementation,
     )
 
     # freeze encoder

--- a/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
+++ b/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
@@ -1,0 +1,49 @@
+import os
+from typing import Optional
+
+import torch
+from habana_frameworks.torch.hpex.kernels import FusedSDPA
+
+
+def gaudi_fused_sdpa_attention_forward(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    is_causal: Optional[bool] = None,
+    **kwargs,
+) -> tuple[torch.Tensor, None]:
+    bsz, num_heads, tgt_len, head_dim = query.shape
+
+    if tgt_len == 1:
+        # next token
+        softmax_mode = True if os.getenv("QUANT_CONFIG", "") else False
+        recompute_mode = False
+    else:
+        # first token
+        softmax_mode = "fast" if os.getenv("FLASH_ATTENTION_FAST_SOFTMAX") == "1" else "None"
+        recompute_mode = True if os.getenv("FLASH_ATTENTION_RECOMPUTE") == "1" else False
+
+    attn_output = FusedSDPA.apply(
+        query,
+        key,
+        value,
+        attention_mask,
+        dropout,
+        is_causal,
+        None,
+        softmax_mode,
+        recompute_mode,
+    )
+
+    if attn_output.size() != (bsz, num_heads, tgt_len, head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size {(bsz, num_heads, tgt_len, head_dim)}, but is {attn_output.size()}"
+        )
+
+    attn_output = attn_output.transpose(1, 2)
+
+    return attn_output, None

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -17,6 +17,7 @@ import os
 
 import transformers
 import transformers.utils.fx
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
 from .generation import (
     GaudiGenerationConfig,
@@ -34,6 +35,7 @@ from .integrations.awq import (
     gaudi_awq_quantizer_validate_environment,
 )
 from .integrations.finegrained_fp8 import GaudiFP8Linear
+from .integrations.gaudi_fused_sdpa_attention import gaudi_fused_sdpa_attention_forward
 from .loss import gaudi_RTDetrHungarianMatcher_forward
 from .models import (
     ArcticConfig,
@@ -342,6 +344,7 @@ def adapt_transformers_to_gaudi():
     Replaces some Transformers' methods for equivalent methods optimized
     for Gaudi.
     """
+    ALL_ATTENTION_FUNCTIONS.register("gaudi_fused_sdpa", gaudi_fused_sdpa_attention_forward)
 
     # models that support symbolic tracing should be added to this list
     models_with_tracing_support = []

--- a/optimum/habana/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/optimum/habana/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -37,12 +37,6 @@ except ImportError:
     print("Could not import Custom CTCLoss kernel. This Kernel is available only for SynapseAI >= 1.15.0")
     custom_ctc_loss_fwd = None
 
-try:
-    from habana_frameworks.torch.hpex.kernels import FusedSDPA
-except ImportError:
-    print("Not using HPU fused scaled dot-product attention kernel.")
-    FusedSDPA = None
-
 
 def _gaudi_wav2vec2_compute_mask_indices(
     shape: tuple[int, int],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -556,7 +556,7 @@ class ExampleTestMeta(type):
             if self.EXAMPLE_NAME == "run_audio_classification":
                 extra_command_line_arguments.append("--sdp_on_bf16")
                 if "wav2vec2" in model_name:
-                    extra_command_line_arguments.append("--attn_implementation sdpa")
+                    extra_command_line_arguments.append("--attn_implementation gaudi_fused_sdpa")
 
             if self.EXAMPLE_NAME == "run_image_classification":
                 extra_command_line_arguments.append("--sdp_on_bf16")
@@ -580,7 +580,7 @@ class ExampleTestMeta(type):
             if self.EXAMPLE_NAME == "run_speech_recognition_ctc":
                 if "wav2vec2" in model_name:
                     extra_command_line_arguments.append("--sdp_on_bf16")
-                    extra_command_line_arguments.append("--attn_implementation sdpa")
+                    extra_command_line_arguments.append("--attn_implementation gaudi_fused_sdpa")
 
             if self.EXAMPLE_NAME == "run_clip":
                 extra_command_line_arguments.append("--sdp_on_bf16")


### PR DESCRIPTION
One of the previous commits (https://github.com/huggingface/optimum-habana/pull/2248/commits/8cae0696885df7df9c37d3941cd0dff33bbf4eff) removed fused sdpa attention from wav2vec2, b/c it seemed like it wasn't used. This caused a performance drop in speech-recognition and audio-classification examples, as they defaulted to sdpa attention.

This PR brings back the attention implementation in alignment with the new attention mechanism introduced in transformers 4.55.