### PR TITLE
Skip MiniCPM3-4B model tests, as it doesn't currently work with new Transformers version, even in HF.

### DIFF
--- a/tests/test_text_generation_example.py
+++ b/tests/test_text_generation_example.py
@@ -64,7 +64,16 @@ if OH_DEVICE_CONTEXT not in ["gaudi1"]:
             # ("facebook/xglm-1.7B", 1, False, False, False),
             # ("CohereForAI/c4ai-command-r-v01", 1, False, False, False),
             ("tiiuae/falcon-mamba-7b", 1, False, False, False),
-            ("openbmb/MiniCPM3-4B", 1, False, False, False),
+            pytest.param(
+                "openbmb/MiniCPM3-4B",
+                1,
+                False,
+                False,
+                False,
+                marks=pytest.mark.skip(
+                    "Original Huggingface model is incompatible with newer Transformers version. https://huggingface.co/openbmb/MiniCPM3-4B/tree/d6b14ddaefdb11c624dd75c3c779549bc90b08cb"
+                ),
+            ),
             ("baichuan-inc/Baichuan2-7B-Chat", 1, True, False, False),
             ("baichuan-inc/Baichuan2-13B-Chat", 1, False, False, False),
             ("deepseek-ai/DeepSeek-V2-Lite", 1, False, False, False),


### PR DESCRIPTION
# What does this PR do?

Skip MiniCPM3-4B model tests in text generation, which was broken due to cache API changes in Transformers.
Official model site in HF lack support for new cache interface. Last update was for Transformers v4.49.0: [here](https://huggingface.co/openbmb/MiniCPM3-4B/tree/d6b14ddaefdb11c624dd75c3c779549bc90b08cb)
