### PR TITLE
Fix device index parsing in accelerator

### DIFF
--- a/optimum/habana/accelerate/accelerator.py
+++ b/optimum/habana/accelerate/accelerator.py
@@ -223,11 +223,15 @@ class GaudiAccelerator(Accelerator):
                 )
             elif len(model_devices) == 1:
                 current_device = list(model_devices)[0]
-                current_device_index = (
-                    current_device.index if isinstance(current_device, torch.device) else current_device
-                )
 
-                if torch.device(current_device_index) != self.device:
+                if isinstance(current_device, torch.device):
+                    current_device_index = current_device.index
+                elif isinstance(current_device, str) and ":" in current_device:
+                    current_device_index = int(current_device.split(":")[1])
+                else:
+                    current_device_index = current_device
+
+                if torch.device(current_device) != self.device:
                     # if on the first device (GPU 0) we don't care
                     if (self.device.index is not None) or (current_device_index != 0):
                         raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Currently, if the current device is passed as a string, e.g., "hpu:0", the `current_device_index` is also set to the same string instead of the actual device index. This commit updates the parsing code to actually extract the device index from the string. Otherwise, the behaviour is left untouched.