### PR TITLE
GaudiTrainer: Take accuracy measurement outside of timer

### DIFF
--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -634,11 +634,13 @@ class GaudiStableDiffusionControlNetPipeline(GaudiDiffusionPipeline, StableDiffu
                     self.htcore.mark_step()
 
             hb_profiler.stop()
+            end_time = time.time()
 
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/controlnet/pipeline_stable_video_diffusion_controlnet.py
+++ b/optimum/habana/diffusers/pipelines/controlnet/pipeline_stable_video_diffusion_controlnet.py
@@ -534,10 +534,13 @@ class GaudiStableVideoDiffusionControlNetPipeline(GaudiStableVideoDiffusionPipel
 
                 outputs["frames"].append(frames)
 
+            end_time = time.time()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/optimum/habana/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -192,6 +192,8 @@ class GaudiDDPMPipeline(GaudiDiffusionPipeline, DDPMPipeline):
             if not self.use_hpu_graphs:  # For checking output resutls
                 self.htcore.mark_step()
 
+        end_time = time.time()
+
         if self.gaudi_config.use_torch_autocast:
             image = image.float()
 
@@ -204,6 +206,7 @@ class GaudiDDPMPipeline(GaudiDiffusionPipeline, DDPMPipeline):
         speed_measures = speed_metrics(
             split=speed_metrics_prefix,
             start_time=start_time,
+            end_time=end_time,
             num_samples=batch_size,
             num_steps=batch_size * len(num_inference_steps),
             start_time_after_warmup=time_after_warmup,

--- a/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
+++ b/optimum/habana/diffusers/pipelines/flux/pipeline_flux.py
@@ -583,12 +583,15 @@ class GaudiFluxPipeline(GaudiDiffusionPipeline, FluxPipeline):
             finalize_calibration(self.transformer)
 
         ht.hpu.synchronize()
+        end_time = time.time()
+
         speed_metrics_prefix = "generation"
         if use_warmup_inference_steps:
             t1 = warmup_inference_steps_time_adjustment(t1, t1, num_inference_steps, throughput_warmup_steps)
         speed_measures = speed_metrics(
             split=speed_metrics_prefix,
             start_time=t0,
+            end_time=end_time,
             num_samples=batch_size
             if t1 == t0 or use_warmup_inference_steps
             else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/flux/pipeline_flux_img2img.py
+++ b/optimum/habana/diffusers/pipelines/flux/pipeline_flux_img2img.py
@@ -615,12 +615,15 @@ class GaudiFluxImg2ImgPipeline(GaudiDiffusionPipeline, FluxImg2ImgPipeline):
             finalize_calibration(self.transformer)
 
         ht.hpu.synchronize()
+        end_time = time.time()
+
         speed_metrics_prefix = "generation"
         if use_warmup_inference_steps:
             t1 = warmup_inference_steps_time_adjustment(t1, t1, num_inference_steps, throughput_warmup_steps)
         speed_measures = speed_metrics(
             split=speed_metrics_prefix,
             start_time=t0,
+            end_time=end_time,
             num_samples=batch_size
             if t1 == t0 or use_warmup_inference_steps
             else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/i2vgen_xl/pipeline_i2vgen_xl.py
+++ b/optimum/habana/diffusers/pipelines/i2vgen_xl/pipeline_i2vgen_xl.py
@@ -624,11 +624,14 @@ class GaudiI2VGenXLPipeline(
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -596,6 +596,7 @@ class GaudiStableDiffusionPipeline(GaudiDiffusionPipeline, StableDiffusionPipeli
                     self.htcore.mark_step()
 
             hb_profiler.stop()
+            end_time = time.time()
 
             speed_metrics_prefix = "generation"
             if t1 == t0 or use_warmup_inference_steps:
@@ -608,6 +609,7 @@ class GaudiStableDiffusionPipeline(GaudiDiffusionPipeline, StableDiffusionPipeli
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_samples,
                 num_steps=num_steps,
                 start_time_after_warmup=t1,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
@@ -372,11 +372,14 @@ class GaudiStableDiffusionImageVariationPipeline(GaudiDiffusionPipeline, StableD
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -607,12 +607,14 @@ class GaudiStableDiffusionImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffusio
 
                 outputs["images"].append(image)
 
+            end_time = time.time()
             hb_profiler.stop()
 
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -708,6 +708,8 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
+
             # Remove dummy generations if needed
             if num_dummy_samples > 0:
                 outputs["images"][-1] = outputs["images"][-1][:-num_dummy_samples]
@@ -716,6 +718,7 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
@@ -491,11 +491,14 @@ class GaudiStableDiffusionInstructPix2PixPipeline(GaudiDiffusionPipeline, Stable
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_ldm3d.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_ldm3d.py
@@ -416,10 +416,13 @@ class GaudiStableDiffusionLDM3DPipeline(GaudiDiffusionPipeline, StableDiffusionL
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
@@ -543,10 +543,13 @@ class GaudiStableDiffusionUpscalePipeline(GaudiDiffusionPipeline, StableDiffusio
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -698,6 +698,7 @@ class GaudiStableDiffusion3Pipeline(GaudiDiffusionPipeline, StableDiffusion3Pipe
 
             # End of Denoising loop
 
+            end_time = time.time()
             hb_profiler.stop()
 
             ht.hpu.synchronize()
@@ -707,6 +708,7 @@ class GaudiStableDiffusion3Pipeline(GaudiDiffusionPipeline, StableDiffusion3Pipe
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -817,6 +817,7 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
 
             speed_metrics_prefix = "generation"
@@ -829,6 +830,7 @@ class GaudiStableDiffusionXLPipeline(GaudiDiffusionPipeline, StableDiffusionXLPi
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_samples,
                 num_steps=num_steps,
                 start_time_after_warmup=t1,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -667,12 +667,14 @@ class GaudiStableDiffusionXLImg2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
 
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -913,6 +913,8 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
+
             # Remove dummy generations if needed
             if num_dummy_samples > 0:
                 outputs["images"][-1] = outputs["images"][-1][:-num_dummy_samples]
@@ -921,6 +923,7 @@ class GaudiStableDiffusionXLInpaintPipeline(GaudiDiffusionPipeline, StableDiffus
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_mlperf.py
@@ -933,6 +933,7 @@ class StableDiffusionXLPipeline_HPU(StableDiffusionXLPipeline):
                 t_vae_e = time.time()
                 t1 = t1 + t_vae_e - t_vae_b
 
+        end_time = time.time()
         hb_profiler.stop()
 
         speed_metrics_prefix = "generation"
@@ -946,6 +947,7 @@ class StableDiffusionXLPipeline_HPU(StableDiffusionXLPipeline):
         speed_measures = speed_metrics(
             split=speed_metrics_prefix,
             start_time=t0,
+            end_time=end_time,
             num_samples=num_samples,
             num_steps=num_steps,
             start_time_after_warmup=t1,

--- a/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/optimum/habana/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -581,11 +581,14 @@ class GaudiStableVideoDiffusionPipeline(GaudiDiffusionPipeline, StableVideoDiffu
                 if not self.use_hpu_graphs:
                     self.htcore.mark_step()
 
+            end_time = time.time()
             hb_profiler.stop()
+
             speed_metrics_prefix = "generation"
             speed_measures = speed_metrics(
                 split=speed_metrics_prefix,
                 start_time=t0,
+                end_time=end_time,
                 num_samples=num_batches * batch_size
                 if t1 == t0 or use_warmup_inference_steps
                 else (num_batches - throughput_warmup_steps) * batch_size,

--- a/optimum/habana/utils/misc.py
+++ b/optimum/habana/utils/misc.py
@@ -66,6 +66,7 @@ def to_device_dtype(my_input: Any, target_device: torch.device = None, target_dt
 def speed_metrics(
     split: str,
     start_time: float,
+    end_time: float,
     num_samples: int = None,
     num_steps: int = None,
     num_tokens: int = None,
@@ -91,7 +92,7 @@ def speed_metrics(
         Dict[str, float]: dictionary with performance metrics.
     """
 
-    runtime = time.time() - start_time
+    runtime = end_time - start_time
     result = {f"{split}_runtime": round(runtime, 4)}
     if runtime == 0:
         return result


### PR DESCRIPTION
In GaudiTrainer, accuracy calculation happened between start_time and end_time, so its duration was included in calculating time for performance measurements.
It was negligible for datasets < 4.0.0, but with the new package, it takes much more time due to numpy array conversion deep in the scikit-learn library, causing incorrect perf reporting.
