### PR TITLE
Enable Int64 support for trl-sft workload.

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -532,6 +532,9 @@ class ExampleTestMeta(type):
                 if "--use_hpu_graphs_for_inference" in extra_command_line_arguments:
                     extra_command_line_arguments.remove("--use_hpu_graphs_for_inference")
 
+            if self.TASK_NAME == "trl-sft":
+                env_variables["PT_ENABLE_INT64_SUPPORT"] = "1"
+
             extra_command_line_arguments += self._get_dataset_args()
 
             if torch_compile and (


### PR DESCRIPTION
# What does this PR do?

# Draft Only

This PR enables Int64 support when running trl-sft tasks in tests, to avoid downcasting to Int32, which in this case results in overflow and err execution.

When this flag is set, though, execution hangs indefinitely. That's why it's a draft.