### PR TITLE
Switch Matthijs/cmu-arctic-xvectors to regisss/cmu-arctic-xvectors (Parquet version)

### DIFF
--- a/examples/text-to-speech/run_pipeline.py
+++ b/examples/text-to-speech/run_pipeline.py
@@ -97,7 +97,7 @@ def main():
 
     forward_params = None
     if generator.model.config.model_type == "speecht5":
-        embeddings_dataset = load_dataset("Matthijs/cmu-arctic-xvectors", split="validation")
+        embeddings_dataset = load_dataset("regisss/cmu-arctic-xvectors", split="validation")
         speaker_embedding = torch.tensor(embeddings_dataset[7306]["xvector"]).unsqueeze(0).to("hpu")
         forward_params = {"speaker_embeddings": speaker_embedding}
     if generator.model.config.model_type == "seamless_m4t":

--- a/optimum/habana/transformers/models/speecht5/modeling_speecht5.py
+++ b/optimum/habana/transformers/models/speecht5/modeling_speecht5.py
@@ -379,7 +379,7 @@ def gaudi_generate_speech(
         raise ValueError(
             """`speaker_embeddings` must be specified. For example, you can use a speaker embeddings by following
                     the code snippet provided in this link:
-                    https://huggingface.co/datasets/Matthijs/cmu-arctic-xvectors
+                    https://huggingface.co/datasets/regisss/cmu-arctic-xvectors
                     """
         )
     from habana_frameworks.torch.hpu import wrap_in_hpu_graph

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,7 +79,7 @@ class TestGaudiPipeline:
             )
             forward_params = None
             if generator.model.config.model_type == "speecht5":
-                embeddings_dataset = load_dataset("Matthijs/cmu-arctic-xvectors", split="validation")
+                embeddings_dataset = load_dataset("regisss/cmu-arctic-xvectors", split="validation")
                 speaker_embedding = torch.tensor(embeddings_dataset[7306]["xvector"]).unsqueeze(0).to("hpu")
                 forward_params = {"speaker_embeddings": speaker_embedding}
             if generator.model.config.model_type == "seamless_m4t":


### PR DESCRIPTION
This PR updates the dataset reference used in SpeechT5-related pipelines and tests from Matthijs/cmu-arctic-xvectors to regisss/cmu-arctic-xvectors.

The new dataset is a Parquet-based equivalent of the original one, containing the same CMU Arctic x-vector data but stored in the Parquet format compatible with datasets>=4.0.0.
No other logic, model, or configuration changes were introduced.