### PR TITLE
Remove redundant arguments from trl/sft ScriptArguments.

### DIFF
--- a/examples/trl/sft.py
+++ b/examples/trl/sft.py
@@ -45,12 +45,6 @@ class ScriptArguments:
     use_flash_attention: Optional[bool] = field(
         default=False, metadata={"help": "Whether to use Habana flash attention for fine-tuning."}
     )
-    flash_attention_recompute: Optional[bool] = field(
-        default=False, metadata={"help": "Whether to enable recompute in Habana flash attention for fine-tuning."}
-    )
-    flash_attention_causal_mask: Optional[bool] = field(
-        default=False, metadata={"help": "Whether to enable causal mask in Habana flash attention for fine-tuning."}
-    )
 
     # LoraConfig
     lora_alpha: Optional[float] = field(default=16, metadata={"help": "the lora alpha parameter"})
@@ -159,13 +153,11 @@ if __name__ == "__main__":
     )
 
     base_model.config.use_cache = False
-    if not script_args.use_flash_attention and (
-        script_args.flash_attention_recompute or script_args.flash_attention_recompute
-    ):
+    if not script_args.use_flash_attention and training_args.flash_attention_recompute:
         assert "Need to enable use_flash_attention"
     base_model.generation_config.use_flash_attention = script_args.use_flash_attention
-    base_model.generation_config.flash_attention_recompute = script_args.flash_attention_recompute
-    base_model.generation_config.flash_attention_causal_mask = script_args.flash_attention_causal_mask
+    base_model.generation_config.flash_attention_recompute = training_args.flash_attention_recompute
+    base_model.generation_config.flash_attention_causal_mask = training_args.flash_attention_causal_mask
 
     if is_zero3_enabled and training_args.use_zero3_leaf_promotion:
         apply_zero3_leaf_promotion(base_model)


### PR DESCRIPTION
# What does this PR do?

In a recent PR https://github.com/huggingface/optimum-habana/pull/2312 there was a change that removed repeated flash_attention arguments, but trl/sft.py script was omitted, leading to failures when initiating argparser.
This commit removes leftover declarations of args in this script.