### PR TITLE
Align MLlama code with Transformers 4.55

### DIFF
--- a/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
+++ b/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
@@ -18,13 +18,13 @@ def gaudi_fused_sdpa_attention_forward(
 ) -> tuple[torch.Tensor, None]:
     bsz, num_heads, tgt_len, head_dim = query.shape
 
+    softmax_mode = "fast" if os.getenv("FLASH_ATTENTION_FAST_SOFTMAX") == "1" else "None"
+
     if tgt_len == 1:
         # next token
-        softmax_mode = True if os.getenv("QUANT_CONFIG", "") else False
-        recompute_mode = False
+        recompute_mode = True if os.getenv("QUANT_CONFIG", "") else False
     else:
         # first token
-        softmax_mode = "fast" if os.getenv("FLASH_ATTENTION_FAST_SOFTMAX") == "1" else "None"
         recompute_mode = True if os.getenv("FLASH_ATTENTION_RECOMPUTE") == "1" else False
 
     attn_output = FusedSDPA.apply(

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -138,9 +138,7 @@ from .models import (
     GaudiMllamaTextModel,
     GaudiMllamaTextSelfAttention,
     GaudiMllamaVisionEncoder,
-    GaudiMllamaVisionEncoderLayer,
     GaudiMllamaVisionModel,
-    GaudiMllamaVisionSdpaAttention,
     GaudiMptAttention,
     GaudiMptBlock,
     GaudiMptForCausalLM,
@@ -835,19 +833,18 @@ def adapt_transformers_to_gaudi():
     transformers.models.whisper.modeling_whisper.WhisperForConditionalGeneration = GaudiWhisperForConditionalGeneration
 
     # Optimization for mllama on Gaudi
-    transformers.models.mllama.modeling_mllama.MllamaSelfAttentionDecoderLayer = GaudiMllamaSelfAttentionDecoderLayer
     transformers.models.mllama.modeling_mllama.MllamaCrossAttentionDecoderLayer = GaudiMllamaCrossAttentionDecoderLayer
     transformers.models.mllama.modeling_mllama.MllamaForCausalLM = GaudiMllamaForCausalLM
-    transformers.models.mllama.modeling_mllama.MllamaTextSelfAttention = GaudiMllamaTextSelfAttention
-    transformers.models.mllama.modeling_mllama.MllamaTextCrossAttention = GaudiMllamaTextCrossAttention
     transformers.models.mllama.modeling_mllama.MllamaForConditionalGeneration = GaudiMllamaForConditionalGeneration
-    transformers.models.mllama.modeling_mllama.MllamaTextModel = GaudiMllamaTextModel
-    transformers.models.mllama.modeling_mllama.MllamaVisionModel = GaudiMllamaVisionModel
-    transformers.models.mllama.modeling_mllama.MllamaVisionEncoder = GaudiMllamaVisionEncoder
-    transformers.models.mllama.modeling_mllama.MllamaVisionEncoderLayer = GaudiMllamaVisionEncoderLayer
-    transformers.models.mllama.modeling_mllama.MllamaVisionSdpaAttention = GaudiMllamaVisionSdpaAttention
     transformers.models.mllama.modeling_mllama.MllamaModel = GaudiMllamaModel
+    transformers.models.mllama.modeling_mllama.MllamaSelfAttentionDecoderLayer = GaudiMllamaSelfAttentionDecoderLayer
+    transformers.models.mllama.modeling_mllama.MllamaTextCrossAttention = GaudiMllamaTextCrossAttention
+    transformers.models.mllama.modeling_mllama.MllamaTextModel = GaudiMllamaTextModel
+    transformers.models.mllama.modeling_mllama.MllamaTextSelfAttention = GaudiMllamaTextSelfAttention
+    transformers.models.mllama.modeling_mllama.MllamaVisionEncoder = GaudiMllamaVisionEncoder
+    transformers.models.mllama.modeling_mllama.MllamaVisionModel = GaudiMllamaVisionModel
 
+    # Optimization for deciLM on Gaudi
     transformers.AutoConfig.register("deci", DeciLMConfig)
     transformers.AutoModelForCausalLM.register(DeciLMConfig, DeciLMForCausalLM)
 

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -226,9 +226,7 @@ from .mllama import (
     GaudiMllamaTextModel,
     GaudiMllamaTextSelfAttention,
     GaudiMllamaVisionEncoder,
-    GaudiMllamaVisionEncoderLayer,
     GaudiMllamaVisionModel,
-    GaudiMllamaVisionSdpaAttention,
 )
 from .modeling_all_models import (
     KVCache,

--- a/optimum/habana/transformers/models/mllama/__init__.py
+++ b/optimum/habana/transformers/models/mllama/__init__.py
@@ -8,7 +8,5 @@ from .modeling_mllama import (
     GaudiMllamaTextModel,
     GaudiMllamaTextSelfAttention,
     GaudiMllamaVisionEncoder,
-    GaudiMllamaVisionEncoderLayer,
     GaudiMllamaVisionModel,
-    GaudiMllamaVisionSdpaAttention,
 )


### PR DESCRIPTION
# What does this PR do?

After the Transformers 4.55 update, one of the attention classes failed to compute the attention scores due to mismatches between arguments in the `torch.matmul` op. This commits updates the whole `Mllama` code base to be fully aligned with the code in Transformers 4.55. In particular, it uses the `_attn_implementation` instead of custom classes.