### PR TITLE
Improve perf for torch.compile scenarios

### DIFF
--- a/optimum/habana/transformers/modeling_attn_mask_utils.py
+++ b/optimum/habana/transformers/modeling_attn_mask_utils.py
@@ -145,7 +145,7 @@ class GaudiAttentionMaskConverter(AttentionMaskConverter):
 
         expanded_mask = mask[:, None, None, :].expand(bsz, 1, tgt_len, src_len).to(dtype)
 
-        inverted_mask = torch.tensor(1.0, dtype=dtype, device=mask.device) - expanded_mask
+        inverted_mask = 1.0 - expanded_mask
 
         return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)
 


### PR DESCRIPTION
This change addresses a performance regression in torch.compile workflows caused by the creation of a new tensor (torch.tensor(1.0)) within the _expand_mask function. In torch.compile mode, this dynamic tensor instantiation led to _expand_mask being treated as re-compilable on every invocation, significantly degrading performance.
By replacing the dynamic tensor creation with a static scalar (1.0), we prevent unnecessary recompilation, restoring expected performance levels in compiled execution paths.