### PR TITLE
Fix for visual-question-answering example

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -335,7 +335,6 @@ from .models import (
     gaudi_XLMRoberta_Sdpa_SelfAttention_forward,
 )
 from .models.deepseek_v2.modeling_deepseek_v2 import DeepseekV2ForCausalLM as GaudiDeepseekV2ForCausalLM
-from .pipelines import GaudiImageToTextPipeline
 from .quantizers.quantizer_finegrained_fp8 import GaudiFineGrainedFP8HfQuantizer
 
 
@@ -417,8 +416,13 @@ def adapt_transformers_to_gaudi():
     transformers.generation.MaxTimeCriteria.__call__ = gaudi_MaxTimeCriteria_call
     transformers.generation.EosTokenCriteria.__call__ = gaudi_EosTokenCriteria_call
     transformers.generation.StoppingCriteriaList.__call__ = gaudi_StoppingCriteriaList_call
-    transformers.pipelines.image_to_text.ImageToTextPipeline._default_generation_config = (
-        GaudiImageToTextPipeline._default_generation_config
+    transformers.pipelines.image_to_text.ImageToTextPipeline._default_generation_config = GaudiGenerationConfig(
+        max_new_tokens=256,
+    )
+    transformers.pipelines.visual_question_answering.VisualQuestionAnsweringPipeline._default_generation_config = (
+        GaudiGenerationConfig(
+            max_new_tokens=256,
+        )
     )
 
     # Optimization for BLOOM generation on Gaudi

--- a/optimum/habana/transformers/pipelines/__init__.py
+++ b/optimum/habana/transformers/pipelines/__init__.py
@@ -1,1 +1,0 @@
-from .image_to_text import GaudiImageToTextPipeline

--- a/optimum/habana/transformers/pipelines/image_to_text.py
+++ b/optimum/habana/transformers/pipelines/image_to_text.py
@@ -1,9 +1,0 @@
-from transformers.pipelines.image_to_text import ImageToTextPipeline
-
-from ..generation import GaudiGenerationConfig
-
-
-class GaudiImageToTextPipeline(ImageToTextPipeline):
-    _default_generation_config = GaudiGenerationConfig(
-        max_new_tokens=256,
-    )


### PR DESCRIPTION
After transformers upgrade, Gaudi Pipelines need to have `_default_generation_config` attribute set to load `GaudiGenerationConfig` instead of `GenerationConfig`. This PR sets the attribute in modeling_utils

It also simplifies the previous solution: https://github.com/huggingface/optimum-habana/pull/2266