### PR TITLE
Fix `.reshape(...)` in `GaudiCLIPAttention`

### DIFF
--- a/optimum/habana/transformers/models/clip/modeling_clip.py
+++ b/optimum/habana/transformers/models/clip/modeling_clip.py
@@ -132,10 +132,8 @@ class GaudiCLIPAttention(CLIPAttention):
 
             attn_output = self.bmm2(attn_weights, values)
 
-        # attn_output = attn_output.view(bsz, self.num_heads, tgt_len, self.head_dim)
         attn_output = attn_output.transpose(1, 2).contiguous()
-
-        attn_output = attn_output.reshape(batch_size, seq_length, embed_dim).contiguous()
+        attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.out_proj(attn_output)
 
         if not output_attentions:


### PR DESCRIPTION
# What does this PR do?

When using deepspeed parallelization the `attn_output` shape is smaller than expected by one of the reshape operations [1]. This commit fixes this issue by loosening the size assumption of the last tensor dimension, i.e., instead of using `.reshape(batch_size, seq_length, embed_dim)` it now performs `.reshape(batch_size, seq_length, -1)` to automatically determine that last dimension size.

[1] https://github.com/huggingface/optimum-habana/blob/568f643875ee218d3b901a339813b6472b8c1c36/optimum/habana/transformers/models/clip/modeling_clip.py#L138


Example command that is currently broken (README example):

```bash
PT_HPU_LAZY_MODE=1 QUANT_CONFIG=./quantization_config/maxabs_measure.json python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_pipeline.py \
--model_name_or_path llava-hf/llava-v1.6-mistral-7b-hf \
--image_path "https://llava-vl.github.io/static/images/view.jpg" \
--use_hpu_graphs \
--bf16 \
--use_flash_attention \
--flash_attention_recompute
```