### PR TITLE
Update text-generation lm-eval dependencies for datasets>=4.8.4

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -660,7 +660,7 @@ pip install -r requirements_lm_eval.txt
 ```
 
 > [!NOTE]
-> For lm-eval tasks that still rely on dataset scripts, use a separate env with datasets 3.x or switch to Parquet/Arrow variants. The example requirements in this repo now install datasets>=4.8.4.
+> The example requirements in this repo install `lm-eval==0.4.11` together with `datasets>=4.8.4`.
 
 The argument --system_instruction adds a system message to the beginning of the prompt.
 This instruction is treated as part of the input context and can influence how the model interprets the task or responds.

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -660,7 +660,7 @@ pip install -r requirements_lm_eval.txt
 ```
 
 > [!NOTE]
-> For lm-eval tasks that still rely on dataset scripts, use a separate env with datasets 3.x or switch to Parquet/Arrow variants. This repo requires datasets>=4.0.0.
+> For lm-eval tasks that still rely on dataset scripts, use a separate env with datasets 3.x or switch to Parquet/Arrow variants. The example requirements in this repo now install datasets>=4.8.4.
 
 The argument --system_instruction adds a system message to the beginning of the prompt.
 This instruction is treated as part of the input context and can influence how the model interprets the task or responds.

--- a/examples/text-generation/model_adapter.py
+++ b/examples/text-generation/model_adapter.py
@@ -26,6 +26,7 @@ import torch.nn.functional as F
 from lm_eval.api.instance import Instance
 from lm_eval.models.huggingface import HFLM, TemplateLM
 
+
 try:
     from lm_eval.models.utils_hf import get_dtype, stop_sequences_criteria
 except ImportError:

--- a/examples/text-generation/model_adapter.py
+++ b/examples/text-generation/model_adapter.py
@@ -25,7 +25,11 @@ import torch
 import torch.nn.functional as F
 from lm_eval.api.instance import Instance
 from lm_eval.models.huggingface import HFLM, TemplateLM
-from lm_eval.models.utils import get_dtype, stop_sequences_criteria
+
+try:
+    from lm_eval.models.utils_hf import get_dtype, stop_sequences_criteria
+except ImportError:
+    from lm_eval.models.utils import get_dtype, stop_sequences_criteria
 
 # Local imports
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/examples/text-generation/requirements.txt
+++ b/examples/text-generation/requirements.txt
@@ -1,4 +1,4 @@
-datasets>=4.0.0
+datasets>=4.8.4
 peft == 0.11.1
 sentencepiece
 tiktoken

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,5 +1,5 @@
 lm-eval==0.4.9.1
-datasets<4.0.0,>=2.16.0 # pinned for lm-eval==0.4.9.1; unpin to datasets>=4.0.0 when supported
+datasets>=4.8.4
 evaluate == 0.4.3
 rouge_score == 0.1.2
 accelerate

--- a/examples/text-generation/requirements_lm_eval.txt
+++ b/examples/text-generation/requirements_lm_eval.txt
@@ -1,4 +1,4 @@
-lm-eval==0.4.9.1
+lm-eval==0.4.11
 datasets>=4.8.4
 evaluate == 0.4.3
 rouge_score == 0.1.2

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -184,8 +184,7 @@ def main() -> None:
     # Keep the runtime datasets version aligned with requirements_lm_eval.txt.
     require_version(
         "datasets>=4.8.4",
-        "Install the LM-Eval dependencies with:\n"
-        "  pip install -r examples/text-generation/requirements_lm_eval.txt",
+        "Install the LM-Eval dependencies with:\n  pip install -r examples/text-generation/requirements_lm_eval.txt",
     )
 
     model, _, tokenizer, generation_config = initialize_model(args, logger)

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -181,10 +181,10 @@ def main() -> None:
     # Modified based on cli_evaluate function in https://github.com/EleutherAI/lm-evaluation-harness/blob/v0.4.9.1/lm_eval/__main__.py#L301
     args = setup_lm_eval_parser()
 
-    # lm-eval==0.4.9.1 needs datasets<4.0 (and >=2.16.0). Remove when lm-eval supports datasets>=4.
+    # Keep the runtime datasets version aligned with requirements_lm_eval.txt.
     require_version(
-        "datasets<4.0,>=2.16.0",
-        "Use a separate environment for LM-Eval and install:\n"
+        "datasets>=4.8.4",
+        "Install the LM-Eval dependencies with:\n"
         "  pip install -r examples/text-generation/requirements_lm_eval.txt",
     )
 

--- a/examples/trl/dpo.py
+++ b/examples/trl/dpo.py
@@ -211,8 +211,10 @@ if __name__ == "__main__":
         data_dir="data/rl", sanity_check=script_args.sanity_check, num_proc=script_args.num_workers
     )
     train_dataset = train_dataset.filter(
-        lambda x: len(x["prompt"]) + len(x["chosen"]) <= script_args.max_length
-        and len(x["prompt"]) + len(x["rejected"]) <= script_args.max_length
+        lambda x: (
+            len(x["prompt"]) + len(x["chosen"]) <= script_args.max_length
+            and len(x["prompt"]) + len(x["rejected"]) <= script_args.max_length
+        )
     )
 
     # 4. Load evaluation dataset
@@ -220,8 +222,10 @@ if __name__ == "__main__":
         data_dir="data/evaluation", sanity_check=True, num_proc=script_args.num_workers
     )
     eval_dataset = eval_dataset.filter(
-        lambda x: len(x["prompt"]) + len(x["chosen"]) <= script_args.max_length
-        and len(x["prompt"]) + len(x["rejected"]) <= script_args.max_length
+        lambda x: (
+            len(x["prompt"]) + len(x["chosen"]) <= script_args.max_length
+            and len(x["prompt"]) + len(x["rejected"]) <= script_args.max_length
+        )
     )
 
     peft_config = LoraConfig(


### PR DESCRIPTION
Bump datasets to 4.8.4 and lm-eval to 0.4.11 for compatibility with datasets>=4.0.