### PR TITLE
Upgrade Whisper Gaudi integration for Transformers 4.55 and migrate dataset to regisss/common_voice_11_0_hi (datasets 4.0.0)

### DIFF
--- a/examples/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/speech-recognition/run_speech_recognition_seq2seq.py
@@ -18,6 +18,7 @@ Fine-tuning the library models for sequence to sequence speech recognition.
 # You can also adapt this script on your own sequence to sequence speech
 # recognition task. Pointers for this are left as comments.
 
+import io
 import logging
 import os
 import sys
@@ -26,9 +27,11 @@ from typing import Any, Optional, Union
 
 import datasets
 import evaluate
+import librosa
+import soundfile as sf
 import torch
 import transformers
-from datasets import DatasetDict, load_dataset
+from datasets import Audio, DatasetDict, load_dataset
 from transformers import (
     AutoConfig,
     AutoFeatureExtractor,
@@ -60,6 +63,9 @@ check_optimum_habana_min_version("1.19.0.dev0")
 require_version("datasets>=4.0.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
 
 logger = logging.getLogger(__name__)
+
+# Disable torchcodec decoding in datasets before any dataset ops
+os.environ.setdefault("HF_DATASETS_DISABLE_TORCHCODEC", "1")
 
 
 @dataclass
@@ -421,6 +427,10 @@ def main():
         token=model_args.token,
         trust_remote_code=model_args.trust_remote_code,
     )
+    raw_datasets = raw_datasets.cast_column(
+        data_args.audio_column_name, Audio(sampling_rate=feature_extractor.sampling_rate, decode=False)
+    )
+
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path,
         cache_dir=model_args.cache_dir,
@@ -510,20 +520,47 @@ def main():
         raw_datasets["eval"] = raw_datasets["eval"].select(range(data_args.max_eval_samples))
 
     def prepare_dataset(batch):
-        # process audio
         sample = batch[audio_column_name]
-        inputs = feature_extractor(
-            sample["array"], sampling_rate=sample["sampling_rate"], return_attention_mask=forward_attention_mask
-        )
-        # process audio length
-        batch[model_input_name] = inputs.get(model_input_name)[0]
-        batch["input_length"] = len(sample["array"])
-        if forward_attention_mask:
-            batch["attention_mask"] = inputs.get("attention_mask")[0]
+        path = sample.get("path", None)
+        wav, sr = None, None
 
-        # process targets
-        input_str = batch[text_column_name].lower() if do_lower_case else batch[text_column_name]
-        batch["labels"] = tokenizer(input_str).input_ids
+        # Try to load from file path
+        if isinstance(path, str):
+            try:
+                wav, sr = sf.read(path, dtype="float32", always_2d=False)
+            except Exception:
+                try:
+                    wav, sr = librosa.load(path, sr=None, mono=False)
+                except Exception:
+                    wav, sr = None, None
+
+        # Fallback: load from bytes if available
+        if wav is None:
+            raw = sample.get("bytes", None)
+            if raw is None:
+                raise RuntimeError(f"Cannot open audio sample {sample}")
+            wav, sr = sf.read(io.BytesIO(raw), dtype="float32", always_2d=False)
+
+        # Convert to mono
+        if getattr(wav, "ndim", 1) > 1:
+            wav = wav.mean(axis=1)
+
+        # Resample if necessary
+        target_sr = feature_extractor.sampling_rate
+        if sr != target_sr:
+            wav = librosa.resample(wav, orig_sr=sr, target_sr=target_sr)
+            sr = target_sr
+
+        inputs = feature_extractor(wav, sampling_rate=sr)
+        batch[model_input_name] = inputs.input_features[0]
+        batch["input_length"] = len(wav)
+
+        if text_column_name in batch:
+            text = batch[text_column_name]
+            if do_lower_case and isinstance(text, str):
+                text = text.lower()
+            batch["labels"] = tokenizer(text).input_ids
+
         return batch
 
     with training_args.main_process_first(desc="dataset map pre-processing"):

--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -212,11 +212,11 @@ from .models import (
     GaudiT5ForConditionalGeneration,
     GaudiVideoLlavaForConditionalGeneration,
     GaudiVisionSdpaAttention,
+    GaudiWhisperAttention,
     GaudiWhisperDecoder,
     GaudiWhisperDecoderLayer,
     GaudiWhisperForConditionalGeneration,
     GaudiWhisperModel,
-    GaudiWhisperSdpaAttention,
     GaudiXGLMForCausalLM,
     GLM4VConfig,
     GLM4VForConditionalGeneration,
@@ -832,7 +832,7 @@ def adapt_transformers_to_gaudi():
     )
 
     # Optimization for Whisper on Gaudi
-    transformers.models.whisper.modeling_whisper.WhisperAttention = GaudiWhisperSdpaAttention
+    transformers.models.whisper.modeling_whisper.WhisperAttention = GaudiWhisperAttention
     transformers.models.whisper.modeling_whisper.WhisperDecoderLayer = GaudiWhisperDecoderLayer
     transformers.models.whisper.modeling_whisper.WhisperDecoder = GaudiWhisperDecoder
     transformers.models.whisper.modeling_whisper.WhisperModel = GaudiWhisperModel

--- a/optimum/habana/transformers/models/__init__.py
+++ b/optimum/habana/transformers/models/__init__.py
@@ -389,11 +389,11 @@ from .wav2vec2 import (
     gaudi_wav2vec2forctc_forward,
 )
 from .whisper import (
+    GaudiWhisperAttention,
     GaudiWhisperDecoder,
     GaudiWhisperDecoderLayer,
     GaudiWhisperForConditionalGeneration,
     GaudiWhisperModel,
-    GaudiWhisperSdpaAttention,
 )
 from .xglm import (
     GaudiXGLMForCausalLM,

--- a/optimum/habana/transformers/models/whisper/__init__.py
+++ b/optimum/habana/transformers/models/whisper/__init__.py
@@ -1,7 +1,7 @@
 from .modeling_whisper import (
+    GaudiWhisperAttention,
     GaudiWhisperDecoder,
     GaudiWhisperDecoderLayer,
     GaudiWhisperForConditionalGeneration,
     GaudiWhisperModel,
-    GaudiWhisperSdpaAttention,
 )


### PR DESCRIPTION
This PR upgrades the Whisper Gaudi implementation to ensure full compatibility with Transformers 4.55.0 and datasets 4.0.0, introducing necessary refactors for caching and dataset handling.

Model & Training Updates:

- Upgraded all Whisper model classes for compatibility with the new caching system introduced in Transformers 4.55:
- Fixed compatibility with new cache structure (DynamicLayer replacing DecoderLayerCache).
- Improved incremental decoding stability with token-level updates on HPU.

Dataset Migration

- Migrated dataset loading from legacy common_language to regisss/common_voice_11_0_hi, fully aligned with datasets>=4.0.0.
- Implemented Parquet-based loading, replacing the deprecated JSON schema.

Validation:
`PT_HPU_LAZY_MODE=1 python run_speech_recognition_seq2seq.py \
--model_name_or_path="openai/whisper-small" \
--dataset_name="regisss/common_voice_11_0_hi" \
--language="hindi" \
--task="transcribe" \
--eval_split_name="test" \
--gaudi_config_name="Habana/whisper" \
--output_dir="./results/whisper-small-clean" \
--per_device_eval_batch_size="32" \
--generation_max_length="225" \
--preprocessing_num_workers="1" \
--max_duration_in_seconds="30" \
--text_column_name="sentence" \
--freeze_feature_encoder="False" \
--sdp_on_bf16 \
--bf16 \
--overwrite_output_dir \
--do_eval \
--predict_with_generate \
--use_habana \
--use_hpu_graphs_for_inference \
--label_features_max_length 128 \
--dataloader_num_workers 8 \
--sdp_on_bf16`
