### PR TITLE
Remove repeating flash_attention options.

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -391,7 +391,7 @@ PT_TE_CUSTOM_OP=1 PT_HPU_LAZY_MODE=0 python ../gaudi_spawn.py \
     --torch_compile_backend hpu_backend \
     --torch_compile \
     --fp8 \
-    --use_flash_attention True \
+    --attn_implementation gaudi_fused_sdpa \
     --flash_attention_causal_mask True  \
     --per_device_eval_batch_size 4  \
     --cache_size_limit 64 \
@@ -435,7 +435,7 @@ python3 ../gaudi_spawn.py --use_deepspeed --world_size 8 run_lora_clm.py \
   --lora_rank 4 \
   --lora_target_modules "q_proj" "v_proj" "k_proj" "o_proj" \
   --validation_split_percentage 4 \
-  --use_flash_attention True \
+  --attn_implementation gaudi_fused_sdpa \
   --flash_attention_causal_mask True \
   --fp8 True
 ```
@@ -478,7 +478,7 @@ python3 ../gaudi_spawn.py --world_size 8 --use_mpi run_lora_clm.py \
   --torch_compile_backend hpu_backend \
   --torch_compile \
   --gradient_accumulation_steps 2 \
-  --use_flash_attention True \
+  --attn_implementation gaudi_fused_sdpa \
   --flash_attention_causal_mask True
 ```
 
@@ -647,7 +647,7 @@ PT_HPU_LAZY_MODE=1 python3 ../gaudi_spawn.py  \
         --eval_strategy epoch \
         --pipelining_fwd_bwd \
         --use_lazy_mode \
-        --use_flash_attention True \
+        --attn_implementation gaudi_fused_sdpa \
         --deepspeed llama3_ds_zero1_config.json \
         --num_train_epochs 3 \
         --eval_delay 3 \

--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -395,8 +395,23 @@ class GaudiTrainingArguments(TrainingArguments):
         default=False,
         metadata={
             "help": "Whether to use fast softmax for Habana flash attention."
-            " It is applicable only when  --attn_implementation gaudi_fused_sdpa."
+            " It is applicable only when --attn_implementation gaudi_fused_sdpa."
         },
+    )
+
+    flash_attention_causal_mask: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to enable causal mask in Habana flash attention for fine-tuning."
+                " It is applicable only when --attn_implementation gaudi_fused_sdpa."
+            )
+        },
+    )
+
+    flash_attention_fp8: bool = field(
+        default=False,
+        metadata={"help": ("Whether to enable flash attention in FP8.")},
     )
 
     sdp_on_bf16: bool = field(
@@ -942,6 +957,14 @@ class GaudiTrainingArguments(TrainingArguments):
                 "flash_attention_fast_softmax works only with --attn_implementation gaudi_fused_sdpa"
             )
             os.environ["FLASH_ATTENTION_FAST_SOFTMAX"] = "1"
+        if self.flash_attention_causal_mask:
+            assert self.attn_implementation == "gaudi_fused_sdpa", (
+                "flash_attention_causal_mask works only with --attn_implementation gaudi_fused_sdpa"
+            )
+        if self.flash_attention_fp8:
+            assert self.attn_implementation == "gaudi_fused_sdpa", (
+                "flash_attention_causal_mask works only with --attn_implementation gaudi_fused_sdpa"
+            )
 
     def __str__(self):
         self_as_dict = asdict(self)


### PR DESCRIPTION
Some flash attention options were duplicated in training args and in run_lora_clm script which caused an ArgumentError.

This is a quick fix to remove the error. A broader unification of the arguments would be nice later.
