### PR TITLE
Block attacker-controlled attention-implementation fields in configs (CVE-2026-4372)

### DIFF
--- a/optimum/habana/transformers/modeling_utils.py
+++ b/optimum/habana/transformers/modeling_utils.py
@@ -335,6 +335,7 @@ from .models import (
 )
 from .models.deepseek_v2.modeling_deepseek_v2 import DeepseekV2ForCausalLM as GaudiDeepseekV2ForCausalLM
 from .quantizers.quantizer_finegrained_fp8 import GaudiFineGrainedFP8HfQuantizer
+from .security_patches import apply_transformers_security_patches
 
 
 def adapt_transformers_to_gaudi():
@@ -342,6 +343,8 @@ def adapt_transformers_to_gaudi():
     Replaces some Transformers' methods for equivalent methods optimized
     for Gaudi.
     """
+    apply_transformers_security_patches()
+
     ALL_ATTENTION_FUNCTIONS.register("gaudi_fused_sdpa", gaudi_fused_sdpa_attention_forward)
 
     # models that support symbolic tracing should be added to this list

--- a/optimum/habana/transformers/security_patches.py
+++ b/optimum/habana/transformers/security_patches.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Security patches applied to Transformers by `adapt_transformers_to_gaudi()`.
+
+This module deliberately imports nothing from `habana_frameworks`, so the patches can be
+unit-tested on any machine without a Gaudi device.
+"""
+
+import transformers
+from optimum.utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+# CVE-2026-4372: `_attn_implementation_internal` is a computed, private field. Transformers resolves
+# it as a kernel repo id and imports code from the Hub, without consulting `trust_remote_code`, so a
+# crafted config.json that sets it directly is an arbitrary code execution vector. Callers must go
+# through the public `attn_implementation` argument instead.
+# `_experts_implementation_internal` does not exist in transformers 4.55.x; it is listed for
+# forward-compatibility with the upstream fix.
+BLOCKED_CONFIG_KWARGS = ("_attn_implementation_internal", "_experts_implementation_internal")
+
+_original_pretrained_config_init = transformers.PretrainedConfig.__init__
+
+
+def gaudi_pretrained_config_init(self, **kwargs):
+    """
+    Wraps `transformers.PretrainedConfig.__init__` to drop internal attention/experts
+    implementation fields before they reach its `setattr` loop (CVE-2026-4372).
+    """
+    for blocked_key in BLOCKED_CONFIG_KWARGS:
+        if kwargs.pop(blocked_key, None) is not None:
+            logger.warning(
+                f"Ignoring `{blocked_key}` found in a model configuration: it is an internal field "
+                "and cannot be set from a config file. Use the `attn_implementation` argument of "
+                "`from_pretrained()` instead."
+            )
+    _original_pretrained_config_init(self, **kwargs)
+
+
+# Set on the patched function rather than on the module, so a re-import cannot mask an applied patch.
+gaudi_pretrained_config_init._is_gaudi_security_patch = True
+
+
+def apply_transformers_security_patches():
+    """Applies the Transformers security patches. Safe to call more than once."""
+    if getattr(transformers.PretrainedConfig.__init__, "_is_gaudi_security_patch", False):
+        return
+    transformers.PretrainedConfig.__init__ = gaudi_pretrained_config_init
+    transformers.configuration_utils.PretrainedConfig.__init__ = gaudi_pretrained_config_init

--- a/tests/test_security_patches.py
+++ b/tests/test_security_patches.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Transformers security patches. These do not require a Gaudi device."""
+
+import pytest
+import transformers
+from transformers import LlamaConfig
+
+from optimum.habana.transformers.security_patches import (
+    BLOCKED_CONFIG_KWARGS,
+    apply_transformers_security_patches,
+)
+
+
+MALICIOUS_REPO_ID = "attacker/malicious-kernel-repo"
+
+
+@pytest.fixture(autouse=True)
+def _patched():
+    apply_transformers_security_patches()
+
+
+@pytest.mark.parametrize("blocked_key", BLOCKED_CONFIG_KWARGS)
+def test_internal_implementation_field_is_dropped_from_config_dict(blocked_key):
+    """CVE-2026-4372: a config file must not be able to set the internal attn-dispatch fields."""
+    config = LlamaConfig.from_dict({"model_type": "llama", blocked_key: MALICIOUS_REPO_ID})
+
+    assert getattr(config, blocked_key, None) != MALICIOUS_REPO_ID
+    assert config._attn_implementation != MALICIOUS_REPO_ID
+
+
+def test_internal_implementation_field_is_dropped_from_kwargs():
+    config = LlamaConfig(_attn_implementation_internal=MALICIOUS_REPO_ID)
+
+    assert config._attn_implementation != MALICIOUS_REPO_ID
+
+
+def test_public_attn_implementation_argument_still_works():
+    """The documented way of selecting an attention implementation must keep working."""
+    assert LlamaConfig(attn_implementation="eager")._attn_implementation == "eager"
+    assert LlamaConfig.from_dict({"model_type": "llama"}, attn_implementation="sdpa")._attn_implementation == "sdpa"
+
+
+def test_unknown_config_keys_are_still_accepted():
+    """Only the blocked keys are filtered; arbitrary custom fields must survive."""
+    assert LlamaConfig.from_dict({"model_type": "llama", "some_custom_field": 42}).some_custom_field == 42
+
+
+def test_patch_is_idempotent():
+    """`adapt_transformers_to_gaudi()` may run more than once; re-patching must not recurse."""
+    patched_init = transformers.PretrainedConfig.__init__
+
+    for _ in range(3):
+        apply_transformers_security_patches()
+
+    assert transformers.PretrainedConfig.__init__ is patched_init
+    assert LlamaConfig(_attn_implementation_internal=MALICIOUS_REPO_ID)._attn_implementation != MALICIOUS_REPO_ID
+
+
+def test_patched_symbols_still_exist_upstream():
+    """Fails loudly if a Transformers upgrade moves what the patch targets, instead of silently no-op'ing."""
+    assert hasattr(transformers, "PretrainedConfig")
+    assert hasattr(transformers.configuration_utils, "PretrainedConfig")
+    assert transformers.PretrainedConfig is transformers.configuration_utils.PretrainedConfig
+    assert hasattr(transformers.PretrainedConfig, "_attn_implementation")


### PR DESCRIPTION
## What this fixes

`CVE-2026-4372` (HIGH) — arbitrary code execution when loading an untrusted checkpoint.

A crafted `config.json` can set the private field `_attn_implementation_internal` to a
Hub repo id. Transformers resolves that value as an attention-kernel repository and
imports Python from it. `trust_remote_code` is never consulted, because the kernel-hub
mechanism is a separate code path — so plain, documented usage is enough to trigger it:

```python
AutoModelForCausalLM.from_pretrained("attacker/repo")   # no trust_remote_code needed
```

The chain in transformers 4.55.4:

1. `PretrainedConfig.from_dict()` passes the raw config dict straight through:
   `config = cls(**config_dict)` — `configuration_utils.py:789`
2. `PretrainedConfig.__init__` assigns every unknown key with `setattr()` —
   `configuration_utils.py:341`
3. `PreTrainedModel.__init__` reads `config._attn_implementation`, whose property returns
   `_attn_implementation_internal` verbatim — `modeling_utils.py:2228`
4. the repo-id regex matches and `get_kernel(repo_id)` downloads and imports the module —
   `modeling_utils.py:2744`

Step 4 is wrapped in a bare `except Exception` that only logs a warning, so a failed
attempt is silent.

## The fix

`adapt_transformers_to_gaudi()` now wraps `PretrainedConfig.__init__` and drops the
internal fields before the `setattr` loop in step 2 — the root cause. The public
`attn_implementation` argument is unaffected, which is the documented way to select an
implementation.

The helper lives in `optimum/habana/transformers/security_patches.py`, which imports
nothing from `habana_frameworks`, so it can be reviewed and reasoned about without Gaudi
hardware.

`_experts_implementation_internal` does not exist in 4.55.x; it is blocked too so the
behaviour matches the upstream fix if a later version introduces it.

## Notes for reviewers

- **Scope.** Upstream's fix also restricts which Hub org may supply attention kernels.
  That part is deliberately left out: it only constrains values the *caller* passes, which
  are not attacker-controlled, and it would break anyone legitimately loading a kernel from
  another org. This PR closes the attacker-controlled route only.
- **Why a monkeypatch.** `configuration_utils.py` is not vendored in optimum-habana, so
  there is no override to edit. `adapt_transformers_to_gaudi()` is the established place
  for this kind of patch and already runs before any model is loaded.
- **Idempotency.** `adapt_transformers_to_gaudi()` can run more than once. The original
  constructor is captured at module import and the patch is guarded by a sentinel, so
  repeated application cannot wrap the wrapper and recurse. There is a test for this.
- **`kernels` is an optional extra** in transformers 4.55.4, and the vulnerable branch
  raises early when it is missing. Whether a given image is exploitable today therefore
  depends on whether `kernels` is installed — the fix lands regardless, so that an image
  which later adds it does not silently become vulnerable.

## Testing

`tests/test_security_patches.py` covers: both blocked fields via `from_dict` and via
kwargs, the public `attn_implementation` argument still working, unrelated custom config
keys still being accepted, idempotency, and a guard test that fails loudly if a
Transformers upgrade moves the symbols this patch targets — so the patch cannot silently
become a no-op.

The blocking assertions were confirmed to **fail** against unpatched transformers 4.55.4
before the fix, so they detect the vulnerability rather than merely passing.

Not yet run on Gaudi hardware.

## References

- https://avd.aquasec.com/nvd/cve-2026-4372
- Upstream fix: https://github.com/huggingface/transformers/commit/a7f8e7ff37d87d1a1a0c8cf607971c607741452f
- Same approach as #2379 (CVE-2026-1839)
