### PR TITLE
Revert "Pin bitsandbytes to 0.49.2 to fix ~43% perf regression (#2369)"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -135,7 +135,7 @@ def pytest_configure(config):
                 "-m",
                 "pip",
                 "install",
-                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@0.49.2",
+                "git+https://github.com/bitsandbytes-foundation/bitsandbytes.git@main",
             ]
         )
     name = ""


### PR DESCRIPTION
Changed the installation source for `bitsandbytes` from a fixed version (`0.49.2`) to the `main` branch to always use the latest code.