### PR TITLE
Replace deprecated stabilityai/stable-diffusion-2-* models with ones maintained by sd2-community.

### DIFF
--- a/docs/source/tutorials/stable_diffusion.mdx
+++ b/docs/source/tutorials/stable_diffusion.mdx
@@ -98,7 +98,7 @@ outputs = pipeline(
 
 <Tip>
 
-There are two different checkpoints for Stable Diffusion 2 ():
+There are two different checkpoints for Stable Diffusion 2:
 
 - use [sd2-community/stable-diffusion-2-1](https://huggingface.co/sd2-community/stable-diffusion-2-1) for generating 768x768 images
 - use [sd2-community/stable-diffusion-2-1-base](https://huggingface.co/sd2-community/stable-diffusion-2-1-base) for generating 512x512 images

--- a/docs/source/tutorials/stable_diffusion.mdx
+++ b/docs/source/tutorials/stable_diffusion.mdx
@@ -67,13 +67,15 @@ Check out the [example](/examples/stable-diffusion) provided in the official Git
 
 ## Stable Diffusion 2
 
+DISCLAIMER: Stable Diffusion 2 models family has been discontinued and withdrawn by Stability AI. The following instruction uses mirrored models maintained by sd2-community, not maintained by Stability AI.
+
 [Stable Diffusion 2](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_2) can be used with the exact same classes.
 Here is an example:
 
 ```python
 from optimum.habana.diffusers import GaudiDDIMScheduler, GaudiStableDiffusionPipeline
 
-model_name = "stabilityai/stable-diffusion-2-1"
+model_name = "sd2-community/stable-diffusion-2-1"
 
 scheduler = GaudiDDIMScheduler.from_pretrained(model_name, subfolder="scheduler")
 
@@ -96,10 +98,10 @@ outputs = pipeline(
 
 <Tip>
 
-There are two different checkpoints for Stable Diffusion 2:
+There are two different checkpoints for Stable Diffusion 2 ():
 
-- use [stabilityai/stable-diffusion-2-1](https://huggingface.co/stabilityai/stable-diffusion-2-1) for generating 768x768 images
-- use [stabilityai/stable-diffusion-2-1-base](https://huggingface.co/stabilityai/stable-diffusion-2-1-base) for generating 512x512 images
+- use [sd2-community/stable-diffusion-2-1](https://huggingface.co/sd2-community/stable-diffusion-2-1) for generating 768x768 images
+- use [sd2-community/stable-diffusion-2-1-base](https://huggingface.co/sd2-community/stable-diffusion-2-1-base) for generating 512x512 images
 
 </Tip>
 

--- a/examples/stable-diffusion/depth_to_image_generation.py
+++ b/examples/stable-diffusion/depth_to_image_generation.py
@@ -52,7 +52,8 @@ def main():
 
     parser.add_argument(
         "--model_name_or_path",
-        default="stabilityai/stable-diffusion-2-depth",
+        # Stability AI has removed stable-diffusion-2 models. This uses unofficial mirror by sd2-community
+        default="sd2-community/stable-diffusion-2-depth",
         type=str,
         help="Path to pre-trained model",
     )

--- a/examples/stable-diffusion/training/README.md
+++ b/examples/stable-diffusion/training/README.md
@@ -91,11 +91,14 @@ To download the example conditioning images locally, run:
 python download_train_datasets.py
 ```
 
+> [!DISCLAIMER]
+> Stable Diffusion 2 models family has been discontinued and withdrawn by Stability AI. The following instruction uses mirrored models maintained by sd2-community, not maintained by Stability AI.
+
 Then proceed to training with command:
 
 ```bash
 PT_HPU_LAZY_MODE=1 python train_controlnet.py \
-   --pretrained_model_name_or_path=stabilityai/stable-diffusion-2-1 \
+   --pretrained_model_name_or_path=sd2-community/stable-diffusion-2-1 \
    --output_dir=/tmp/stable_diffusion2_1 \
    --dataset_name=fusing/fill50k \
    --resolution=512 \
@@ -116,11 +119,14 @@ with `python ../../gaudi_spawn.py --world_size <num-HPUs> train_controlnet.py`.
 
 ### Inference
 
+> [!DISCLAIMER]
+> Stable Diffusion 2 models family has been discontinued and withdrawn by Stability AI. The following instruction uses mirrored models maintained by sd2-community, not maintained by Stability AI.
+
 After training completes, you can use `text_to_image_generation.py` sample to run inference with the fine-tuned ControlNet model:
 
 ```bash
 PT_HPU_LAZY_MODE=1 python ../text_to_image_generation.py \
-    --model_name_or_path stabilityai/stable-diffusion-2-1 \
+    --model_name_or_path sd2-community/stable-diffusion-2-1 \
     --controlnet_model_name_or_path /tmp/stable_diffusion2_1 \
     --prompts "pale golden rod circle with old lace background" \
     --control_image "./cnet/conditioning_image_1.png" \
@@ -224,9 +230,12 @@ python download_train_datasets.py
 
 To launch the multi-card Stable Diffusion training, use:
 
+> [!DISCLAIMER]
+> Stable Diffusion 2 models family has been discontinued and withdrawn by Stability AI. The following instruction uses mirrored models maintained by sd2-community, not maintained by Stability AI.
+
 ```bash
 PT_HPU_LAZY_MODE=1 python ../../gaudi_spawn.py --world_size 8 --use_mpi train_dreambooth.py \
-    --pretrained_model_name_or_path="stabilityai/stable-diffusion-2-1"  \
+    --pretrained_model_name_or_path="sd2-community/stable-diffusion-2-1"  \
     --instance_data_dir="dog" \
     --output_dir="dog_sd" \
     --class_data_dir="path-to-class-images" \
@@ -263,9 +272,12 @@ UNet or text encoder.
 
 To run the multi-card training, use:
 
+> [!DISCLAIMER]
+> Stable Diffusion 2 models family has been discontinued and withdrawn by Stability AI. The following instruction uses mirrored models maintained by sd2-community, not maintained by Stability AI.
+
 ```bash
 PT_HPU_LAZY_MODE=1 python ../../gaudi_spawn.py --world_size 8 --use_mpi train_dreambooth.py \
-    --pretrained_model_name_or_path="stabilityai/stable-diffusion-2-1"  \
+    --pretrained_model_name_or_path="sd2-community/stable-diffusion-2-1"  \
     --instance_data_dir="dog" \
     --output_dir="dog_sd" \
     --class_data_dir="path-to-class-images" \
@@ -310,7 +322,7 @@ After training completes, you can use `text_to_image_generation.py` sample for i
 
 ```bash
 PT_HPU_LAZY_MODE=1 python ../text_to_image_generation.py \
-    --model_name_or_path stabilityai/stable-diffusion-2-1  \
+    --model_name_or_path sd2-community/stable-diffusion-2-1  \
     --unet_adapter_name_or_path dog_sd/unet \
     --prompts "a sks dog" \
     --num_images_per_prompt 5 \

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_depth2img.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_depth2img.py
@@ -368,7 +368,7 @@ class GaudiStableDiffusionDepth2ImgPipeline(GaudiDiffusionPipeline, StableDiffus
         >>> from diffusers import StableDiffusionDepth2ImgPipeline
 
         >>> pipe = StableDiffusionDepth2ImgPipeline.from_pretrained(
-        ...     "stabilityai/stable-diffusion-2-depth",
+        ...     "sd2-community/stable-diffusion-2-depth",
         ...     torch_dtype=torch.float16,
         ... )
         >>> pipe.to("cuda")

--- a/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/habana/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -339,7 +339,7 @@ class GaudiStableDiffusionInpaintPipeline(GaudiDiffusionPipeline, StableDiffusio
         >>> mask_image = download_image(mask_url).resize((512, 512))
 
         >>> pipe = StableDiffusionInpaintPipeline.from_pretrained(
-        ...     "stabilityai/stable-diffusion-2-inpainting", torch_dtype=torch.float16
+        ...     "sd2-community/stable-diffusion-2-inpainting", torch_dtype=torch.float16
         ... )
         >>> pipe = pipe.to("cuda")
 

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -793,7 +793,8 @@ class GaudiStableDiffusionPipelineTester(TestCase):
         ]
         num_images_per_prompt = 28
         batch_size = 7
-        model_name = "stabilityai/stable-diffusion-2-1"
+        # Stability AI has removed stable-diffusion-2 models. This uses unofficial mirror by sd2-community
+        model_name = "sd2-community/stable-diffusion-2-1"
         scheduler = GaudiDDIMScheduler.from_pretrained(model_name, subfolder="scheduler")
         pipeline = GaudiStableDiffusionPipeline.from_pretrained(
             model_name,
@@ -2635,7 +2636,8 @@ class GaudiStableDiffusionDepth2ImgPipelineTester(TestCase):
     @legacy
     def test_depth2img_pipeline(self):
         gaudi_config = GaudiConfig(use_torch_autocast=True)
-        model_name = "stabilityai/stable-diffusion-2-depth"
+        # Stability AI has removed stable-diffusion-2 models. This uses unofficial mirror by sd2-community
+        model_name = "sd2-community/stable-diffusion-2-depth"
         scheduler = GaudiDDIMScheduler.from_pretrained(model_name, subfolder="scheduler")
 
         pipe = GaudiStableDiffusionDepth2ImgPipeline.from_pretrained(
@@ -5687,7 +5689,8 @@ class StableDiffusionInpaintPipelineTests(
         prompts = [
             "concept art digital painting of an elven castle, inspired by lord of the rings, highly detailed, 8k",
         ]
-        model_name = "stabilityai/stable-diffusion-2-inpainting"
+        # Stability AI has removed stable-diffusion-2 models. This uses unofficial mirror by sd2-community
+        model_name = "sd2-community/stable-diffusion-2-inpainting"
         num_images_per_prompt = 12
         batch_size = 4
         pipeline = GaudiStableDiffusionInpaintPipeline.from_pretrained(


### PR DESCRIPTION
Around 13th of November 2025 Stability AI have removed stable-diffusion-2-* models family from their domain. Currently these models are maintained by sd2-community.

In order to maintain integrity of README examples, we'll use these models instead.

This change should be cherry-picked to v1.21-release
