### PR TITLE
Fix `run_clm.py` for streaming datasets

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -766,7 +766,7 @@ def main():
         metrics = trainer.evaluate()
 
         if data_args.streaming:
-            metrics["eval_samples"] = max_eval_samples
+            metrics["eval_samples"] = training_args.max_steps * training_args.per_device_eval_batch_size
         else:
             max_eval_samples = (
                 data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)


### PR DESCRIPTION
# What does this PR do?

The variable `max_eval_samples` in L769 was referenced before assignment. This commit fixes the computation of `eval_samples` for the metrics report by computing it in a similar way as for the training split.

Note:
- bug introduced during Transformers 4.55 upgrade
- applies only to scenarios with `--streaming` enabled
