### PR TITLE
Fix Mllama attention selection

### DIFF
--- a/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
+++ b/optimum/habana/transformers/integrations/gaudi_fused_sdpa_attention.py
@@ -34,7 +34,7 @@ def gaudi_fused_sdpa_attention_forward(
         attention_mask,
         dropout,
         is_causal,
-        None,
+        scaling,
         softmax_mode,
         recompute_mode,
     )

--- a/optimum/habana/transformers/models/mllama/modeling_mllama.py
+++ b/optimum/habana/transformers/models/mllama/modeling_mllama.py
@@ -802,11 +802,12 @@ class GaudiMllamaModel(MllamaModel):
 
 class GaudiMllamaForConditionalGeneration(MllamaForConditionalGeneration):
     def __init__(self, config: MllamaConfig):
-        # Use the user option as the attention for the text model
+        # Use the user option as the attention choice
+        # If not provided, use default values:
+        # - text model -> "eager"
+        # - vision model -> "sdpa" (better choice than "eager" on HPU)
         config.text_config._attn_implementation = config._attn_implementation or "eager"
-
-        # Use always `sdpa` as it is better for the vision model on HPU
-        config.vision_config._attn_implementation = "sdpa"
+        config.vision_config._attn_implementation = config._attn_implementation or "sdpa"
 
         super().__init__(config)
 


### PR DESCRIPTION
# What does this PR do?

There was a wrong assumption in PR [1] that the `vision_model` attention implementation should always use the `sdpa` option. However, if the flag for `FusedSDPA` was passed (i.e., `use_flash_attention`), the model should not use `sdpa` but `FusedSDPA` in the vision model. This commit fixes the selection of the attention implementation.

Additionally, I noticed that the `gaudi_fused_sdpa_attention_forward(...)` function does not pass the `scaling` argument into the actual kernel call - I fixed that as well.

[1] https://github.com/huggingface/optimum-habana/pull/2319


