### PR TITLE
Add README known issue for bitsandbytes >= 0.5 with torch.compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Please refer to the Intel Gaudi AI Accelerator official [installation guide](htt
 To install the latest stable release of this package
 ```bash
 pip install --upgrade-strategy eager optimum[habana]
-```
 
 The `--upgrade-strategy eager` option is needed to ensure `optimum-habana` is upgraded to the latest stable release.
 
@@ -339,3 +338,17 @@ The list of validated models through continuous integration tests is posted [her
 ## Development
 
 Check the [contributor guide](https://github.com/huggingface/optimum/blob/v1.20-release/CONTRIBUTING.md) for instructions.
+
+## Known Issues
+
+### bitsandbytes >= 0.5 with `torch.compile` can regress performance
+
+When running quantized workloads with bitsandbytes >= 0.5 and `torch.compile`, performance may regress.
+
+- **Root cause**: upstream bitsandbytes changes can reduce the effectiveness of `torch.compile` optimizations in some setups.
+- **Impact**: lower throughput may be observed compared to bitsandbytes 0.49.2.
+- **Scope**: this issue is upstream in bitsandbytes and is not specific to Intel Gaudi.
+- **Workarounds**:
+  - Pin `bitsandbytes==0.49.2` for workloads relying on `torch.compile`.
+  - Run without `torch.compile` when using bitsandbytes >= 0.5.
+- **Status**: an upstream fix is in progress.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please refer to the Intel Gaudi AI Accelerator official [installation guide](htt
 To install the latest stable release of this package
 ```bash
 pip install --upgrade-strategy eager optimum[habana]
+```
 
 The `--upgrade-strategy eager` option is needed to ensure `optimum-habana` is upgraded to the latest stable release.
 


### PR DESCRIPTION
This PR adds a new Known Issues section at the end of the README.
It documents a performance regression observed when using bitsandbytes >= 0.5 together with torch.compile.
The note clarifies that this is an upstream bitsandbytes issue and is not Gaudi-specific.