### PR TITLE
Fix None-handling in WhisperDecoder

### DIFF
--- a/optimum/habana/transformers/models/whisper/modeling_whisper.py
+++ b/optimum/habana/transformers/models/whisper/modeling_whisper.py
@@ -192,8 +192,12 @@ class GaudiWhisperDecoder(WhisperDecoder):
             use_cache = False
             past_key_values = None
 
-        if (input_ids is None) == (inputs_embeds is None):
-            raise ValueError("You must specify exactly one of decoder_input_ids or decoder_inputs_embeds.")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You must specify exactly one of decoder_input_ids or decoder_inputs_embeds (both None).")
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You must specify exactly one of decoder_input_ids or decoder_inputs_embeds (both provided)."
+            )
 
         if input_ids is not None:
             input_shape = input_ids.size()


### PR DESCRIPTION
This PR adds explicit validation for `input_ids` and `inputs_embeds` in `WhisperDecoder.forward` 
to ensure that exactly one of them is provided. 

Coverity raised a false-positive `FORWARD_NULL` warning due to the previous condition 
`(input_ids is None) == (inputs_embeds is None)`, which obscured the nullability flow analysis 
and led it to believe that `inputs_embeds` might be null when accessed later.
