### PR TITLE
Add validation for negative_prompt_embeds to satisfy Coverity null-check analysis

### DIFF
--- a/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
+++ b/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
@@ -360,6 +360,8 @@ class GaudiWanPipeline(GaudiDiffusionPipeline, WanPipeline):
         prompt_embeds = prompt_embeds.to(transformer_dtype)
         if negative_prompt_embeds is not None:
             negative_prompt_embeds = negative_prompt_embeds.to(transformer_dtype)
+        if self.do_classifier_free_guidance and negative_prompt_embeds is None:
+            raise ValueError("negative_prompt_embeds must not be None when classifier-free guidance is enabled.")
 
         # 4. Prepare timesteps
         self.scheduler.set_timesteps(num_inference_steps, device=device)


### PR DESCRIPTION
This PR adds an explicit validation step ensuring that `negative_prompt_embeds` is not None 
when classifier-free guidance (CFG) is enabled. 

Coverity reported false-positive `null_check` and `FORWARD_NULL` warnings because 
`negative_prompt_embeds` is declared as optional, even though Diffusers always generates 
valid embeddings when CFG is active.