### PR TITLE
Align distributed_runner with openmpi 5.0

### DIFF
--- a/optimum/habana/distributed/distributed_runner.py
+++ b/optimum/habana/distributed/distributed_runner.py
@@ -161,7 +161,7 @@ class DistributedRunner:
 
         mpi_cmd = self.setup_config_env_mpirun()
         self._interpreter = (
-            f"mpirun -n {self._world_size} --bind-to core {mpi_cmd} --rank-by core --report-bindings"
+            f"mpirun -n {self._world_size} --bind-to core {mpi_cmd} --rank-by slot --report-bindings"
             f" --allow-run-as-root {sys.executable} "
         )
 


### PR DESCRIPTION
This pull request updates the distributed_runner.py script within the optimum-habana repository to align with OpenMPI 5.0 standards. The key change involves modifying the mpirun command configuration to use --rank-by slot instead of --rank-by core.