### PR TITLE
Fix mxeval installation in mbxp_evaluation setup

### DIFF
--- a/examples/text-generation/mbxp_evaluation/setup.sh
+++ b/examples/text-generation/mbxp_evaluation/setup.sh
@@ -5,9 +5,13 @@
 
 set -xe
 
+MXEVAL_COMMIT="e09974f"
+
 apt-get update
 git clone https://github.com/amazon-science/mxeval.git
-pip install -e mxeval
+cd mxeval && git checkout ${MXEVAL_COMMIT} && cd ..
+sed -i 's/evaluate_functional_correctness = mxeval.evaluate_functional_correctness"/evaluate_functional_correctness = mxeval.evaluate_functional_correctness:main"/' mxeval/setup.py
+pip install -e mxeval --no-build-isolation
 sed -i 's/npx tsc/tsc/g' mxeval/mxeval/execution.py
 cp evaluation_setup/ubuntu.sh mxeval/language_setup/ubuntu.sh
 PATH="$HOME/.rbenv/bin:$PATH" bash mxeval/language_setup/ubuntu.sh


### PR DESCRIPTION
## Problem

Mixtral evaluation models are crashing with `ModuleNotFoundError: No module named 'mxeval.execution'`.

The `mxeval` package fails to install during `mbxp_evaluation/setup.sh` execution due to two issues with newer pip/setuptools versions:

1. **`pkg_resources` removed from `setuptools>=82`**: `mxeval/setup.py` uses `import pkg_resources`, which has been removed. When `pip install -e mxeval` runs with build isolation (default), pip creates an isolated build environment with the latest `setuptools` which no longer includes `pkg_resources`.

2. **Invalid `entry_point` format**: `mxeval/setup.py` declares an entry point without the required callable suffix (`:main`), which newer pip versions enforce strictly.

## Fix

- Pin `mxeval` to a known-good commit (`e09974f`)
- Patch the broken `entry_point` in `mxeval/setup.py` after cloning
- Use `--no-build-isolation` to avoid the `pkg_resources` issue

Fixes: GAUDISW-246483