### PR TITLE
Align distributed_runner with openmpi 5.0 (#2320)

### DIFF
--- a/optimum/habana/distributed/distributed_runner.py
+++ b/optimum/habana/distributed/distributed_runner.py
@@ -161,7 +161,7 @@ class DistributedRunner:
 
         mpi_cmd = self.setup_config_env_mpirun()
         self._interpreter = (
-            f"mpirun -n {self._world_size} --bind-to core {mpi_cmd} --rank-by core --report-bindings"
+            f"mpirun -n {self._world_size} --bind-to core {mpi_cmd} --rank-by slot --report-bindings"
             f" --allow-run-as-root {sys.executable} "
         )
 


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/huggingface/optimum-habana/pull/2320 which was merged to `v1.20-release` branch, and corrects mpirun command to use `--rank-by slot` where `--rank-by core` was previously used, but is no longer valid.