### PR TITLE
Disable image processor loading for `THUDM/glm-4v-9b`

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -893,6 +893,7 @@ def adapt_transformers_to_gaudi():
         transformers.AutoModelForSeq2SeqLM.register(GLM4VConfig, GLM4VForConditionalGeneration)
         transformers.AutoModelForVision2Seq.register(GLM4VConfig, GLM4VForConditionalGeneration)
         transformers.AutoModelForSequenceClassification.register(GLM4VConfig, GLM4VForSequenceClassification)
+        transformers.pipelines.image_to_text.ImageToTextPipeline._load_image_processor = False
     else:
         # Register chatglm with optimization on Gaudi
         transformers.AutoConfig.register("chatglm", ChatGLMConfig)


### PR DESCRIPTION
# What does this PR do?

After the Transformers 4.51->4.55 upgrade, the `pipeline(...)` function was completely refactored [1]. The logic related to loading individual components of a given pipeline was also updated. Now, despite setting the `image_processor=None` argument, when dealing with the `chatglm` model, the code in the `pipeline(...)` will still try to load the image processor, which fails eventually (`chatglm` does not have an image processor class). To fix that, this commit overrides the `ImageToTextPipeline._load_image_processor` property to `False`.

[1] https://github.com/huggingface/transformers/commit/3d8be20cd2f76aa03d3f42808f2c9b36c94608b3

