### PR TITLE
Set default generation config for TextGenerationPipeline and TextToAudioPipeline

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -425,6 +425,12 @@ def adapt_transformers_to_gaudi():
             max_new_tokens=256,
         )
     )
+    transformers.pipelines.text_generation.TextGenerationPipeline._default_generation_config = GaudiGenerationConfig(
+        max_new_tokens=256,
+    )
+    transformers.pipelines.text_to_audio.TextToAudioPipeline._default_generation_config = GaudiGenerationConfig(
+        max_new_tokens=256,
+    )
 
     # Optimization for BLOOM generation on Gaudi
     transformers.models.bloom.modeling_bloom.BloomAttention.forward = gaudi_bloom_attention_forward


### PR DESCRIPTION
# What does this PR do?

After transformers upgrade pipelines need to have `_default_generation_config` set to `GaudiGenerationConfig` to properly initialize. This PR sets this value for TextGenerationPipeline and TextToAudioPipeline classes.