### PR TITLE
fix: add compatibility workaround for torchvision VideoReader

### DIFF
--- a/examples/contrastive-image-text/README.md
+++ b/examples/contrastive-image-text/README.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 **Recommended (datasets>=4.0.0):** use the COCO captions dataset hosted on the Hub. It provides image–caption pairs and does **not** require `trust_remote_code`:
 ```python
 import datasets
+
 ds = datasets.load_dataset("regisss/coco_2017", split="train")
 ```
 This dataset exposes at least the columns `image` (PIL image) and `caption` (string).
@@ -51,16 +52,9 @@ The `VisionTextDualEncoderModel` class lets you load any vision and text encoder
 Here is an example of how to load the model using pre-trained vision and text models.
 
 ```python
-from transformers import (
-    VisionTextDualEncoderModel,
-    VisionTextDualEncoderProcessor,
-    AutoTokenizer,
-    AutoImageProcessor
-)
+from transformers import VisionTextDualEncoderModel, VisionTextDualEncoderProcessor, AutoTokenizer, AutoImageProcessor
 
-model = VisionTextDualEncoderModel.from_vision_text_pretrained(
-    "openai/clip-vit-base-patch32", "roberta-base"
-)
+model = VisionTextDualEncoderModel.from_vision_text_pretrained("openai/clip-vit-base-patch32", "roberta-base")
 
 tokenizer = AutoTokenizer.from_pretrained("roberta-base")
 image_processor = AutoImageProcessor.from_pretrained("openai/clip-vit-base-patch32")

--- a/examples/image-classification/README.md
+++ b/examples/image-classification/README.md
@@ -132,10 +132,15 @@ dataset = load_dataset("imagefolder", data_dir="path_to_your_folder")
 dataset = load_dataset("imagefolder", data_files="path_to_zip_file")
 
 # example 3: remote files (supported formats are tar, gzip, zip, xz, rar, zstd)
-dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip")
+dataset = load_dataset(
+    "imagefolder",
+    data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip",
+)
 
 # example 4: providing several splits
-dataset = load_dataset("imagefolder", data_files={"train": ["path/to/file1", "path/to/file2"], "test": ["path/to/file3", "path/to/file4"]})
+dataset = load_dataset(
+    "imagefolder", data_files={"train": ["path/to/file1", "path/to/file2"], "test": ["path/to/file3", "path/to/file4"]}
+)
 ```
 
 `ImageFolder` will create a `label` column, and the label name is based on the directory name.

--- a/examples/sentence-transformers-training/sts/README.md
+++ b/examples/sentence-transformers-training/sts/README.md
@@ -76,11 +76,13 @@ from datasets import Dataset
 sentence1_list = ["My first sentence", "Another pair"]
 sentence2_list = ["My second sentence", "Unrelated sentence"]
 labels_list = [0.8, 0.3]
-train_dataset = Dataset.from_dict({
-    "sentence1": sentence1_list,
-    "sentence2": sentence2_list,
-    "label": labels_list,
-})
+train_dataset = Dataset.from_dict(
+    {
+        "sentence1": sentence1_list,
+        "sentence2": sentence2_list,
+        "label": labels_list,
+    }
+)
 # => Dataset({
 #     features: ['sentence1', 'sentence2', 'label'],
 #     num_rows: 2

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
 from functools import partial
@@ -116,6 +117,29 @@ PATH_SAMPLE_TEXT = f"{get_tests_dir()}/resource/sample_text.txt"
 
 
 adapt_transformers_to_gaudi()
+
+
+def _ensure_torchvision_video_reader_compat():
+    """
+    Work around torchvision builds that expose torchvision.io without VideoReader.
+    datasets' torch formatter imports VideoReader when torchvision is already loaded.
+    """
+    if "torchvision" not in sys.modules:
+        return
+
+    try:
+        import torchvision.io as torchvision_io
+    except ImportError:
+        return
+
+    if hasattr(torchvision_io, "VideoReader"):
+        return
+
+    class _UnavailableVideoReader:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("torchvision.io.VideoReader is not available in this torchvision build")
+
+    torchvision_io.VideoReader = _UnavailableVideoReader
 
 
 class StoreLossCallback(TrainerCallback):
@@ -713,6 +737,7 @@ class GaudiTrainerIntegrationPrerunTest(TestCasePlus, GaudiTrainerIntegrationCom
             self.check_trained_model(trainer.model)
 
             # Can return tensors.
+            _ensure_torchvision_video_reader_compat()
             train_dataset = train_dataset.with_format("torch")
             model = RegressionModel()
             trainer = GaudiTrainer(model, gaudi_config, args, train_dataset=train_dataset)


### PR DESCRIPTION
This PR fixes a CI failure in `test_trainer` that was blocking `GaudiTrainerIntegrationPrerunTest.test_trainer_with_datasets` when the dataset was converted to torch format.

**Problem**
The promote suite failed before trainer execution in CI.

**Root Cause**
`datasets.Dataset.with_format("torch")` triggered an import of `torchvision.io.VideoReader`. In the CI environment, `torchvision.io` was available but did not export `VideoReader`, which caused an `ImportError` inside the datasets torch formatter.

**Failure snippet**
```text
File ".../datasets/formatting/torch_formatter.py", line 99, in _recursive_tensorize
  return self._tensorize(data_struct)
File ".../datasets/formatting/torch_formatter.py", line 119, in format_batch
  from torchvision.io import VideoReader
ImportError: cannot import name 'VideoReader' from 'torchvision.io'
```

**Fix**
Added a narrow compatibility shim in test_trainer.py that makes the affected test path resilient to partial torchvision builds, so the test continues to validate `GaudiTrainer` behavior instead of failing on the external formatter import.
