### PR TITLE
Pin bitsandbytes to 0.49.2 to fix ~43% perf regression

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -135,7 +135,7 @@ def pytest_configure(config):
                 "-m",
                 "pip",
                 "install",
-                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@main",
+                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@0.49.2",
             ]
         )
     name = ""


### PR DESCRIPTION
bitsandbytes 0.50.0.dev0 (from @main) causes ~44.5% performance regression in LLaMA3.1-70B-QLoRA-FT (Torch.compile) on Gaudi2/Gaudi3.