### PR TITLE
Gate dynamic module loading in Diffusers (CVE-2026-44513, CVE-2026-45804)

### DIFF
--- a/optimum/habana/diffusers/__init__.py
+++ b/optimum/habana/diffusers/__init__.py
@@ -37,3 +37,7 @@ from .schedulers import (
     GaudiEulerDiscreteScheduler,
     GaudiFlowMatchEulerDiscreteScheduler,
 )
+from .security_patches import apply_diffusers_security_patches
+
+
+apply_diffusers_security_patches()

--- a/optimum/habana/diffusers/security_patches.py
+++ b/optimum/habana/diffusers/security_patches.py
@@ -1,0 +1,93 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Security patches applied to Diffusers when `optimum.habana.diffusers` is imported.
+
+This module deliberately imports nothing from `habana_frameworks`, so the patches can be
+unit-tested on any machine without a Gaudi device.
+"""
+
+import contextvars
+import functools
+
+from diffusers import DiffusionPipeline
+from diffusers.utils import dynamic_modules_utils
+from optimum.utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+# CVE-2026-44513 / CVE-2026-45804: in diffusers <= 0.37 the `trust_remote_code` gate lives in
+# `DiffusionPipeline.download()`, which is skipped for local paths and only inspects the main repo,
+# and which resolves the revision separately from the download that actually runs the code. The gate
+# is moved here, to the single point where any dynamic module is resolved, so local paths, local
+# snapshots and Hub repos are all covered and there is no resolve-then-fetch window left to race.
+# The caller's choice is carried in a ContextVar because the intermediate diffusers functions have
+# no `trust_remote_code` parameter to thread it through.
+_trust_remote_code = contextvars.ContextVar("gaudi_diffusers_trust_remote_code", default=False)
+
+_original_get_cached_module_file = dynamic_modules_utils.get_cached_module_file
+
+
+@functools.wraps(_original_get_cached_module_file)
+def gaudi_get_cached_module_file(pretrained_model_name_or_path, module_file, *args, **kwargs):
+    if not _trust_remote_code.get():
+        raise ValueError(
+            f"Loading {module_file} from {pretrained_model_name_or_path} would execute custom code "
+            "that is not part of Diffusers. Pass `trust_remote_code=True` to `from_pretrained()` if "
+            "you have read that code and trust it."
+        )
+    logger.warning(f"`trust_remote_code` is enabled: executing custom code from {pretrained_model_name_or_path}.")
+    return _original_get_cached_module_file(pretrained_model_name_or_path, module_file, *args, **kwargs)
+
+
+gaudi_get_cached_module_file._is_gaudi_security_patch = True
+
+
+def _with_trust_remote_code_scope(original):
+    """Publishes the caller's `trust_remote_code` value for the duration of the wrapped call."""
+
+    @functools.wraps(original)
+    def wrapper(cls, *args, **kwargs):
+        token = _trust_remote_code.set(bool(kwargs.get("trust_remote_code", False)))
+        try:
+            return original(cls, *args, **kwargs)
+        finally:
+            _trust_remote_code.reset(token)
+
+    wrapper._is_gaudi_security_patch = True
+    return classmethod(wrapper)
+
+
+def apply_diffusers_security_patches():
+    """Applies the Diffusers security patches. Safe to call more than once."""
+    if getattr(dynamic_modules_utils.get_cached_module_file, "_is_gaudi_security_patch", False):
+        return
+
+    # `get_class_from_dynamic_module` resolves this by module global at call time, so patching the
+    # module attribute is enough to cover every caller.
+    dynamic_modules_utils.get_cached_module_file = gaudi_get_cached_module_file
+
+    DiffusionPipeline.from_pretrained = _with_trust_remote_code_scope(DiffusionPipeline.from_pretrained.__func__)
+
+    # Modular pipelines have their own (correct) gate, but they resolve modules through the same
+    # chokepoint, so they must publish their decision too or they would be blocked outright.
+    try:
+        from diffusers.modular_pipelines.modular_pipeline import ModularPipelineBlocks
+    except ImportError:
+        return
+    ModularPipelineBlocks.from_pretrained = _with_trust_remote_code_scope(
+        ModularPipelineBlocks.from_pretrained.__func__
+    )

--- a/tests/test_diffusers_security_patches.py
+++ b/tests/test_diffusers_security_patches.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Diffusers security patches. These do not require a Gaudi device."""
+
+import json
+import threading
+
+import pytest
+from diffusers.utils import dynamic_modules_utils
+
+from optimum.habana.diffusers.security_patches import apply_diffusers_security_patches
+
+
+CUSTOM_PIPELINE_SOURCE = """
+from pathlib import Path
+
+Path(r"{marker}").write_text("executed")
+
+
+class EvilPipeline:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+"""
+
+
+@pytest.fixture(autouse=True)
+def _patched():
+    apply_diffusers_security_patches()
+
+
+@pytest.fixture
+def evil_repo(tmp_path, request):
+    """A local 'repo' whose custom pipeline module writes a marker file when imported."""
+    repo = tmp_path / "evil_repo"
+    repo.mkdir()
+    marker = tmp_path / "PWNED"
+    # Diffusers derives the `sys.modules` key from the module path, so a name reused across tests
+    # would return the cached module and skip re-execution, masking the result.
+    module_file = f"evil_pipeline_{request.node.name}.py"
+    (repo / module_file).write_text(CUSTOM_PIPELINE_SOURCE.format(marker=marker))
+    (repo / "model_index.json").write_text(
+        json.dumps({"_class_name": [module_file[:-3], "EvilPipeline"], "_diffusers_version": "0.35.1"})
+    )
+    return repo, marker, module_file
+
+
+def test_local_custom_module_is_refused(evil_repo):
+    """CVE-2026-44513: a local path must not bypass the trust gate."""
+    repo, marker, module_file = evil_repo
+
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        dynamic_modules_utils.get_class_from_dynamic_module(
+            str(repo), module_file=module_file, class_name="EvilPipeline"
+        )
+
+    # The payload runs at import time, so an exception alone would not prove it was blocked.
+    assert not marker.exists()
+
+
+def test_custom_module_is_allowed_when_trusted(evil_repo):
+    """The feature must keep working for callers that explicitly opt in."""
+    repo, marker, module_file = evil_repo
+
+    from optimum.habana.diffusers.security_patches import _trust_remote_code
+
+    token = _trust_remote_code.set(True)
+    try:
+        dynamic_modules_utils.get_class_from_dynamic_module(
+            str(repo), module_file=module_file, class_name="EvilPipeline"
+        )
+    finally:
+        _trust_remote_code.reset(token)
+
+    assert marker.exists()
+
+
+def test_trust_scope_does_not_leak_across_threads(evil_repo):
+    """A ContextVar (not a module global) is required for concurrent pipeline loads."""
+    _repo, marker, _module_file = evil_repo
+    from optimum.habana.diffusers.security_patches import _trust_remote_code
+
+    seen = {}
+
+    def worker():
+        seen["value"] = _trust_remote_code.get()
+
+    token = _trust_remote_code.set(True)
+    try:
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+    finally:
+        _trust_remote_code.reset(token)
+
+    assert seen["value"] is False
+    assert not marker.exists()
+
+
+def test_trust_scope_is_restored_after_failure():
+    """A failed load must not leave remote code enabled for subsequent loads."""
+    from diffusers import DiffusionPipeline
+
+    from optimum.habana.diffusers.security_patches import _trust_remote_code
+
+    with pytest.raises(Exception):
+        DiffusionPipeline.from_pretrained("this/repo-does-not-exist-xyz", trust_remote_code=True)
+
+    assert _trust_remote_code.get() is False
+
+
+def test_patch_is_idempotent():
+    patched = dynamic_modules_utils.get_cached_module_file
+
+    for _ in range(3):
+        apply_diffusers_security_patches()
+
+    assert dynamic_modules_utils.get_cached_module_file is patched
+
+
+def test_patched_symbols_still_exist_upstream():
+    """Fails loudly if a Diffusers upgrade moves what the patch targets, instead of silently no-op'ing."""
+    from diffusers import DiffusionPipeline
+
+    assert hasattr(dynamic_modules_utils, "get_cached_module_file")
+    assert hasattr(dynamic_modules_utils, "get_class_from_dynamic_module")
+    assert callable(getattr(DiffusionPipeline, "from_pretrained", None))


### PR DESCRIPTION
## What this fixes

`CVE-2026-44513` and `CVE-2026-45804` (both HIGH) — `trust_remote_code=False` does not
prevent custom pipeline/component code from being executed.

`DiffusionPipeline.from_pretrained()` is meant to refuse custom code unless
`trust_remote_code=True`, but in 0.35.1 the check lives in `DiffusionPipeline.download()`
(`pipelines/pipeline_utils.py:1533`), which is the wrong place:

**CVE-2026-44513** — three call patterns skip it entirely:

1. `from_pretrained("repoA", custom_pipeline="attacker/repoB", trust_remote_code=False)`
   — the gate inspects `repoA`, while the code comes from `repoB`
2. the same, with a **local path** as the main repo — the local branch never calls
   `download()`
3. `from_pretrained("/local/snapshot", trust_remote_code=False)` where the snapshot's
   `model_index.json` references custom component `.py` files — same reason

**CVE-2026-45804** — even on the normal Hub path, the trust check reads `model_index.json`
via one `hf_hub_download()` and the repo is fetched by a separate `snapshot_download()`.
Both resolve the branch head independently, so a commit pushed between them means the code
that runs is not the code that was checked. No `custom_pipeline` argument and no
`trust_remote_code=True` are needed.

This is reachable from optimum-habana: `GaudiDiffusionPipeline.from_pretrained` delegates
to `DiffusionPipeline.from_pretrained`.

## The fix

The check moves to `get_cached_module_file()` — the single point where any dynamic module
is resolved, whether it comes from a local file, a local snapshot or the Hub. That covers
all three variants above, including the two that never reach `download()`, and because the
check now happens at the moment of use there is no separate resolution step left to race.

This mirrors where upstream put the gate in
[huggingface/diffusers#13448](https://github.com/huggingface/diffusers/pull/13448),
released in 0.38.0.

The caller's `trust_remote_code` value is published in a `ContextVar` by
`from_pretrained()`, because the functions in between have no parameter to thread it
through — `_get_custom_pipeline_class()` does not define one, and neither call site in
`pipeline_loading_utils.py` passes one. A `ContextVar` rather than a module global is
required so concurrent pipeline loads cannot see each other's setting; there is a test
for that. The default is to refuse.

## Notes for reviewers

- **This is a mitigation, not the real fix.** The proper fix is upgrading to diffusers
  0.38.0. That bump has a large blast radius here — 45 files under `optimum/habana/` import
  diffusers internals, several Gaudi pipelines are line-by-line copies of upstream
  pipelines, and 0.38.0 also brings PEP-604 typing, a new `DIFFUSERS_DISABLE_REMOTE_CODE`
  env var, signature changes and a `check_imports()` behaviour change. This PR reduces risk
  now; the upgrade is tracked separately and should remove this guard when it lands.
- **`ModularPipelineBlocks.from_pretrained` is wrapped too.** Modular pipelines have their
  own correct gate but resolve modules through the same chokepoint, so without this they
  would be refused outright.
- **Known behaviour change.** Code calling `diffusers.DiffusionPipeline.from_pretrained`
  gets the guard via the wrapped classmethod, so `trust_remote_code=True` keeps working.
  Any path that reaches `get_cached_module_file()` without going through a wrapped entry
  point will be refused — it fails closed by design. Happy to widen the set of wrapped
  entry points if you can think of one I have missed.

## Testing

`tests/test_diffusers_security_patches.py` builds a local repository whose custom module
writes a marker file when imported, then asserts the marker is **absent** — the module body
executes during the import, so asserting only that an exception was raised would not show
the code was actually blocked.

Also covered: opt-in still works (no over-blocking), the trust scope does not leak across
threads, the scope is restored after a failed load, idempotency, and a guard test that
fails loudly if a Diffusers upgrade moves the symbols this patch targets.

The bypass was confirmed to work against unpatched diffusers 0.35.1 before the fix, so the
tests detect the vulnerability rather than merely passing.

Not yet run on Gaudi hardware.

## References

- https://avd.aquasec.com/nvd/cve-2026-44513
- https://avd.aquasec.com/nvd/cve-2026-45804
- Upstream fix: https://github.com/huggingface/diffusers/pull/13448
